### PR TITLE
Added Artix 7 PCIE_2_1 and Zynq7 IOB18 for Zynq7030

### DIFF
--- a/artix7/site_type_PCIE_2_1.json
+++ b/artix7/site_type_PCIE_2_1.json
@@ -1,0 +1,20256 @@
+{
+  "PCIE_2_1": {
+    "bels": {
+      "PCIE_2_1": {
+        "type": "PCIE_2_1_PCIE_2_1",
+        "class": "BEL",
+        "pins": {
+          "CFGAERECRCCHECKEN": {
+            "dir": "OUTPUT",
+            "wire": "CFGAERECRCCHECKEN"
+          },
+          "CFGAERECRCGENEN": {
+            "dir": "OUTPUT",
+            "wire": "CFGAERECRCGENEN"
+          },
+          "CFGAERINTERRUPTMSGNUM0": {
+            "dir": "INPUT",
+            "wire": "CFGAERINTERRUPTMSGNUM0"
+          },
+          "CFGAERINTERRUPTMSGNUM1": {
+            "dir": "INPUT",
+            "wire": "CFGAERINTERRUPTMSGNUM1"
+          },
+          "CFGAERINTERRUPTMSGNUM2": {
+            "dir": "INPUT",
+            "wire": "CFGAERINTERRUPTMSGNUM2"
+          },
+          "CFGAERINTERRUPTMSGNUM3": {
+            "dir": "INPUT",
+            "wire": "CFGAERINTERRUPTMSGNUM3"
+          },
+          "CFGAERINTERRUPTMSGNUM4": {
+            "dir": "INPUT",
+            "wire": "CFGAERINTERRUPTMSGNUM4"
+          },
+          "CFGAERROOTERRCORRERRRECEIVED": {
+            "dir": "OUTPUT",
+            "wire": "CFGAERROOTERRCORRERRRECEIVED"
+          },
+          "CFGAERROOTERRCORRERRREPORTINGEN": {
+            "dir": "OUTPUT",
+            "wire": "CFGAERROOTERRCORRERRREPORTINGEN"
+          },
+          "CFGAERROOTERRFATALERRRECEIVED": {
+            "dir": "OUTPUT",
+            "wire": "CFGAERROOTERRFATALERRRECEIVED"
+          },
+          "CFGAERROOTERRFATALERRREPORTINGEN": {
+            "dir": "OUTPUT",
+            "wire": "CFGAERROOTERRFATALERRREPORTINGEN"
+          },
+          "CFGAERROOTERRNONFATALERRRECEIVED": {
+            "dir": "OUTPUT",
+            "wire": "CFGAERROOTERRNONFATALERRRECEIVED"
+          },
+          "CFGAERROOTERRNONFATALERRREPORTINGEN": {
+            "dir": "OUTPUT",
+            "wire": "CFGAERROOTERRNONFATALERRREPORTINGEN"
+          },
+          "CFGBRIDGESERREN": {
+            "dir": "OUTPUT",
+            "wire": "CFGBRIDGESERREN"
+          },
+          "CFGCOMMANDBUSMASTERENABLE": {
+            "dir": "OUTPUT",
+            "wire": "CFGCOMMANDBUSMASTERENABLE"
+          },
+          "CFGCOMMANDINTERRUPTDISABLE": {
+            "dir": "OUTPUT",
+            "wire": "CFGCOMMANDINTERRUPTDISABLE"
+          },
+          "CFGCOMMANDIOENABLE": {
+            "dir": "OUTPUT",
+            "wire": "CFGCOMMANDIOENABLE"
+          },
+          "CFGCOMMANDMEMENABLE": {
+            "dir": "OUTPUT",
+            "wire": "CFGCOMMANDMEMENABLE"
+          },
+          "CFGCOMMANDSERREN": {
+            "dir": "OUTPUT",
+            "wire": "CFGCOMMANDSERREN"
+          },
+          "CFGDEVCONTROL2ARIFORWARDEN": {
+            "dir": "OUTPUT",
+            "wire": "CFGDEVCONTROL2ARIFORWARDEN"
+          },
+          "CFGDEVCONTROL2ATOMICEGRESSBLOCK": {
+            "dir": "OUTPUT",
+            "wire": "CFGDEVCONTROL2ATOMICEGRESSBLOCK"
+          },
+          "CFGDEVCONTROL2ATOMICREQUESTEREN": {
+            "dir": "OUTPUT",
+            "wire": "CFGDEVCONTROL2ATOMICREQUESTEREN"
+          },
+          "CFGDEVCONTROL2CPLTIMEOUTDIS": {
+            "dir": "OUTPUT",
+            "wire": "CFGDEVCONTROL2CPLTIMEOUTDIS"
+          },
+          "CFGDEVCONTROL2CPLTIMEOUTVAL0": {
+            "dir": "OUTPUT",
+            "wire": "CFGDEVCONTROL2CPLTIMEOUTVAL0"
+          },
+          "CFGDEVCONTROL2CPLTIMEOUTVAL1": {
+            "dir": "OUTPUT",
+            "wire": "CFGDEVCONTROL2CPLTIMEOUTVAL1"
+          },
+          "CFGDEVCONTROL2CPLTIMEOUTVAL2": {
+            "dir": "OUTPUT",
+            "wire": "CFGDEVCONTROL2CPLTIMEOUTVAL2"
+          },
+          "CFGDEVCONTROL2CPLTIMEOUTVAL3": {
+            "dir": "OUTPUT",
+            "wire": "CFGDEVCONTROL2CPLTIMEOUTVAL3"
+          },
+          "CFGDEVCONTROL2IDOCPLEN": {
+            "dir": "OUTPUT",
+            "wire": "CFGDEVCONTROL2IDOCPLEN"
+          },
+          "CFGDEVCONTROL2IDOREQEN": {
+            "dir": "OUTPUT",
+            "wire": "CFGDEVCONTROL2IDOREQEN"
+          },
+          "CFGDEVCONTROL2LTREN": {
+            "dir": "OUTPUT",
+            "wire": "CFGDEVCONTROL2LTREN"
+          },
+          "CFGDEVCONTROL2TLPPREFIXBLOCK": {
+            "dir": "OUTPUT",
+            "wire": "CFGDEVCONTROL2TLPPREFIXBLOCK"
+          },
+          "CFGDEVCONTROLAUXPOWEREN": {
+            "dir": "OUTPUT",
+            "wire": "CFGDEVCONTROLAUXPOWEREN"
+          },
+          "CFGDEVCONTROLCORRERRREPORTINGEN": {
+            "dir": "OUTPUT",
+            "wire": "CFGDEVCONTROLCORRERRREPORTINGEN"
+          },
+          "CFGDEVCONTROLENABLERO": {
+            "dir": "OUTPUT",
+            "wire": "CFGDEVCONTROLENABLERO"
+          },
+          "CFGDEVCONTROLEXTTAGEN": {
+            "dir": "OUTPUT",
+            "wire": "CFGDEVCONTROLEXTTAGEN"
+          },
+          "CFGDEVCONTROLFATALERRREPORTINGEN": {
+            "dir": "OUTPUT",
+            "wire": "CFGDEVCONTROLFATALERRREPORTINGEN"
+          },
+          "CFGDEVCONTROLMAXPAYLOAD0": {
+            "dir": "OUTPUT",
+            "wire": "CFGDEVCONTROLMAXPAYLOAD0"
+          },
+          "CFGDEVCONTROLMAXPAYLOAD1": {
+            "dir": "OUTPUT",
+            "wire": "CFGDEVCONTROLMAXPAYLOAD1"
+          },
+          "CFGDEVCONTROLMAXPAYLOAD2": {
+            "dir": "OUTPUT",
+            "wire": "CFGDEVCONTROLMAXPAYLOAD2"
+          },
+          "CFGDEVCONTROLMAXREADREQ0": {
+            "dir": "OUTPUT",
+            "wire": "CFGDEVCONTROLMAXREADREQ0"
+          },
+          "CFGDEVCONTROLMAXREADREQ1": {
+            "dir": "OUTPUT",
+            "wire": "CFGDEVCONTROLMAXREADREQ1"
+          },
+          "CFGDEVCONTROLMAXREADREQ2": {
+            "dir": "OUTPUT",
+            "wire": "CFGDEVCONTROLMAXREADREQ2"
+          },
+          "CFGDEVCONTROLNONFATALREPORTINGEN": {
+            "dir": "OUTPUT",
+            "wire": "CFGDEVCONTROLNONFATALREPORTINGEN"
+          },
+          "CFGDEVCONTROLNOSNOOPEN": {
+            "dir": "OUTPUT",
+            "wire": "CFGDEVCONTROLNOSNOOPEN"
+          },
+          "CFGDEVCONTROLPHANTOMEN": {
+            "dir": "OUTPUT",
+            "wire": "CFGDEVCONTROLPHANTOMEN"
+          },
+          "CFGDEVCONTROLURERRREPORTINGEN": {
+            "dir": "OUTPUT",
+            "wire": "CFGDEVCONTROLURERRREPORTINGEN"
+          },
+          "CFGDEVID0": {
+            "dir": "INPUT",
+            "wire": "CFGDEVID0"
+          },
+          "CFGDEVID1": {
+            "dir": "INPUT",
+            "wire": "CFGDEVID1"
+          },
+          "CFGDEVID2": {
+            "dir": "INPUT",
+            "wire": "CFGDEVID2"
+          },
+          "CFGDEVID3": {
+            "dir": "INPUT",
+            "wire": "CFGDEVID3"
+          },
+          "CFGDEVID4": {
+            "dir": "INPUT",
+            "wire": "CFGDEVID4"
+          },
+          "CFGDEVID5": {
+            "dir": "INPUT",
+            "wire": "CFGDEVID5"
+          },
+          "CFGDEVID6": {
+            "dir": "INPUT",
+            "wire": "CFGDEVID6"
+          },
+          "CFGDEVID7": {
+            "dir": "INPUT",
+            "wire": "CFGDEVID7"
+          },
+          "CFGDEVID8": {
+            "dir": "INPUT",
+            "wire": "CFGDEVID8"
+          },
+          "CFGDEVID9": {
+            "dir": "INPUT",
+            "wire": "CFGDEVID9"
+          },
+          "CFGDEVID10": {
+            "dir": "INPUT",
+            "wire": "CFGDEVID10"
+          },
+          "CFGDEVID11": {
+            "dir": "INPUT",
+            "wire": "CFGDEVID11"
+          },
+          "CFGDEVID12": {
+            "dir": "INPUT",
+            "wire": "CFGDEVID12"
+          },
+          "CFGDEVID13": {
+            "dir": "INPUT",
+            "wire": "CFGDEVID13"
+          },
+          "CFGDEVID14": {
+            "dir": "INPUT",
+            "wire": "CFGDEVID14"
+          },
+          "CFGDEVID15": {
+            "dir": "INPUT",
+            "wire": "CFGDEVID15"
+          },
+          "CFGDEVSTATUSCORRERRDETECTED": {
+            "dir": "OUTPUT",
+            "wire": "CFGDEVSTATUSCORRERRDETECTED"
+          },
+          "CFGDEVSTATUSFATALERRDETECTED": {
+            "dir": "OUTPUT",
+            "wire": "CFGDEVSTATUSFATALERRDETECTED"
+          },
+          "CFGDEVSTATUSNONFATALERRDETECTED": {
+            "dir": "OUTPUT",
+            "wire": "CFGDEVSTATUSNONFATALERRDETECTED"
+          },
+          "CFGDEVSTATUSURDETECTED": {
+            "dir": "OUTPUT",
+            "wire": "CFGDEVSTATUSURDETECTED"
+          },
+          "CFGDSBUSNUMBER0": {
+            "dir": "INPUT",
+            "wire": "CFGDSBUSNUMBER0"
+          },
+          "CFGDSBUSNUMBER1": {
+            "dir": "INPUT",
+            "wire": "CFGDSBUSNUMBER1"
+          },
+          "CFGDSBUSNUMBER2": {
+            "dir": "INPUT",
+            "wire": "CFGDSBUSNUMBER2"
+          },
+          "CFGDSBUSNUMBER3": {
+            "dir": "INPUT",
+            "wire": "CFGDSBUSNUMBER3"
+          },
+          "CFGDSBUSNUMBER4": {
+            "dir": "INPUT",
+            "wire": "CFGDSBUSNUMBER4"
+          },
+          "CFGDSBUSNUMBER5": {
+            "dir": "INPUT",
+            "wire": "CFGDSBUSNUMBER5"
+          },
+          "CFGDSBUSNUMBER6": {
+            "dir": "INPUT",
+            "wire": "CFGDSBUSNUMBER6"
+          },
+          "CFGDSBUSNUMBER7": {
+            "dir": "INPUT",
+            "wire": "CFGDSBUSNUMBER7"
+          },
+          "CFGDSDEVICENUMBER0": {
+            "dir": "INPUT",
+            "wire": "CFGDSDEVICENUMBER0"
+          },
+          "CFGDSDEVICENUMBER1": {
+            "dir": "INPUT",
+            "wire": "CFGDSDEVICENUMBER1"
+          },
+          "CFGDSDEVICENUMBER2": {
+            "dir": "INPUT",
+            "wire": "CFGDSDEVICENUMBER2"
+          },
+          "CFGDSDEVICENUMBER3": {
+            "dir": "INPUT",
+            "wire": "CFGDSDEVICENUMBER3"
+          },
+          "CFGDSDEVICENUMBER4": {
+            "dir": "INPUT",
+            "wire": "CFGDSDEVICENUMBER4"
+          },
+          "CFGDSFUNCTIONNUMBER0": {
+            "dir": "INPUT",
+            "wire": "CFGDSFUNCTIONNUMBER0"
+          },
+          "CFGDSFUNCTIONNUMBER1": {
+            "dir": "INPUT",
+            "wire": "CFGDSFUNCTIONNUMBER1"
+          },
+          "CFGDSFUNCTIONNUMBER2": {
+            "dir": "INPUT",
+            "wire": "CFGDSFUNCTIONNUMBER2"
+          },
+          "CFGDSN0": {
+            "dir": "INPUT",
+            "wire": "CFGDSN0"
+          },
+          "CFGDSN1": {
+            "dir": "INPUT",
+            "wire": "CFGDSN1"
+          },
+          "CFGDSN2": {
+            "dir": "INPUT",
+            "wire": "CFGDSN2"
+          },
+          "CFGDSN3": {
+            "dir": "INPUT",
+            "wire": "CFGDSN3"
+          },
+          "CFGDSN4": {
+            "dir": "INPUT",
+            "wire": "CFGDSN4"
+          },
+          "CFGDSN5": {
+            "dir": "INPUT",
+            "wire": "CFGDSN5"
+          },
+          "CFGDSN6": {
+            "dir": "INPUT",
+            "wire": "CFGDSN6"
+          },
+          "CFGDSN7": {
+            "dir": "INPUT",
+            "wire": "CFGDSN7"
+          },
+          "CFGDSN8": {
+            "dir": "INPUT",
+            "wire": "CFGDSN8"
+          },
+          "CFGDSN9": {
+            "dir": "INPUT",
+            "wire": "CFGDSN9"
+          },
+          "CFGDSN10": {
+            "dir": "INPUT",
+            "wire": "CFGDSN10"
+          },
+          "CFGDSN11": {
+            "dir": "INPUT",
+            "wire": "CFGDSN11"
+          },
+          "CFGDSN12": {
+            "dir": "INPUT",
+            "wire": "CFGDSN12"
+          },
+          "CFGDSN13": {
+            "dir": "INPUT",
+            "wire": "CFGDSN13"
+          },
+          "CFGDSN14": {
+            "dir": "INPUT",
+            "wire": "CFGDSN14"
+          },
+          "CFGDSN15": {
+            "dir": "INPUT",
+            "wire": "CFGDSN15"
+          },
+          "CFGDSN16": {
+            "dir": "INPUT",
+            "wire": "CFGDSN16"
+          },
+          "CFGDSN17": {
+            "dir": "INPUT",
+            "wire": "CFGDSN17"
+          },
+          "CFGDSN18": {
+            "dir": "INPUT",
+            "wire": "CFGDSN18"
+          },
+          "CFGDSN19": {
+            "dir": "INPUT",
+            "wire": "CFGDSN19"
+          },
+          "CFGDSN20": {
+            "dir": "INPUT",
+            "wire": "CFGDSN20"
+          },
+          "CFGDSN21": {
+            "dir": "INPUT",
+            "wire": "CFGDSN21"
+          },
+          "CFGDSN22": {
+            "dir": "INPUT",
+            "wire": "CFGDSN22"
+          },
+          "CFGDSN23": {
+            "dir": "INPUT",
+            "wire": "CFGDSN23"
+          },
+          "CFGDSN24": {
+            "dir": "INPUT",
+            "wire": "CFGDSN24"
+          },
+          "CFGDSN25": {
+            "dir": "INPUT",
+            "wire": "CFGDSN25"
+          },
+          "CFGDSN26": {
+            "dir": "INPUT",
+            "wire": "CFGDSN26"
+          },
+          "CFGDSN27": {
+            "dir": "INPUT",
+            "wire": "CFGDSN27"
+          },
+          "CFGDSN28": {
+            "dir": "INPUT",
+            "wire": "CFGDSN28"
+          },
+          "CFGDSN29": {
+            "dir": "INPUT",
+            "wire": "CFGDSN29"
+          },
+          "CFGDSN30": {
+            "dir": "INPUT",
+            "wire": "CFGDSN30"
+          },
+          "CFGDSN31": {
+            "dir": "INPUT",
+            "wire": "CFGDSN31"
+          },
+          "CFGDSN32": {
+            "dir": "INPUT",
+            "wire": "CFGDSN32"
+          },
+          "CFGDSN33": {
+            "dir": "INPUT",
+            "wire": "CFGDSN33"
+          },
+          "CFGDSN34": {
+            "dir": "INPUT",
+            "wire": "CFGDSN34"
+          },
+          "CFGDSN35": {
+            "dir": "INPUT",
+            "wire": "CFGDSN35"
+          },
+          "CFGDSN36": {
+            "dir": "INPUT",
+            "wire": "CFGDSN36"
+          },
+          "CFGDSN37": {
+            "dir": "INPUT",
+            "wire": "CFGDSN37"
+          },
+          "CFGDSN38": {
+            "dir": "INPUT",
+            "wire": "CFGDSN38"
+          },
+          "CFGDSN39": {
+            "dir": "INPUT",
+            "wire": "CFGDSN39"
+          },
+          "CFGDSN40": {
+            "dir": "INPUT",
+            "wire": "CFGDSN40"
+          },
+          "CFGDSN41": {
+            "dir": "INPUT",
+            "wire": "CFGDSN41"
+          },
+          "CFGDSN42": {
+            "dir": "INPUT",
+            "wire": "CFGDSN42"
+          },
+          "CFGDSN43": {
+            "dir": "INPUT",
+            "wire": "CFGDSN43"
+          },
+          "CFGDSN44": {
+            "dir": "INPUT",
+            "wire": "CFGDSN44"
+          },
+          "CFGDSN45": {
+            "dir": "INPUT",
+            "wire": "CFGDSN45"
+          },
+          "CFGDSN46": {
+            "dir": "INPUT",
+            "wire": "CFGDSN46"
+          },
+          "CFGDSN47": {
+            "dir": "INPUT",
+            "wire": "CFGDSN47"
+          },
+          "CFGDSN48": {
+            "dir": "INPUT",
+            "wire": "CFGDSN48"
+          },
+          "CFGDSN49": {
+            "dir": "INPUT",
+            "wire": "CFGDSN49"
+          },
+          "CFGDSN50": {
+            "dir": "INPUT",
+            "wire": "CFGDSN50"
+          },
+          "CFGDSN51": {
+            "dir": "INPUT",
+            "wire": "CFGDSN51"
+          },
+          "CFGDSN52": {
+            "dir": "INPUT",
+            "wire": "CFGDSN52"
+          },
+          "CFGDSN53": {
+            "dir": "INPUT",
+            "wire": "CFGDSN53"
+          },
+          "CFGDSN54": {
+            "dir": "INPUT",
+            "wire": "CFGDSN54"
+          },
+          "CFGDSN55": {
+            "dir": "INPUT",
+            "wire": "CFGDSN55"
+          },
+          "CFGDSN56": {
+            "dir": "INPUT",
+            "wire": "CFGDSN56"
+          },
+          "CFGDSN57": {
+            "dir": "INPUT",
+            "wire": "CFGDSN57"
+          },
+          "CFGDSN58": {
+            "dir": "INPUT",
+            "wire": "CFGDSN58"
+          },
+          "CFGDSN59": {
+            "dir": "INPUT",
+            "wire": "CFGDSN59"
+          },
+          "CFGDSN60": {
+            "dir": "INPUT",
+            "wire": "CFGDSN60"
+          },
+          "CFGDSN61": {
+            "dir": "INPUT",
+            "wire": "CFGDSN61"
+          },
+          "CFGDSN62": {
+            "dir": "INPUT",
+            "wire": "CFGDSN62"
+          },
+          "CFGDSN63": {
+            "dir": "INPUT",
+            "wire": "CFGDSN63"
+          },
+          "CFGERRACSN": {
+            "dir": "INPUT",
+            "wire": "CFGERRACSN"
+          },
+          "CFGERRAERHEADERLOG0": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG0"
+          },
+          "CFGERRAERHEADERLOG1": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG1"
+          },
+          "CFGERRAERHEADERLOG2": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG2"
+          },
+          "CFGERRAERHEADERLOG3": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG3"
+          },
+          "CFGERRAERHEADERLOG4": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG4"
+          },
+          "CFGERRAERHEADERLOG5": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG5"
+          },
+          "CFGERRAERHEADERLOG6": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG6"
+          },
+          "CFGERRAERHEADERLOG7": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG7"
+          },
+          "CFGERRAERHEADERLOG8": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG8"
+          },
+          "CFGERRAERHEADERLOG9": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG9"
+          },
+          "CFGERRAERHEADERLOG10": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG10"
+          },
+          "CFGERRAERHEADERLOG11": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG11"
+          },
+          "CFGERRAERHEADERLOG12": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG12"
+          },
+          "CFGERRAERHEADERLOG13": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG13"
+          },
+          "CFGERRAERHEADERLOG14": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG14"
+          },
+          "CFGERRAERHEADERLOG15": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG15"
+          },
+          "CFGERRAERHEADERLOG16": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG16"
+          },
+          "CFGERRAERHEADERLOG17": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG17"
+          },
+          "CFGERRAERHEADERLOG18": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG18"
+          },
+          "CFGERRAERHEADERLOG19": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG19"
+          },
+          "CFGERRAERHEADERLOG20": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG20"
+          },
+          "CFGERRAERHEADERLOG21": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG21"
+          },
+          "CFGERRAERHEADERLOG22": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG22"
+          },
+          "CFGERRAERHEADERLOG23": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG23"
+          },
+          "CFGERRAERHEADERLOG24": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG24"
+          },
+          "CFGERRAERHEADERLOG25": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG25"
+          },
+          "CFGERRAERHEADERLOG26": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG26"
+          },
+          "CFGERRAERHEADERLOG27": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG27"
+          },
+          "CFGERRAERHEADERLOG28": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG28"
+          },
+          "CFGERRAERHEADERLOG29": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG29"
+          },
+          "CFGERRAERHEADERLOG30": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG30"
+          },
+          "CFGERRAERHEADERLOG31": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG31"
+          },
+          "CFGERRAERHEADERLOG32": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG32"
+          },
+          "CFGERRAERHEADERLOG33": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG33"
+          },
+          "CFGERRAERHEADERLOG34": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG34"
+          },
+          "CFGERRAERHEADERLOG35": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG35"
+          },
+          "CFGERRAERHEADERLOG36": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG36"
+          },
+          "CFGERRAERHEADERLOG37": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG37"
+          },
+          "CFGERRAERHEADERLOG38": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG38"
+          },
+          "CFGERRAERHEADERLOG39": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG39"
+          },
+          "CFGERRAERHEADERLOG40": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG40"
+          },
+          "CFGERRAERHEADERLOG41": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG41"
+          },
+          "CFGERRAERHEADERLOG42": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG42"
+          },
+          "CFGERRAERHEADERLOG43": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG43"
+          },
+          "CFGERRAERHEADERLOG44": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG44"
+          },
+          "CFGERRAERHEADERLOG45": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG45"
+          },
+          "CFGERRAERHEADERLOG46": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG46"
+          },
+          "CFGERRAERHEADERLOG47": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG47"
+          },
+          "CFGERRAERHEADERLOG48": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG48"
+          },
+          "CFGERRAERHEADERLOG49": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG49"
+          },
+          "CFGERRAERHEADERLOG50": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG50"
+          },
+          "CFGERRAERHEADERLOG51": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG51"
+          },
+          "CFGERRAERHEADERLOG52": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG52"
+          },
+          "CFGERRAERHEADERLOG53": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG53"
+          },
+          "CFGERRAERHEADERLOG54": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG54"
+          },
+          "CFGERRAERHEADERLOG55": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG55"
+          },
+          "CFGERRAERHEADERLOG56": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG56"
+          },
+          "CFGERRAERHEADERLOG57": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG57"
+          },
+          "CFGERRAERHEADERLOG58": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG58"
+          },
+          "CFGERRAERHEADERLOG59": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG59"
+          },
+          "CFGERRAERHEADERLOG60": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG60"
+          },
+          "CFGERRAERHEADERLOG61": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG61"
+          },
+          "CFGERRAERHEADERLOG62": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG62"
+          },
+          "CFGERRAERHEADERLOG63": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG63"
+          },
+          "CFGERRAERHEADERLOG64": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG64"
+          },
+          "CFGERRAERHEADERLOG65": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG65"
+          },
+          "CFGERRAERHEADERLOG66": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG66"
+          },
+          "CFGERRAERHEADERLOG67": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG67"
+          },
+          "CFGERRAERHEADERLOG68": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG68"
+          },
+          "CFGERRAERHEADERLOG69": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG69"
+          },
+          "CFGERRAERHEADERLOG70": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG70"
+          },
+          "CFGERRAERHEADERLOG71": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG71"
+          },
+          "CFGERRAERHEADERLOG72": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG72"
+          },
+          "CFGERRAERHEADERLOG73": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG73"
+          },
+          "CFGERRAERHEADERLOG74": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG74"
+          },
+          "CFGERRAERHEADERLOG75": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG75"
+          },
+          "CFGERRAERHEADERLOG76": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG76"
+          },
+          "CFGERRAERHEADERLOG77": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG77"
+          },
+          "CFGERRAERHEADERLOG78": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG78"
+          },
+          "CFGERRAERHEADERLOG79": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG79"
+          },
+          "CFGERRAERHEADERLOG80": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG80"
+          },
+          "CFGERRAERHEADERLOG81": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG81"
+          },
+          "CFGERRAERHEADERLOG82": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG82"
+          },
+          "CFGERRAERHEADERLOG83": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG83"
+          },
+          "CFGERRAERHEADERLOG84": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG84"
+          },
+          "CFGERRAERHEADERLOG85": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG85"
+          },
+          "CFGERRAERHEADERLOG86": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG86"
+          },
+          "CFGERRAERHEADERLOG87": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG87"
+          },
+          "CFGERRAERHEADERLOG88": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG88"
+          },
+          "CFGERRAERHEADERLOG89": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG89"
+          },
+          "CFGERRAERHEADERLOG90": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG90"
+          },
+          "CFGERRAERHEADERLOG91": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG91"
+          },
+          "CFGERRAERHEADERLOG92": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG92"
+          },
+          "CFGERRAERHEADERLOG93": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG93"
+          },
+          "CFGERRAERHEADERLOG94": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG94"
+          },
+          "CFGERRAERHEADERLOG95": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG95"
+          },
+          "CFGERRAERHEADERLOG96": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG96"
+          },
+          "CFGERRAERHEADERLOG97": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG97"
+          },
+          "CFGERRAERHEADERLOG98": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG98"
+          },
+          "CFGERRAERHEADERLOG99": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG99"
+          },
+          "CFGERRAERHEADERLOG100": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG100"
+          },
+          "CFGERRAERHEADERLOG101": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG101"
+          },
+          "CFGERRAERHEADERLOG102": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG102"
+          },
+          "CFGERRAERHEADERLOG103": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG103"
+          },
+          "CFGERRAERHEADERLOG104": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG104"
+          },
+          "CFGERRAERHEADERLOG105": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG105"
+          },
+          "CFGERRAERHEADERLOG106": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG106"
+          },
+          "CFGERRAERHEADERLOG107": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG107"
+          },
+          "CFGERRAERHEADERLOG108": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG108"
+          },
+          "CFGERRAERHEADERLOG109": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG109"
+          },
+          "CFGERRAERHEADERLOG110": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG110"
+          },
+          "CFGERRAERHEADERLOG111": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG111"
+          },
+          "CFGERRAERHEADERLOG112": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG112"
+          },
+          "CFGERRAERHEADERLOG113": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG113"
+          },
+          "CFGERRAERHEADERLOG114": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG114"
+          },
+          "CFGERRAERHEADERLOG115": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG115"
+          },
+          "CFGERRAERHEADERLOG116": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG116"
+          },
+          "CFGERRAERHEADERLOG117": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG117"
+          },
+          "CFGERRAERHEADERLOG118": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG118"
+          },
+          "CFGERRAERHEADERLOG119": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG119"
+          },
+          "CFGERRAERHEADERLOG120": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG120"
+          },
+          "CFGERRAERHEADERLOG121": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG121"
+          },
+          "CFGERRAERHEADERLOG122": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG122"
+          },
+          "CFGERRAERHEADERLOG123": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG123"
+          },
+          "CFGERRAERHEADERLOG124": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG124"
+          },
+          "CFGERRAERHEADERLOG125": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG125"
+          },
+          "CFGERRAERHEADERLOG126": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG126"
+          },
+          "CFGERRAERHEADERLOG127": {
+            "dir": "INPUT",
+            "wire": "CFGERRAERHEADERLOG127"
+          },
+          "CFGERRAERHEADERLOGSETN": {
+            "dir": "OUTPUT",
+            "wire": "CFGERRAERHEADERLOGSETN"
+          },
+          "CFGERRATOMICEGRESSBLOCKEDN": {
+            "dir": "INPUT",
+            "wire": "CFGERRATOMICEGRESSBLOCKEDN"
+          },
+          "CFGERRCORN": {
+            "dir": "INPUT",
+            "wire": "CFGERRCORN"
+          },
+          "CFGERRCPLABORTN": {
+            "dir": "INPUT",
+            "wire": "CFGERRCPLABORTN"
+          },
+          "CFGERRCPLRDYN": {
+            "dir": "OUTPUT",
+            "wire": "CFGERRCPLRDYN"
+          },
+          "CFGERRCPLTIMEOUTN": {
+            "dir": "INPUT",
+            "wire": "CFGERRCPLTIMEOUTN"
+          },
+          "CFGERRCPLUNEXPECTN": {
+            "dir": "INPUT",
+            "wire": "CFGERRCPLUNEXPECTN"
+          },
+          "CFGERRECRCN": {
+            "dir": "INPUT",
+            "wire": "CFGERRECRCN"
+          },
+          "CFGERRINTERNALCORN": {
+            "dir": "INPUT",
+            "wire": "CFGERRINTERNALCORN"
+          },
+          "CFGERRINTERNALUNCORN": {
+            "dir": "INPUT",
+            "wire": "CFGERRINTERNALUNCORN"
+          },
+          "CFGERRLOCKEDN": {
+            "dir": "INPUT",
+            "wire": "CFGERRLOCKEDN"
+          },
+          "CFGERRMALFORMEDN": {
+            "dir": "INPUT",
+            "wire": "CFGERRMALFORMEDN"
+          },
+          "CFGERRMCBLOCKEDN": {
+            "dir": "INPUT",
+            "wire": "CFGERRMCBLOCKEDN"
+          },
+          "CFGERRNORECOVERYN": {
+            "dir": "INPUT",
+            "wire": "CFGERRNORECOVERYN"
+          },
+          "CFGERRPOISONEDN": {
+            "dir": "INPUT",
+            "wire": "CFGERRPOISONEDN"
+          },
+          "CFGERRPOSTEDN": {
+            "dir": "INPUT",
+            "wire": "CFGERRPOSTEDN"
+          },
+          "CFGERRTLPCPLHEADER0": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER0"
+          },
+          "CFGERRTLPCPLHEADER1": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER1"
+          },
+          "CFGERRTLPCPLHEADER2": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER2"
+          },
+          "CFGERRTLPCPLHEADER3": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER3"
+          },
+          "CFGERRTLPCPLHEADER4": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER4"
+          },
+          "CFGERRTLPCPLHEADER5": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER5"
+          },
+          "CFGERRTLPCPLHEADER6": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER6"
+          },
+          "CFGERRTLPCPLHEADER7": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER7"
+          },
+          "CFGERRTLPCPLHEADER8": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER8"
+          },
+          "CFGERRTLPCPLHEADER9": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER9"
+          },
+          "CFGERRTLPCPLHEADER10": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER10"
+          },
+          "CFGERRTLPCPLHEADER11": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER11"
+          },
+          "CFGERRTLPCPLHEADER12": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER12"
+          },
+          "CFGERRTLPCPLHEADER13": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER13"
+          },
+          "CFGERRTLPCPLHEADER14": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER14"
+          },
+          "CFGERRTLPCPLHEADER15": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER15"
+          },
+          "CFGERRTLPCPLHEADER16": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER16"
+          },
+          "CFGERRTLPCPLHEADER17": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER17"
+          },
+          "CFGERRTLPCPLHEADER18": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER18"
+          },
+          "CFGERRTLPCPLHEADER19": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER19"
+          },
+          "CFGERRTLPCPLHEADER20": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER20"
+          },
+          "CFGERRTLPCPLHEADER21": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER21"
+          },
+          "CFGERRTLPCPLHEADER22": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER22"
+          },
+          "CFGERRTLPCPLHEADER23": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER23"
+          },
+          "CFGERRTLPCPLHEADER24": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER24"
+          },
+          "CFGERRTLPCPLHEADER25": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER25"
+          },
+          "CFGERRTLPCPLHEADER26": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER26"
+          },
+          "CFGERRTLPCPLHEADER27": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER27"
+          },
+          "CFGERRTLPCPLHEADER28": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER28"
+          },
+          "CFGERRTLPCPLHEADER29": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER29"
+          },
+          "CFGERRTLPCPLHEADER30": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER30"
+          },
+          "CFGERRTLPCPLHEADER31": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER31"
+          },
+          "CFGERRTLPCPLHEADER32": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER32"
+          },
+          "CFGERRTLPCPLHEADER33": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER33"
+          },
+          "CFGERRTLPCPLHEADER34": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER34"
+          },
+          "CFGERRTLPCPLHEADER35": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER35"
+          },
+          "CFGERRTLPCPLHEADER36": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER36"
+          },
+          "CFGERRTLPCPLHEADER37": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER37"
+          },
+          "CFGERRTLPCPLHEADER38": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER38"
+          },
+          "CFGERRTLPCPLHEADER39": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER39"
+          },
+          "CFGERRTLPCPLHEADER40": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER40"
+          },
+          "CFGERRTLPCPLHEADER41": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER41"
+          },
+          "CFGERRTLPCPLHEADER42": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER42"
+          },
+          "CFGERRTLPCPLHEADER43": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER43"
+          },
+          "CFGERRTLPCPLHEADER44": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER44"
+          },
+          "CFGERRTLPCPLHEADER45": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER45"
+          },
+          "CFGERRTLPCPLHEADER46": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER46"
+          },
+          "CFGERRTLPCPLHEADER47": {
+            "dir": "INPUT",
+            "wire": "CFGERRTLPCPLHEADER47"
+          },
+          "CFGERRURN": {
+            "dir": "INPUT",
+            "wire": "CFGERRURN"
+          },
+          "CFGFORCECOMMONCLOCKOFF": {
+            "dir": "INPUT",
+            "wire": "CFGFORCECOMMONCLOCKOFF"
+          },
+          "CFGFORCEEXTENDEDSYNCON": {
+            "dir": "INPUT",
+            "wire": "CFGFORCEEXTENDEDSYNCON"
+          },
+          "CFGFORCEMPS0": {
+            "dir": "INPUT",
+            "wire": "CFGFORCEMPS0"
+          },
+          "CFGFORCEMPS1": {
+            "dir": "INPUT",
+            "wire": "CFGFORCEMPS1"
+          },
+          "CFGFORCEMPS2": {
+            "dir": "INPUT",
+            "wire": "CFGFORCEMPS2"
+          },
+          "CFGINTERRUPTASSERTN": {
+            "dir": "INPUT",
+            "wire": "CFGINTERRUPTASSERTN"
+          },
+          "CFGINTERRUPTDI0": {
+            "dir": "INPUT",
+            "wire": "CFGINTERRUPTDI0"
+          },
+          "CFGINTERRUPTDI1": {
+            "dir": "INPUT",
+            "wire": "CFGINTERRUPTDI1"
+          },
+          "CFGINTERRUPTDI2": {
+            "dir": "INPUT",
+            "wire": "CFGINTERRUPTDI2"
+          },
+          "CFGINTERRUPTDI3": {
+            "dir": "INPUT",
+            "wire": "CFGINTERRUPTDI3"
+          },
+          "CFGINTERRUPTDI4": {
+            "dir": "INPUT",
+            "wire": "CFGINTERRUPTDI4"
+          },
+          "CFGINTERRUPTDI5": {
+            "dir": "INPUT",
+            "wire": "CFGINTERRUPTDI5"
+          },
+          "CFGINTERRUPTDI6": {
+            "dir": "INPUT",
+            "wire": "CFGINTERRUPTDI6"
+          },
+          "CFGINTERRUPTDI7": {
+            "dir": "INPUT",
+            "wire": "CFGINTERRUPTDI7"
+          },
+          "CFGINTERRUPTDO0": {
+            "dir": "OUTPUT",
+            "wire": "CFGINTERRUPTDO0"
+          },
+          "CFGINTERRUPTDO1": {
+            "dir": "OUTPUT",
+            "wire": "CFGINTERRUPTDO1"
+          },
+          "CFGINTERRUPTDO2": {
+            "dir": "OUTPUT",
+            "wire": "CFGINTERRUPTDO2"
+          },
+          "CFGINTERRUPTDO3": {
+            "dir": "OUTPUT",
+            "wire": "CFGINTERRUPTDO3"
+          },
+          "CFGINTERRUPTDO4": {
+            "dir": "OUTPUT",
+            "wire": "CFGINTERRUPTDO4"
+          },
+          "CFGINTERRUPTDO5": {
+            "dir": "OUTPUT",
+            "wire": "CFGINTERRUPTDO5"
+          },
+          "CFGINTERRUPTDO6": {
+            "dir": "OUTPUT",
+            "wire": "CFGINTERRUPTDO6"
+          },
+          "CFGINTERRUPTDO7": {
+            "dir": "OUTPUT",
+            "wire": "CFGINTERRUPTDO7"
+          },
+          "CFGINTERRUPTMMENABLE0": {
+            "dir": "OUTPUT",
+            "wire": "CFGINTERRUPTMMENABLE0"
+          },
+          "CFGINTERRUPTMMENABLE1": {
+            "dir": "OUTPUT",
+            "wire": "CFGINTERRUPTMMENABLE1"
+          },
+          "CFGINTERRUPTMMENABLE2": {
+            "dir": "OUTPUT",
+            "wire": "CFGINTERRUPTMMENABLE2"
+          },
+          "CFGINTERRUPTMSIENABLE": {
+            "dir": "OUTPUT",
+            "wire": "CFGINTERRUPTMSIENABLE"
+          },
+          "CFGINTERRUPTMSIXENABLE": {
+            "dir": "OUTPUT",
+            "wire": "CFGINTERRUPTMSIXENABLE"
+          },
+          "CFGINTERRUPTMSIXFM": {
+            "dir": "OUTPUT",
+            "wire": "CFGINTERRUPTMSIXFM"
+          },
+          "CFGINTERRUPTN": {
+            "dir": "INPUT",
+            "wire": "CFGINTERRUPTN"
+          },
+          "CFGINTERRUPTRDYN": {
+            "dir": "OUTPUT",
+            "wire": "CFGINTERRUPTRDYN"
+          },
+          "CFGINTERRUPTSTATN": {
+            "dir": "INPUT",
+            "wire": "CFGINTERRUPTSTATN"
+          },
+          "CFGLINKCONTROLASPMCONTROL0": {
+            "dir": "OUTPUT",
+            "wire": "CFGLINKCONTROLASPMCONTROL0"
+          },
+          "CFGLINKCONTROLASPMCONTROL1": {
+            "dir": "OUTPUT",
+            "wire": "CFGLINKCONTROLASPMCONTROL1"
+          },
+          "CFGLINKCONTROLAUTOBANDWIDTHINTEN": {
+            "dir": "OUTPUT",
+            "wire": "CFGLINKCONTROLAUTOBANDWIDTHINTEN"
+          },
+          "CFGLINKCONTROLBANDWIDTHINTEN": {
+            "dir": "OUTPUT",
+            "wire": "CFGLINKCONTROLBANDWIDTHINTEN"
+          },
+          "CFGLINKCONTROLCLOCKPMEN": {
+            "dir": "OUTPUT",
+            "wire": "CFGLINKCONTROLCLOCKPMEN"
+          },
+          "CFGLINKCONTROLCOMMONCLOCK": {
+            "dir": "OUTPUT",
+            "wire": "CFGLINKCONTROLCOMMONCLOCK"
+          },
+          "CFGLINKCONTROLEXTENDEDSYNC": {
+            "dir": "OUTPUT",
+            "wire": "CFGLINKCONTROLEXTENDEDSYNC"
+          },
+          "CFGLINKCONTROLHWAUTOWIDTHDIS": {
+            "dir": "OUTPUT",
+            "wire": "CFGLINKCONTROLHWAUTOWIDTHDIS"
+          },
+          "CFGLINKCONTROLLINKDISABLE": {
+            "dir": "OUTPUT",
+            "wire": "CFGLINKCONTROLLINKDISABLE"
+          },
+          "CFGLINKCONTROLRCB": {
+            "dir": "OUTPUT",
+            "wire": "CFGLINKCONTROLRCB"
+          },
+          "CFGLINKCONTROLRETRAINLINK": {
+            "dir": "OUTPUT",
+            "wire": "CFGLINKCONTROLRETRAINLINK"
+          },
+          "CFGLINKSTATUSAUTOBANDWIDTHSTATUS": {
+            "dir": "OUTPUT",
+            "wire": "CFGLINKSTATUSAUTOBANDWIDTHSTATUS"
+          },
+          "CFGLINKSTATUSBANDWIDTHSTATUS": {
+            "dir": "OUTPUT",
+            "wire": "CFGLINKSTATUSBANDWIDTHSTATUS"
+          },
+          "CFGLINKSTATUSCURRENTSPEED0": {
+            "dir": "OUTPUT",
+            "wire": "CFGLINKSTATUSCURRENTSPEED0"
+          },
+          "CFGLINKSTATUSCURRENTSPEED1": {
+            "dir": "OUTPUT",
+            "wire": "CFGLINKSTATUSCURRENTSPEED1"
+          },
+          "CFGLINKSTATUSDLLACTIVE": {
+            "dir": "OUTPUT",
+            "wire": "CFGLINKSTATUSDLLACTIVE"
+          },
+          "CFGLINKSTATUSLINKTRAINING": {
+            "dir": "OUTPUT",
+            "wire": "CFGLINKSTATUSLINKTRAINING"
+          },
+          "CFGLINKSTATUSNEGOTIATEDWIDTH0": {
+            "dir": "OUTPUT",
+            "wire": "CFGLINKSTATUSNEGOTIATEDWIDTH0"
+          },
+          "CFGLINKSTATUSNEGOTIATEDWIDTH1": {
+            "dir": "OUTPUT",
+            "wire": "CFGLINKSTATUSNEGOTIATEDWIDTH1"
+          },
+          "CFGLINKSTATUSNEGOTIATEDWIDTH2": {
+            "dir": "OUTPUT",
+            "wire": "CFGLINKSTATUSNEGOTIATEDWIDTH2"
+          },
+          "CFGLINKSTATUSNEGOTIATEDWIDTH3": {
+            "dir": "OUTPUT",
+            "wire": "CFGLINKSTATUSNEGOTIATEDWIDTH3"
+          },
+          "CFGMGMTBYTEENN0": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTBYTEENN0"
+          },
+          "CFGMGMTBYTEENN1": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTBYTEENN1"
+          },
+          "CFGMGMTBYTEENN2": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTBYTEENN2"
+          },
+          "CFGMGMTBYTEENN3": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTBYTEENN3"
+          },
+          "CFGMGMTDI0": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDI0"
+          },
+          "CFGMGMTDI1": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDI1"
+          },
+          "CFGMGMTDI2": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDI2"
+          },
+          "CFGMGMTDI3": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDI3"
+          },
+          "CFGMGMTDI4": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDI4"
+          },
+          "CFGMGMTDI5": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDI5"
+          },
+          "CFGMGMTDI6": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDI6"
+          },
+          "CFGMGMTDI7": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDI7"
+          },
+          "CFGMGMTDI8": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDI8"
+          },
+          "CFGMGMTDI9": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDI9"
+          },
+          "CFGMGMTDI10": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDI10"
+          },
+          "CFGMGMTDI11": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDI11"
+          },
+          "CFGMGMTDI12": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDI12"
+          },
+          "CFGMGMTDI13": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDI13"
+          },
+          "CFGMGMTDI14": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDI14"
+          },
+          "CFGMGMTDI15": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDI15"
+          },
+          "CFGMGMTDI16": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDI16"
+          },
+          "CFGMGMTDI17": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDI17"
+          },
+          "CFGMGMTDI18": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDI18"
+          },
+          "CFGMGMTDI19": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDI19"
+          },
+          "CFGMGMTDI20": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDI20"
+          },
+          "CFGMGMTDI21": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDI21"
+          },
+          "CFGMGMTDI22": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDI22"
+          },
+          "CFGMGMTDI23": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDI23"
+          },
+          "CFGMGMTDI24": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDI24"
+          },
+          "CFGMGMTDI25": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDI25"
+          },
+          "CFGMGMTDI26": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDI26"
+          },
+          "CFGMGMTDI27": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDI27"
+          },
+          "CFGMGMTDI28": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDI28"
+          },
+          "CFGMGMTDI29": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDI29"
+          },
+          "CFGMGMTDI30": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDI30"
+          },
+          "CFGMGMTDI31": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDI31"
+          },
+          "CFGMGMTDO0": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTDO0"
+          },
+          "CFGMGMTDO1": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTDO1"
+          },
+          "CFGMGMTDO2": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTDO2"
+          },
+          "CFGMGMTDO3": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTDO3"
+          },
+          "CFGMGMTDO4": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTDO4"
+          },
+          "CFGMGMTDO5": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTDO5"
+          },
+          "CFGMGMTDO6": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTDO6"
+          },
+          "CFGMGMTDO7": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTDO7"
+          },
+          "CFGMGMTDO8": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTDO8"
+          },
+          "CFGMGMTDO9": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTDO9"
+          },
+          "CFGMGMTDO10": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTDO10"
+          },
+          "CFGMGMTDO11": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTDO11"
+          },
+          "CFGMGMTDO12": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTDO12"
+          },
+          "CFGMGMTDO13": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTDO13"
+          },
+          "CFGMGMTDO14": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTDO14"
+          },
+          "CFGMGMTDO15": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTDO15"
+          },
+          "CFGMGMTDO16": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTDO16"
+          },
+          "CFGMGMTDO17": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTDO17"
+          },
+          "CFGMGMTDO18": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTDO18"
+          },
+          "CFGMGMTDO19": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTDO19"
+          },
+          "CFGMGMTDO20": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTDO20"
+          },
+          "CFGMGMTDO21": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTDO21"
+          },
+          "CFGMGMTDO22": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTDO22"
+          },
+          "CFGMGMTDO23": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTDO23"
+          },
+          "CFGMGMTDO24": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTDO24"
+          },
+          "CFGMGMTDO25": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTDO25"
+          },
+          "CFGMGMTDO26": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTDO26"
+          },
+          "CFGMGMTDO27": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTDO27"
+          },
+          "CFGMGMTDO28": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTDO28"
+          },
+          "CFGMGMTDO29": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTDO29"
+          },
+          "CFGMGMTDO30": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTDO30"
+          },
+          "CFGMGMTDO31": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTDO31"
+          },
+          "CFGMGMTDWADDR0": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDWADDR0"
+          },
+          "CFGMGMTDWADDR1": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDWADDR1"
+          },
+          "CFGMGMTDWADDR2": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDWADDR2"
+          },
+          "CFGMGMTDWADDR3": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDWADDR3"
+          },
+          "CFGMGMTDWADDR4": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDWADDR4"
+          },
+          "CFGMGMTDWADDR5": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDWADDR5"
+          },
+          "CFGMGMTDWADDR6": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDWADDR6"
+          },
+          "CFGMGMTDWADDR7": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDWADDR7"
+          },
+          "CFGMGMTDWADDR8": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDWADDR8"
+          },
+          "CFGMGMTDWADDR9": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTDWADDR9"
+          },
+          "CFGMGMTRDENN": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTRDENN"
+          },
+          "CFGMGMTRDWRDONEN": {
+            "dir": "OUTPUT",
+            "wire": "CFGMGMTRDWRDONEN"
+          },
+          "CFGMGMTWRENN": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTWRENN"
+          },
+          "CFGMGMTWRREADONLYN": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTWRREADONLYN"
+          },
+          "CFGMGMTWRRW1CASRWN": {
+            "dir": "INPUT",
+            "wire": "CFGMGMTWRRW1CASRWN"
+          },
+          "CFGMSGDATA0": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGDATA0"
+          },
+          "CFGMSGDATA1": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGDATA1"
+          },
+          "CFGMSGDATA2": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGDATA2"
+          },
+          "CFGMSGDATA3": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGDATA3"
+          },
+          "CFGMSGDATA4": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGDATA4"
+          },
+          "CFGMSGDATA5": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGDATA5"
+          },
+          "CFGMSGDATA6": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGDATA6"
+          },
+          "CFGMSGDATA7": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGDATA7"
+          },
+          "CFGMSGDATA8": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGDATA8"
+          },
+          "CFGMSGDATA9": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGDATA9"
+          },
+          "CFGMSGDATA10": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGDATA10"
+          },
+          "CFGMSGDATA11": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGDATA11"
+          },
+          "CFGMSGDATA12": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGDATA12"
+          },
+          "CFGMSGDATA13": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGDATA13"
+          },
+          "CFGMSGDATA14": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGDATA14"
+          },
+          "CFGMSGDATA15": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGDATA15"
+          },
+          "CFGMSGRECEIVED": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGRECEIVED"
+          },
+          "CFGMSGRECEIVEDASSERTINTA": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGRECEIVEDASSERTINTA"
+          },
+          "CFGMSGRECEIVEDASSERTINTB": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGRECEIVEDASSERTINTB"
+          },
+          "CFGMSGRECEIVEDASSERTINTC": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGRECEIVEDASSERTINTC"
+          },
+          "CFGMSGRECEIVEDASSERTINTD": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGRECEIVEDASSERTINTD"
+          },
+          "CFGMSGRECEIVEDDEASSERTINTA": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGRECEIVEDDEASSERTINTA"
+          },
+          "CFGMSGRECEIVEDDEASSERTINTB": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGRECEIVEDDEASSERTINTB"
+          },
+          "CFGMSGRECEIVEDDEASSERTINTC": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGRECEIVEDDEASSERTINTC"
+          },
+          "CFGMSGRECEIVEDDEASSERTINTD": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGRECEIVEDDEASSERTINTD"
+          },
+          "CFGMSGRECEIVEDERRCOR": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGRECEIVEDERRCOR"
+          },
+          "CFGMSGRECEIVEDERRFATAL": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGRECEIVEDERRFATAL"
+          },
+          "CFGMSGRECEIVEDERRNONFATAL": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGRECEIVEDERRNONFATAL"
+          },
+          "CFGMSGRECEIVEDPMASNAK": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGRECEIVEDPMASNAK"
+          },
+          "CFGMSGRECEIVEDPMETO": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGRECEIVEDPMETO"
+          },
+          "CFGMSGRECEIVEDPMETOACK": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGRECEIVEDPMETOACK"
+          },
+          "CFGMSGRECEIVEDPMPME": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGRECEIVEDPMPME"
+          },
+          "CFGMSGRECEIVEDSETSLOTPOWERLIMIT": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGRECEIVEDSETSLOTPOWERLIMIT"
+          },
+          "CFGMSGRECEIVEDUNLOCK": {
+            "dir": "OUTPUT",
+            "wire": "CFGMSGRECEIVEDUNLOCK"
+          },
+          "CFGPCIECAPINTERRUPTMSGNUM0": {
+            "dir": "INPUT",
+            "wire": "CFGPCIECAPINTERRUPTMSGNUM0"
+          },
+          "CFGPCIECAPINTERRUPTMSGNUM1": {
+            "dir": "INPUT",
+            "wire": "CFGPCIECAPINTERRUPTMSGNUM1"
+          },
+          "CFGPCIECAPINTERRUPTMSGNUM2": {
+            "dir": "INPUT",
+            "wire": "CFGPCIECAPINTERRUPTMSGNUM2"
+          },
+          "CFGPCIECAPINTERRUPTMSGNUM3": {
+            "dir": "INPUT",
+            "wire": "CFGPCIECAPINTERRUPTMSGNUM3"
+          },
+          "CFGPCIECAPINTERRUPTMSGNUM4": {
+            "dir": "INPUT",
+            "wire": "CFGPCIECAPINTERRUPTMSGNUM4"
+          },
+          "CFGPCIELINKSTATE0": {
+            "dir": "OUTPUT",
+            "wire": "CFGPCIELINKSTATE0"
+          },
+          "CFGPCIELINKSTATE1": {
+            "dir": "OUTPUT",
+            "wire": "CFGPCIELINKSTATE1"
+          },
+          "CFGPCIELINKSTATE2": {
+            "dir": "OUTPUT",
+            "wire": "CFGPCIELINKSTATE2"
+          },
+          "CFGPMCSRPMEEN": {
+            "dir": "OUTPUT",
+            "wire": "CFGPMCSRPMEEN"
+          },
+          "CFGPMCSRPMESTATUS": {
+            "dir": "OUTPUT",
+            "wire": "CFGPMCSRPMESTATUS"
+          },
+          "CFGPMCSRPOWERSTATE0": {
+            "dir": "OUTPUT",
+            "wire": "CFGPMCSRPOWERSTATE0"
+          },
+          "CFGPMCSRPOWERSTATE1": {
+            "dir": "OUTPUT",
+            "wire": "CFGPMCSRPOWERSTATE1"
+          },
+          "CFGPMFORCESTATE0": {
+            "dir": "INPUT",
+            "wire": "CFGPMFORCESTATE0"
+          },
+          "CFGPMFORCESTATE1": {
+            "dir": "INPUT",
+            "wire": "CFGPMFORCESTATE1"
+          },
+          "CFGPMFORCESTATEENN": {
+            "dir": "INPUT",
+            "wire": "CFGPMFORCESTATEENN"
+          },
+          "CFGPMHALTASPML0SN": {
+            "dir": "INPUT",
+            "wire": "CFGPMHALTASPML0SN"
+          },
+          "CFGPMHALTASPML1N": {
+            "dir": "INPUT",
+            "wire": "CFGPMHALTASPML1N"
+          },
+          "CFGPMRCVASREQL1N": {
+            "dir": "OUTPUT",
+            "wire": "CFGPMRCVASREQL1N"
+          },
+          "CFGPMRCVENTERL1N": {
+            "dir": "OUTPUT",
+            "wire": "CFGPMRCVENTERL1N"
+          },
+          "CFGPMRCVENTERL23N": {
+            "dir": "OUTPUT",
+            "wire": "CFGPMRCVENTERL23N"
+          },
+          "CFGPMRCVREQACKN": {
+            "dir": "OUTPUT",
+            "wire": "CFGPMRCVREQACKN"
+          },
+          "CFGPMSENDPMETON": {
+            "dir": "INPUT",
+            "wire": "CFGPMSENDPMETON"
+          },
+          "CFGPMTURNOFFOKN": {
+            "dir": "INPUT",
+            "wire": "CFGPMTURNOFFOKN"
+          },
+          "CFGPMWAKEN": {
+            "dir": "INPUT",
+            "wire": "CFGPMWAKEN"
+          },
+          "CFGPORTNUMBER0": {
+            "dir": "INPUT",
+            "wire": "CFGPORTNUMBER0"
+          },
+          "CFGPORTNUMBER1": {
+            "dir": "INPUT",
+            "wire": "CFGPORTNUMBER1"
+          },
+          "CFGPORTNUMBER2": {
+            "dir": "INPUT",
+            "wire": "CFGPORTNUMBER2"
+          },
+          "CFGPORTNUMBER3": {
+            "dir": "INPUT",
+            "wire": "CFGPORTNUMBER3"
+          },
+          "CFGPORTNUMBER4": {
+            "dir": "INPUT",
+            "wire": "CFGPORTNUMBER4"
+          },
+          "CFGPORTNUMBER5": {
+            "dir": "INPUT",
+            "wire": "CFGPORTNUMBER5"
+          },
+          "CFGPORTNUMBER6": {
+            "dir": "INPUT",
+            "wire": "CFGPORTNUMBER6"
+          },
+          "CFGPORTNUMBER7": {
+            "dir": "INPUT",
+            "wire": "CFGPORTNUMBER7"
+          },
+          "CFGREVID0": {
+            "dir": "INPUT",
+            "wire": "CFGREVID0"
+          },
+          "CFGREVID1": {
+            "dir": "INPUT",
+            "wire": "CFGREVID1"
+          },
+          "CFGREVID2": {
+            "dir": "INPUT",
+            "wire": "CFGREVID2"
+          },
+          "CFGREVID3": {
+            "dir": "INPUT",
+            "wire": "CFGREVID3"
+          },
+          "CFGREVID4": {
+            "dir": "INPUT",
+            "wire": "CFGREVID4"
+          },
+          "CFGREVID5": {
+            "dir": "INPUT",
+            "wire": "CFGREVID5"
+          },
+          "CFGREVID6": {
+            "dir": "INPUT",
+            "wire": "CFGREVID6"
+          },
+          "CFGREVID7": {
+            "dir": "INPUT",
+            "wire": "CFGREVID7"
+          },
+          "CFGROOTCONTROLPMEINTEN": {
+            "dir": "OUTPUT",
+            "wire": "CFGROOTCONTROLPMEINTEN"
+          },
+          "CFGROOTCONTROLSYSERRCORRERREN": {
+            "dir": "OUTPUT",
+            "wire": "CFGROOTCONTROLSYSERRCORRERREN"
+          },
+          "CFGROOTCONTROLSYSERRFATALERREN": {
+            "dir": "OUTPUT",
+            "wire": "CFGROOTCONTROLSYSERRFATALERREN"
+          },
+          "CFGROOTCONTROLSYSERRNONFATALERREN": {
+            "dir": "OUTPUT",
+            "wire": "CFGROOTCONTROLSYSERRNONFATALERREN"
+          },
+          "CFGSLOTCONTROLELECTROMECHILCTLPULSE": {
+            "dir": "OUTPUT",
+            "wire": "CFGSLOTCONTROLELECTROMECHILCTLPULSE"
+          },
+          "CFGSUBSYSID0": {
+            "dir": "INPUT",
+            "wire": "CFGSUBSYSID0"
+          },
+          "CFGSUBSYSID1": {
+            "dir": "INPUT",
+            "wire": "CFGSUBSYSID1"
+          },
+          "CFGSUBSYSID2": {
+            "dir": "INPUT",
+            "wire": "CFGSUBSYSID2"
+          },
+          "CFGSUBSYSID3": {
+            "dir": "INPUT",
+            "wire": "CFGSUBSYSID3"
+          },
+          "CFGSUBSYSID4": {
+            "dir": "INPUT",
+            "wire": "CFGSUBSYSID4"
+          },
+          "CFGSUBSYSID5": {
+            "dir": "INPUT",
+            "wire": "CFGSUBSYSID5"
+          },
+          "CFGSUBSYSID6": {
+            "dir": "INPUT",
+            "wire": "CFGSUBSYSID6"
+          },
+          "CFGSUBSYSID7": {
+            "dir": "INPUT",
+            "wire": "CFGSUBSYSID7"
+          },
+          "CFGSUBSYSID8": {
+            "dir": "INPUT",
+            "wire": "CFGSUBSYSID8"
+          },
+          "CFGSUBSYSID9": {
+            "dir": "INPUT",
+            "wire": "CFGSUBSYSID9"
+          },
+          "CFGSUBSYSID10": {
+            "dir": "INPUT",
+            "wire": "CFGSUBSYSID10"
+          },
+          "CFGSUBSYSID11": {
+            "dir": "INPUT",
+            "wire": "CFGSUBSYSID11"
+          },
+          "CFGSUBSYSID12": {
+            "dir": "INPUT",
+            "wire": "CFGSUBSYSID12"
+          },
+          "CFGSUBSYSID13": {
+            "dir": "INPUT",
+            "wire": "CFGSUBSYSID13"
+          },
+          "CFGSUBSYSID14": {
+            "dir": "INPUT",
+            "wire": "CFGSUBSYSID14"
+          },
+          "CFGSUBSYSID15": {
+            "dir": "INPUT",
+            "wire": "CFGSUBSYSID15"
+          },
+          "CFGSUBSYSVENDID0": {
+            "dir": "INPUT",
+            "wire": "CFGSUBSYSVENDID0"
+          },
+          "CFGSUBSYSVENDID1": {
+            "dir": "INPUT",
+            "wire": "CFGSUBSYSVENDID1"
+          },
+          "CFGSUBSYSVENDID2": {
+            "dir": "INPUT",
+            "wire": "CFGSUBSYSVENDID2"
+          },
+          "CFGSUBSYSVENDID3": {
+            "dir": "INPUT",
+            "wire": "CFGSUBSYSVENDID3"
+          },
+          "CFGSUBSYSVENDID4": {
+            "dir": "INPUT",
+            "wire": "CFGSUBSYSVENDID4"
+          },
+          "CFGSUBSYSVENDID5": {
+            "dir": "INPUT",
+            "wire": "CFGSUBSYSVENDID5"
+          },
+          "CFGSUBSYSVENDID6": {
+            "dir": "INPUT",
+            "wire": "CFGSUBSYSVENDID6"
+          },
+          "CFGSUBSYSVENDID7": {
+            "dir": "INPUT",
+            "wire": "CFGSUBSYSVENDID7"
+          },
+          "CFGSUBSYSVENDID8": {
+            "dir": "INPUT",
+            "wire": "CFGSUBSYSVENDID8"
+          },
+          "CFGSUBSYSVENDID9": {
+            "dir": "INPUT",
+            "wire": "CFGSUBSYSVENDID9"
+          },
+          "CFGSUBSYSVENDID10": {
+            "dir": "INPUT",
+            "wire": "CFGSUBSYSVENDID10"
+          },
+          "CFGSUBSYSVENDID11": {
+            "dir": "INPUT",
+            "wire": "CFGSUBSYSVENDID11"
+          },
+          "CFGSUBSYSVENDID12": {
+            "dir": "INPUT",
+            "wire": "CFGSUBSYSVENDID12"
+          },
+          "CFGSUBSYSVENDID13": {
+            "dir": "INPUT",
+            "wire": "CFGSUBSYSVENDID13"
+          },
+          "CFGSUBSYSVENDID14": {
+            "dir": "INPUT",
+            "wire": "CFGSUBSYSVENDID14"
+          },
+          "CFGSUBSYSVENDID15": {
+            "dir": "INPUT",
+            "wire": "CFGSUBSYSVENDID15"
+          },
+          "CFGTRANSACTION": {
+            "dir": "OUTPUT",
+            "wire": "CFGTRANSACTION"
+          },
+          "CFGTRANSACTIONADDR0": {
+            "dir": "OUTPUT",
+            "wire": "CFGTRANSACTIONADDR0"
+          },
+          "CFGTRANSACTIONADDR1": {
+            "dir": "OUTPUT",
+            "wire": "CFGTRANSACTIONADDR1"
+          },
+          "CFGTRANSACTIONADDR2": {
+            "dir": "OUTPUT",
+            "wire": "CFGTRANSACTIONADDR2"
+          },
+          "CFGTRANSACTIONADDR3": {
+            "dir": "OUTPUT",
+            "wire": "CFGTRANSACTIONADDR3"
+          },
+          "CFGTRANSACTIONADDR4": {
+            "dir": "OUTPUT",
+            "wire": "CFGTRANSACTIONADDR4"
+          },
+          "CFGTRANSACTIONADDR5": {
+            "dir": "OUTPUT",
+            "wire": "CFGTRANSACTIONADDR5"
+          },
+          "CFGTRANSACTIONADDR6": {
+            "dir": "OUTPUT",
+            "wire": "CFGTRANSACTIONADDR6"
+          },
+          "CFGTRANSACTIONTYPE": {
+            "dir": "OUTPUT",
+            "wire": "CFGTRANSACTIONTYPE"
+          },
+          "CFGTRNPENDINGN": {
+            "dir": "INPUT",
+            "wire": "CFGTRNPENDINGN"
+          },
+          "CFGVCTCVCMAP0": {
+            "dir": "OUTPUT",
+            "wire": "CFGVCTCVCMAP0"
+          },
+          "CFGVCTCVCMAP1": {
+            "dir": "OUTPUT",
+            "wire": "CFGVCTCVCMAP1"
+          },
+          "CFGVCTCVCMAP2": {
+            "dir": "OUTPUT",
+            "wire": "CFGVCTCVCMAP2"
+          },
+          "CFGVCTCVCMAP3": {
+            "dir": "OUTPUT",
+            "wire": "CFGVCTCVCMAP3"
+          },
+          "CFGVCTCVCMAP4": {
+            "dir": "OUTPUT",
+            "wire": "CFGVCTCVCMAP4"
+          },
+          "CFGVCTCVCMAP5": {
+            "dir": "OUTPUT",
+            "wire": "CFGVCTCVCMAP5"
+          },
+          "CFGVCTCVCMAP6": {
+            "dir": "OUTPUT",
+            "wire": "CFGVCTCVCMAP6"
+          },
+          "CFGVENDID0": {
+            "dir": "INPUT",
+            "wire": "CFGVENDID0"
+          },
+          "CFGVENDID1": {
+            "dir": "INPUT",
+            "wire": "CFGVENDID1"
+          },
+          "CFGVENDID2": {
+            "dir": "INPUT",
+            "wire": "CFGVENDID2"
+          },
+          "CFGVENDID3": {
+            "dir": "INPUT",
+            "wire": "CFGVENDID3"
+          },
+          "CFGVENDID4": {
+            "dir": "INPUT",
+            "wire": "CFGVENDID4"
+          },
+          "CFGVENDID5": {
+            "dir": "INPUT",
+            "wire": "CFGVENDID5"
+          },
+          "CFGVENDID6": {
+            "dir": "INPUT",
+            "wire": "CFGVENDID6"
+          },
+          "CFGVENDID7": {
+            "dir": "INPUT",
+            "wire": "CFGVENDID7"
+          },
+          "CFGVENDID8": {
+            "dir": "INPUT",
+            "wire": "CFGVENDID8"
+          },
+          "CFGVENDID9": {
+            "dir": "INPUT",
+            "wire": "CFGVENDID9"
+          },
+          "CFGVENDID10": {
+            "dir": "INPUT",
+            "wire": "CFGVENDID10"
+          },
+          "CFGVENDID11": {
+            "dir": "INPUT",
+            "wire": "CFGVENDID11"
+          },
+          "CFGVENDID12": {
+            "dir": "INPUT",
+            "wire": "CFGVENDID12"
+          },
+          "CFGVENDID13": {
+            "dir": "INPUT",
+            "wire": "CFGVENDID13"
+          },
+          "CFGVENDID14": {
+            "dir": "INPUT",
+            "wire": "CFGVENDID14"
+          },
+          "CFGVENDID15": {
+            "dir": "INPUT",
+            "wire": "CFGVENDID15"
+          },
+          "CMRSTN": {
+            "dir": "INPUT",
+            "wire": "CMRSTN"
+          },
+          "CMSTICKYRSTN": {
+            "dir": "INPUT",
+            "wire": "CMSTICKYRSTN"
+          },
+          "DBGMODE0": {
+            "dir": "INPUT",
+            "wire": "DBGMODE0"
+          },
+          "DBGMODE1": {
+            "dir": "INPUT",
+            "wire": "DBGMODE1"
+          },
+          "DBGSCLRA": {
+            "dir": "OUTPUT",
+            "wire": "DBGSCLRA"
+          },
+          "DBGSCLRB": {
+            "dir": "OUTPUT",
+            "wire": "DBGSCLRB"
+          },
+          "DBGSCLRC": {
+            "dir": "OUTPUT",
+            "wire": "DBGSCLRC"
+          },
+          "DBGSCLRD": {
+            "dir": "OUTPUT",
+            "wire": "DBGSCLRD"
+          },
+          "DBGSCLRE": {
+            "dir": "OUTPUT",
+            "wire": "DBGSCLRE"
+          },
+          "DBGSCLRF": {
+            "dir": "OUTPUT",
+            "wire": "DBGSCLRF"
+          },
+          "DBGSCLRG": {
+            "dir": "OUTPUT",
+            "wire": "DBGSCLRG"
+          },
+          "DBGSCLRH": {
+            "dir": "OUTPUT",
+            "wire": "DBGSCLRH"
+          },
+          "DBGSCLRI": {
+            "dir": "OUTPUT",
+            "wire": "DBGSCLRI"
+          },
+          "DBGSCLRJ": {
+            "dir": "OUTPUT",
+            "wire": "DBGSCLRJ"
+          },
+          "DBGSCLRK": {
+            "dir": "OUTPUT",
+            "wire": "DBGSCLRK"
+          },
+          "DBGSUBMODE": {
+            "dir": "INPUT",
+            "wire": "DBGSUBMODE"
+          },
+          "DBGVECA0": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA0"
+          },
+          "DBGVECA1": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA1"
+          },
+          "DBGVECA2": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA2"
+          },
+          "DBGVECA3": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA3"
+          },
+          "DBGVECA4": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA4"
+          },
+          "DBGVECA5": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA5"
+          },
+          "DBGVECA6": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA6"
+          },
+          "DBGVECA7": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA7"
+          },
+          "DBGVECA8": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA8"
+          },
+          "DBGVECA9": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA9"
+          },
+          "DBGVECA10": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA10"
+          },
+          "DBGVECA11": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA11"
+          },
+          "DBGVECA12": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA12"
+          },
+          "DBGVECA13": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA13"
+          },
+          "DBGVECA14": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA14"
+          },
+          "DBGVECA15": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA15"
+          },
+          "DBGVECA16": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA16"
+          },
+          "DBGVECA17": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA17"
+          },
+          "DBGVECA18": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA18"
+          },
+          "DBGVECA19": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA19"
+          },
+          "DBGVECA20": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA20"
+          },
+          "DBGVECA21": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA21"
+          },
+          "DBGVECA22": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA22"
+          },
+          "DBGVECA23": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA23"
+          },
+          "DBGVECA24": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA24"
+          },
+          "DBGVECA25": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA25"
+          },
+          "DBGVECA26": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA26"
+          },
+          "DBGVECA27": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA27"
+          },
+          "DBGVECA28": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA28"
+          },
+          "DBGVECA29": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA29"
+          },
+          "DBGVECA30": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA30"
+          },
+          "DBGVECA31": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA31"
+          },
+          "DBGVECA32": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA32"
+          },
+          "DBGVECA33": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA33"
+          },
+          "DBGVECA34": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA34"
+          },
+          "DBGVECA35": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA35"
+          },
+          "DBGVECA36": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA36"
+          },
+          "DBGVECA37": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA37"
+          },
+          "DBGVECA38": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA38"
+          },
+          "DBGVECA39": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA39"
+          },
+          "DBGVECA40": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA40"
+          },
+          "DBGVECA41": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA41"
+          },
+          "DBGVECA42": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA42"
+          },
+          "DBGVECA43": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA43"
+          },
+          "DBGVECA44": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA44"
+          },
+          "DBGVECA45": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA45"
+          },
+          "DBGVECA46": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA46"
+          },
+          "DBGVECA47": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA47"
+          },
+          "DBGVECA48": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA48"
+          },
+          "DBGVECA49": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA49"
+          },
+          "DBGVECA50": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA50"
+          },
+          "DBGVECA51": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA51"
+          },
+          "DBGVECA52": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA52"
+          },
+          "DBGVECA53": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA53"
+          },
+          "DBGVECA54": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA54"
+          },
+          "DBGVECA55": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA55"
+          },
+          "DBGVECA56": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA56"
+          },
+          "DBGVECA57": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA57"
+          },
+          "DBGVECA58": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA58"
+          },
+          "DBGVECA59": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA59"
+          },
+          "DBGVECA60": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA60"
+          },
+          "DBGVECA61": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA61"
+          },
+          "DBGVECA62": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA62"
+          },
+          "DBGVECA63": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECA63"
+          },
+          "DBGVECB0": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB0"
+          },
+          "DBGVECB1": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB1"
+          },
+          "DBGVECB2": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB2"
+          },
+          "DBGVECB3": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB3"
+          },
+          "DBGVECB4": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB4"
+          },
+          "DBGVECB5": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB5"
+          },
+          "DBGVECB6": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB6"
+          },
+          "DBGVECB7": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB7"
+          },
+          "DBGVECB8": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB8"
+          },
+          "DBGVECB9": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB9"
+          },
+          "DBGVECB10": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB10"
+          },
+          "DBGVECB11": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB11"
+          },
+          "DBGVECB12": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB12"
+          },
+          "DBGVECB13": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB13"
+          },
+          "DBGVECB14": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB14"
+          },
+          "DBGVECB15": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB15"
+          },
+          "DBGVECB16": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB16"
+          },
+          "DBGVECB17": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB17"
+          },
+          "DBGVECB18": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB18"
+          },
+          "DBGVECB19": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB19"
+          },
+          "DBGVECB20": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB20"
+          },
+          "DBGVECB21": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB21"
+          },
+          "DBGVECB22": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB22"
+          },
+          "DBGVECB23": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB23"
+          },
+          "DBGVECB24": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB24"
+          },
+          "DBGVECB25": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB25"
+          },
+          "DBGVECB26": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB26"
+          },
+          "DBGVECB27": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB27"
+          },
+          "DBGVECB28": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB28"
+          },
+          "DBGVECB29": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB29"
+          },
+          "DBGVECB30": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB30"
+          },
+          "DBGVECB31": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB31"
+          },
+          "DBGVECB32": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB32"
+          },
+          "DBGVECB33": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB33"
+          },
+          "DBGVECB34": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB34"
+          },
+          "DBGVECB35": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB35"
+          },
+          "DBGVECB36": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB36"
+          },
+          "DBGVECB37": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB37"
+          },
+          "DBGVECB38": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB38"
+          },
+          "DBGVECB39": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB39"
+          },
+          "DBGVECB40": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB40"
+          },
+          "DBGVECB41": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB41"
+          },
+          "DBGVECB42": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB42"
+          },
+          "DBGVECB43": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB43"
+          },
+          "DBGVECB44": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB44"
+          },
+          "DBGVECB45": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB45"
+          },
+          "DBGVECB46": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB46"
+          },
+          "DBGVECB47": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB47"
+          },
+          "DBGVECB48": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB48"
+          },
+          "DBGVECB49": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB49"
+          },
+          "DBGVECB50": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB50"
+          },
+          "DBGVECB51": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB51"
+          },
+          "DBGVECB52": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB52"
+          },
+          "DBGVECB53": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB53"
+          },
+          "DBGVECB54": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB54"
+          },
+          "DBGVECB55": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB55"
+          },
+          "DBGVECB56": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB56"
+          },
+          "DBGVECB57": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB57"
+          },
+          "DBGVECB58": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB58"
+          },
+          "DBGVECB59": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB59"
+          },
+          "DBGVECB60": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB60"
+          },
+          "DBGVECB61": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB61"
+          },
+          "DBGVECB62": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB62"
+          },
+          "DBGVECB63": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECB63"
+          },
+          "DBGVECC0": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECC0"
+          },
+          "DBGVECC1": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECC1"
+          },
+          "DBGVECC2": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECC2"
+          },
+          "DBGVECC3": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECC3"
+          },
+          "DBGVECC4": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECC4"
+          },
+          "DBGVECC5": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECC5"
+          },
+          "DBGVECC6": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECC6"
+          },
+          "DBGVECC7": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECC7"
+          },
+          "DBGVECC8": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECC8"
+          },
+          "DBGVECC9": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECC9"
+          },
+          "DBGVECC10": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECC10"
+          },
+          "DBGVECC11": {
+            "dir": "OUTPUT",
+            "wire": "DBGVECC11"
+          },
+          "DLRSTN": {
+            "dir": "INPUT",
+            "wire": "DLRSTN"
+          },
+          "DRPADDR0": {
+            "dir": "INPUT",
+            "wire": "DRPADDR0"
+          },
+          "DRPADDR1": {
+            "dir": "INPUT",
+            "wire": "DRPADDR1"
+          },
+          "DRPADDR2": {
+            "dir": "INPUT",
+            "wire": "DRPADDR2"
+          },
+          "DRPADDR3": {
+            "dir": "INPUT",
+            "wire": "DRPADDR3"
+          },
+          "DRPADDR4": {
+            "dir": "INPUT",
+            "wire": "DRPADDR4"
+          },
+          "DRPADDR5": {
+            "dir": "INPUT",
+            "wire": "DRPADDR5"
+          },
+          "DRPADDR6": {
+            "dir": "INPUT",
+            "wire": "DRPADDR6"
+          },
+          "DRPADDR7": {
+            "dir": "INPUT",
+            "wire": "DRPADDR7"
+          },
+          "DRPADDR8": {
+            "dir": "INPUT",
+            "wire": "DRPADDR8"
+          },
+          "DRPCLK": {
+            "dir": "INPUT",
+            "wire": "DRPCLK"
+          },
+          "DRPDI0": {
+            "dir": "INPUT",
+            "wire": "DRPDI0"
+          },
+          "DRPDI1": {
+            "dir": "INPUT",
+            "wire": "DRPDI1"
+          },
+          "DRPDI2": {
+            "dir": "INPUT",
+            "wire": "DRPDI2"
+          },
+          "DRPDI3": {
+            "dir": "INPUT",
+            "wire": "DRPDI3"
+          },
+          "DRPDI4": {
+            "dir": "INPUT",
+            "wire": "DRPDI4"
+          },
+          "DRPDI5": {
+            "dir": "INPUT",
+            "wire": "DRPDI5"
+          },
+          "DRPDI6": {
+            "dir": "INPUT",
+            "wire": "DRPDI6"
+          },
+          "DRPDI7": {
+            "dir": "INPUT",
+            "wire": "DRPDI7"
+          },
+          "DRPDI8": {
+            "dir": "INPUT",
+            "wire": "DRPDI8"
+          },
+          "DRPDI9": {
+            "dir": "INPUT",
+            "wire": "DRPDI9"
+          },
+          "DRPDI10": {
+            "dir": "INPUT",
+            "wire": "DRPDI10"
+          },
+          "DRPDI11": {
+            "dir": "INPUT",
+            "wire": "DRPDI11"
+          },
+          "DRPDI12": {
+            "dir": "INPUT",
+            "wire": "DRPDI12"
+          },
+          "DRPDI13": {
+            "dir": "INPUT",
+            "wire": "DRPDI13"
+          },
+          "DRPDI14": {
+            "dir": "INPUT",
+            "wire": "DRPDI14"
+          },
+          "DRPDI15": {
+            "dir": "INPUT",
+            "wire": "DRPDI15"
+          },
+          "DRPDO0": {
+            "dir": "OUTPUT",
+            "wire": "DRPDO0"
+          },
+          "DRPDO1": {
+            "dir": "OUTPUT",
+            "wire": "DRPDO1"
+          },
+          "DRPDO2": {
+            "dir": "OUTPUT",
+            "wire": "DRPDO2"
+          },
+          "DRPDO3": {
+            "dir": "OUTPUT",
+            "wire": "DRPDO3"
+          },
+          "DRPDO4": {
+            "dir": "OUTPUT",
+            "wire": "DRPDO4"
+          },
+          "DRPDO5": {
+            "dir": "OUTPUT",
+            "wire": "DRPDO5"
+          },
+          "DRPDO6": {
+            "dir": "OUTPUT",
+            "wire": "DRPDO6"
+          },
+          "DRPDO7": {
+            "dir": "OUTPUT",
+            "wire": "DRPDO7"
+          },
+          "DRPDO8": {
+            "dir": "OUTPUT",
+            "wire": "DRPDO8"
+          },
+          "DRPDO9": {
+            "dir": "OUTPUT",
+            "wire": "DRPDO9"
+          },
+          "DRPDO10": {
+            "dir": "OUTPUT",
+            "wire": "DRPDO10"
+          },
+          "DRPDO11": {
+            "dir": "OUTPUT",
+            "wire": "DRPDO11"
+          },
+          "DRPDO12": {
+            "dir": "OUTPUT",
+            "wire": "DRPDO12"
+          },
+          "DRPDO13": {
+            "dir": "OUTPUT",
+            "wire": "DRPDO13"
+          },
+          "DRPDO14": {
+            "dir": "OUTPUT",
+            "wire": "DRPDO14"
+          },
+          "DRPDO15": {
+            "dir": "OUTPUT",
+            "wire": "DRPDO15"
+          },
+          "DRPEN": {
+            "dir": "INPUT",
+            "wire": "DRPEN"
+          },
+          "DRPRDY": {
+            "dir": "OUTPUT",
+            "wire": "DRPRDY"
+          },
+          "DRPWE": {
+            "dir": "INPUT",
+            "wire": "DRPWE"
+          },
+          "EDTBYPASS": {
+            "dir": "INPUT",
+            "wire": "EDTBYPASS"
+          },
+          "EDTCHANNELSIN1": {
+            "dir": "INPUT",
+            "wire": "EDTCHANNELSIN1"
+          },
+          "EDTCHANNELSIN2": {
+            "dir": "INPUT",
+            "wire": "EDTCHANNELSIN2"
+          },
+          "EDTCHANNELSIN3": {
+            "dir": "INPUT",
+            "wire": "EDTCHANNELSIN3"
+          },
+          "EDTCHANNELSIN4": {
+            "dir": "INPUT",
+            "wire": "EDTCHANNELSIN4"
+          },
+          "EDTCHANNELSIN5": {
+            "dir": "INPUT",
+            "wire": "EDTCHANNELSIN5"
+          },
+          "EDTCHANNELSIN6": {
+            "dir": "INPUT",
+            "wire": "EDTCHANNELSIN6"
+          },
+          "EDTCHANNELSIN7": {
+            "dir": "INPUT",
+            "wire": "EDTCHANNELSIN7"
+          },
+          "EDTCHANNELSIN8": {
+            "dir": "INPUT",
+            "wire": "EDTCHANNELSIN8"
+          },
+          "EDTCHANNELSOUT1": {
+            "dir": "OUTPUT",
+            "wire": "EDTCHANNELSOUT1"
+          },
+          "EDTCHANNELSOUT2": {
+            "dir": "OUTPUT",
+            "wire": "EDTCHANNELSOUT2"
+          },
+          "EDTCHANNELSOUT3": {
+            "dir": "OUTPUT",
+            "wire": "EDTCHANNELSOUT3"
+          },
+          "EDTCHANNELSOUT4": {
+            "dir": "OUTPUT",
+            "wire": "EDTCHANNELSOUT4"
+          },
+          "EDTCHANNELSOUT5": {
+            "dir": "OUTPUT",
+            "wire": "EDTCHANNELSOUT5"
+          },
+          "EDTCHANNELSOUT6": {
+            "dir": "OUTPUT",
+            "wire": "EDTCHANNELSOUT6"
+          },
+          "EDTCHANNELSOUT7": {
+            "dir": "OUTPUT",
+            "wire": "EDTCHANNELSOUT7"
+          },
+          "EDTCHANNELSOUT8": {
+            "dir": "OUTPUT",
+            "wire": "EDTCHANNELSOUT8"
+          },
+          "EDTCLK": {
+            "dir": "INPUT",
+            "wire": "EDTCLK"
+          },
+          "EDTCONFIGURATION": {
+            "dir": "INPUT",
+            "wire": "EDTCONFIGURATION"
+          },
+          "EDTSINGLEBYPASSCHAIN": {
+            "dir": "INPUT",
+            "wire": "EDTSINGLEBYPASSCHAIN"
+          },
+          "EDTUPDATE": {
+            "dir": "INPUT",
+            "wire": "EDTUPDATE"
+          },
+          "FUNCLVLRSTN": {
+            "dir": "INPUT",
+            "wire": "FUNCLVLRSTN"
+          },
+          "LL2BADDLLPERR": {
+            "dir": "OUTPUT",
+            "wire": "LL2BADDLLPERR"
+          },
+          "LL2BADTLPERR": {
+            "dir": "OUTPUT",
+            "wire": "LL2BADTLPERR"
+          },
+          "LL2LINKSTATUS0": {
+            "dir": "OUTPUT",
+            "wire": "LL2LINKSTATUS0"
+          },
+          "LL2LINKSTATUS1": {
+            "dir": "OUTPUT",
+            "wire": "LL2LINKSTATUS1"
+          },
+          "LL2LINKSTATUS2": {
+            "dir": "OUTPUT",
+            "wire": "LL2LINKSTATUS2"
+          },
+          "LL2LINKSTATUS3": {
+            "dir": "OUTPUT",
+            "wire": "LL2LINKSTATUS3"
+          },
+          "LL2LINKSTATUS4": {
+            "dir": "OUTPUT",
+            "wire": "LL2LINKSTATUS4"
+          },
+          "LL2PROTOCOLERR": {
+            "dir": "OUTPUT",
+            "wire": "LL2PROTOCOLERR"
+          },
+          "LL2RECEIVERERR": {
+            "dir": "OUTPUT",
+            "wire": "LL2RECEIVERERR"
+          },
+          "LL2REPLAYROERR": {
+            "dir": "OUTPUT",
+            "wire": "LL2REPLAYROERR"
+          },
+          "LL2REPLAYTOERR": {
+            "dir": "OUTPUT",
+            "wire": "LL2REPLAYTOERR"
+          },
+          "LL2SENDASREQL1": {
+            "dir": "INPUT",
+            "wire": "LL2SENDASREQL1"
+          },
+          "LL2SENDENTERL1": {
+            "dir": "INPUT",
+            "wire": "LL2SENDENTERL1"
+          },
+          "LL2SENDENTERL23": {
+            "dir": "INPUT",
+            "wire": "LL2SENDENTERL23"
+          },
+          "LL2SENDPMACK": {
+            "dir": "INPUT",
+            "wire": "LL2SENDPMACK"
+          },
+          "LL2SUSPENDNOW": {
+            "dir": "INPUT",
+            "wire": "LL2SUSPENDNOW"
+          },
+          "LL2SUSPENDOK": {
+            "dir": "OUTPUT",
+            "wire": "LL2SUSPENDOK"
+          },
+          "LL2TFCINIT1SEQ": {
+            "dir": "OUTPUT",
+            "wire": "LL2TFCINIT1SEQ"
+          },
+          "LL2TFCINIT2SEQ": {
+            "dir": "OUTPUT",
+            "wire": "LL2TFCINIT2SEQ"
+          },
+          "LL2TLPRCV": {
+            "dir": "INPUT",
+            "wire": "LL2TLPRCV"
+          },
+          "LL2TXIDLE": {
+            "dir": "OUTPUT",
+            "wire": "LL2TXIDLE"
+          },
+          "LNKCLKEN": {
+            "dir": "OUTPUT",
+            "wire": "LNKCLKEN"
+          },
+          "MIMRXRADDR0": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXRADDR0"
+          },
+          "MIMRXRADDR1": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXRADDR1"
+          },
+          "MIMRXRADDR2": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXRADDR2"
+          },
+          "MIMRXRADDR3": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXRADDR3"
+          },
+          "MIMRXRADDR4": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXRADDR4"
+          },
+          "MIMRXRADDR5": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXRADDR5"
+          },
+          "MIMRXRADDR6": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXRADDR6"
+          },
+          "MIMRXRADDR7": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXRADDR7"
+          },
+          "MIMRXRADDR8": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXRADDR8"
+          },
+          "MIMRXRADDR9": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXRADDR9"
+          },
+          "MIMRXRADDR10": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXRADDR10"
+          },
+          "MIMRXRADDR11": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXRADDR11"
+          },
+          "MIMRXRADDR12": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXRADDR12"
+          },
+          "MIMRXRDATA0": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA0"
+          },
+          "MIMRXRDATA1": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA1"
+          },
+          "MIMRXRDATA2": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA2"
+          },
+          "MIMRXRDATA3": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA3"
+          },
+          "MIMRXRDATA4": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA4"
+          },
+          "MIMRXRDATA5": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA5"
+          },
+          "MIMRXRDATA6": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA6"
+          },
+          "MIMRXRDATA7": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA7"
+          },
+          "MIMRXRDATA8": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA8"
+          },
+          "MIMRXRDATA9": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA9"
+          },
+          "MIMRXRDATA10": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA10"
+          },
+          "MIMRXRDATA11": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA11"
+          },
+          "MIMRXRDATA12": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA12"
+          },
+          "MIMRXRDATA13": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA13"
+          },
+          "MIMRXRDATA14": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA14"
+          },
+          "MIMRXRDATA15": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA15"
+          },
+          "MIMRXRDATA16": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA16"
+          },
+          "MIMRXRDATA17": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA17"
+          },
+          "MIMRXRDATA18": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA18"
+          },
+          "MIMRXRDATA19": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA19"
+          },
+          "MIMRXRDATA20": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA20"
+          },
+          "MIMRXRDATA21": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA21"
+          },
+          "MIMRXRDATA22": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA22"
+          },
+          "MIMRXRDATA23": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA23"
+          },
+          "MIMRXRDATA24": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA24"
+          },
+          "MIMRXRDATA25": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA25"
+          },
+          "MIMRXRDATA26": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA26"
+          },
+          "MIMRXRDATA27": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA27"
+          },
+          "MIMRXRDATA28": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA28"
+          },
+          "MIMRXRDATA29": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA29"
+          },
+          "MIMRXRDATA30": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA30"
+          },
+          "MIMRXRDATA31": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA31"
+          },
+          "MIMRXRDATA32": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA32"
+          },
+          "MIMRXRDATA33": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA33"
+          },
+          "MIMRXRDATA34": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA34"
+          },
+          "MIMRXRDATA35": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA35"
+          },
+          "MIMRXRDATA36": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA36"
+          },
+          "MIMRXRDATA37": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA37"
+          },
+          "MIMRXRDATA38": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA38"
+          },
+          "MIMRXRDATA39": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA39"
+          },
+          "MIMRXRDATA40": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA40"
+          },
+          "MIMRXRDATA41": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA41"
+          },
+          "MIMRXRDATA42": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA42"
+          },
+          "MIMRXRDATA43": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA43"
+          },
+          "MIMRXRDATA44": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA44"
+          },
+          "MIMRXRDATA45": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA45"
+          },
+          "MIMRXRDATA46": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA46"
+          },
+          "MIMRXRDATA47": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA47"
+          },
+          "MIMRXRDATA48": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA48"
+          },
+          "MIMRXRDATA49": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA49"
+          },
+          "MIMRXRDATA50": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA50"
+          },
+          "MIMRXRDATA51": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA51"
+          },
+          "MIMRXRDATA52": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA52"
+          },
+          "MIMRXRDATA53": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA53"
+          },
+          "MIMRXRDATA54": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA54"
+          },
+          "MIMRXRDATA55": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA55"
+          },
+          "MIMRXRDATA56": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA56"
+          },
+          "MIMRXRDATA57": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA57"
+          },
+          "MIMRXRDATA58": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA58"
+          },
+          "MIMRXRDATA59": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA59"
+          },
+          "MIMRXRDATA60": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA60"
+          },
+          "MIMRXRDATA61": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA61"
+          },
+          "MIMRXRDATA62": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA62"
+          },
+          "MIMRXRDATA63": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA63"
+          },
+          "MIMRXRDATA64": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA64"
+          },
+          "MIMRXRDATA65": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA65"
+          },
+          "MIMRXRDATA66": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA66"
+          },
+          "MIMRXRDATA67": {
+            "dir": "INPUT",
+            "wire": "MIMRXRDATA67"
+          },
+          "MIMRXREN": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXREN"
+          },
+          "MIMRXWADDR0": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWADDR0"
+          },
+          "MIMRXWADDR1": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWADDR1"
+          },
+          "MIMRXWADDR2": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWADDR2"
+          },
+          "MIMRXWADDR3": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWADDR3"
+          },
+          "MIMRXWADDR4": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWADDR4"
+          },
+          "MIMRXWADDR5": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWADDR5"
+          },
+          "MIMRXWADDR6": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWADDR6"
+          },
+          "MIMRXWADDR7": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWADDR7"
+          },
+          "MIMRXWADDR8": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWADDR8"
+          },
+          "MIMRXWADDR9": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWADDR9"
+          },
+          "MIMRXWADDR10": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWADDR10"
+          },
+          "MIMRXWADDR11": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWADDR11"
+          },
+          "MIMRXWADDR12": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWADDR12"
+          },
+          "MIMRXWDATA0": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA0"
+          },
+          "MIMRXWDATA1": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA1"
+          },
+          "MIMRXWDATA2": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA2"
+          },
+          "MIMRXWDATA3": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA3"
+          },
+          "MIMRXWDATA4": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA4"
+          },
+          "MIMRXWDATA5": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA5"
+          },
+          "MIMRXWDATA6": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA6"
+          },
+          "MIMRXWDATA7": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA7"
+          },
+          "MIMRXWDATA8": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA8"
+          },
+          "MIMRXWDATA9": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA9"
+          },
+          "MIMRXWDATA10": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA10"
+          },
+          "MIMRXWDATA11": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA11"
+          },
+          "MIMRXWDATA12": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA12"
+          },
+          "MIMRXWDATA13": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA13"
+          },
+          "MIMRXWDATA14": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA14"
+          },
+          "MIMRXWDATA15": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA15"
+          },
+          "MIMRXWDATA16": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA16"
+          },
+          "MIMRXWDATA17": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA17"
+          },
+          "MIMRXWDATA18": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA18"
+          },
+          "MIMRXWDATA19": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA19"
+          },
+          "MIMRXWDATA20": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA20"
+          },
+          "MIMRXWDATA21": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA21"
+          },
+          "MIMRXWDATA22": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA22"
+          },
+          "MIMRXWDATA23": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA23"
+          },
+          "MIMRXWDATA24": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA24"
+          },
+          "MIMRXWDATA25": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA25"
+          },
+          "MIMRXWDATA26": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA26"
+          },
+          "MIMRXWDATA27": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA27"
+          },
+          "MIMRXWDATA28": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA28"
+          },
+          "MIMRXWDATA29": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA29"
+          },
+          "MIMRXWDATA30": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA30"
+          },
+          "MIMRXWDATA31": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA31"
+          },
+          "MIMRXWDATA32": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA32"
+          },
+          "MIMRXWDATA33": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA33"
+          },
+          "MIMRXWDATA34": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA34"
+          },
+          "MIMRXWDATA35": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA35"
+          },
+          "MIMRXWDATA36": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA36"
+          },
+          "MIMRXWDATA37": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA37"
+          },
+          "MIMRXWDATA38": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA38"
+          },
+          "MIMRXWDATA39": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA39"
+          },
+          "MIMRXWDATA40": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA40"
+          },
+          "MIMRXWDATA41": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA41"
+          },
+          "MIMRXWDATA42": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA42"
+          },
+          "MIMRXWDATA43": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA43"
+          },
+          "MIMRXWDATA44": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA44"
+          },
+          "MIMRXWDATA45": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA45"
+          },
+          "MIMRXWDATA46": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA46"
+          },
+          "MIMRXWDATA47": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA47"
+          },
+          "MIMRXWDATA48": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA48"
+          },
+          "MIMRXWDATA49": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA49"
+          },
+          "MIMRXWDATA50": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA50"
+          },
+          "MIMRXWDATA51": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA51"
+          },
+          "MIMRXWDATA52": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA52"
+          },
+          "MIMRXWDATA53": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA53"
+          },
+          "MIMRXWDATA54": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA54"
+          },
+          "MIMRXWDATA55": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA55"
+          },
+          "MIMRXWDATA56": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA56"
+          },
+          "MIMRXWDATA57": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA57"
+          },
+          "MIMRXWDATA58": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA58"
+          },
+          "MIMRXWDATA59": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA59"
+          },
+          "MIMRXWDATA60": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA60"
+          },
+          "MIMRXWDATA61": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA61"
+          },
+          "MIMRXWDATA62": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA62"
+          },
+          "MIMRXWDATA63": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA63"
+          },
+          "MIMRXWDATA64": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA64"
+          },
+          "MIMRXWDATA65": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA65"
+          },
+          "MIMRXWDATA66": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA66"
+          },
+          "MIMRXWDATA67": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWDATA67"
+          },
+          "MIMRXWEN": {
+            "dir": "OUTPUT",
+            "wire": "MIMRXWEN"
+          },
+          "MIMTXRADDR0": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXRADDR0"
+          },
+          "MIMTXRADDR1": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXRADDR1"
+          },
+          "MIMTXRADDR2": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXRADDR2"
+          },
+          "MIMTXRADDR3": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXRADDR3"
+          },
+          "MIMTXRADDR4": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXRADDR4"
+          },
+          "MIMTXRADDR5": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXRADDR5"
+          },
+          "MIMTXRADDR6": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXRADDR6"
+          },
+          "MIMTXRADDR7": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXRADDR7"
+          },
+          "MIMTXRADDR8": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXRADDR8"
+          },
+          "MIMTXRADDR9": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXRADDR9"
+          },
+          "MIMTXRADDR10": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXRADDR10"
+          },
+          "MIMTXRADDR11": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXRADDR11"
+          },
+          "MIMTXRADDR12": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXRADDR12"
+          },
+          "MIMTXRDATA0": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA0"
+          },
+          "MIMTXRDATA1": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA1"
+          },
+          "MIMTXRDATA2": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA2"
+          },
+          "MIMTXRDATA3": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA3"
+          },
+          "MIMTXRDATA4": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA4"
+          },
+          "MIMTXRDATA5": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA5"
+          },
+          "MIMTXRDATA6": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA6"
+          },
+          "MIMTXRDATA7": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA7"
+          },
+          "MIMTXRDATA8": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA8"
+          },
+          "MIMTXRDATA9": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA9"
+          },
+          "MIMTXRDATA10": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA10"
+          },
+          "MIMTXRDATA11": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA11"
+          },
+          "MIMTXRDATA12": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA12"
+          },
+          "MIMTXRDATA13": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA13"
+          },
+          "MIMTXRDATA14": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA14"
+          },
+          "MIMTXRDATA15": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA15"
+          },
+          "MIMTXRDATA16": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA16"
+          },
+          "MIMTXRDATA17": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA17"
+          },
+          "MIMTXRDATA18": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA18"
+          },
+          "MIMTXRDATA19": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA19"
+          },
+          "MIMTXRDATA20": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA20"
+          },
+          "MIMTXRDATA21": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA21"
+          },
+          "MIMTXRDATA22": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA22"
+          },
+          "MIMTXRDATA23": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA23"
+          },
+          "MIMTXRDATA24": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA24"
+          },
+          "MIMTXRDATA25": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA25"
+          },
+          "MIMTXRDATA26": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA26"
+          },
+          "MIMTXRDATA27": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA27"
+          },
+          "MIMTXRDATA28": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA28"
+          },
+          "MIMTXRDATA29": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA29"
+          },
+          "MIMTXRDATA30": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA30"
+          },
+          "MIMTXRDATA31": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA31"
+          },
+          "MIMTXRDATA32": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA32"
+          },
+          "MIMTXRDATA33": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA33"
+          },
+          "MIMTXRDATA34": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA34"
+          },
+          "MIMTXRDATA35": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA35"
+          },
+          "MIMTXRDATA36": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA36"
+          },
+          "MIMTXRDATA37": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA37"
+          },
+          "MIMTXRDATA38": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA38"
+          },
+          "MIMTXRDATA39": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA39"
+          },
+          "MIMTXRDATA40": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA40"
+          },
+          "MIMTXRDATA41": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA41"
+          },
+          "MIMTXRDATA42": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA42"
+          },
+          "MIMTXRDATA43": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA43"
+          },
+          "MIMTXRDATA44": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA44"
+          },
+          "MIMTXRDATA45": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA45"
+          },
+          "MIMTXRDATA46": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA46"
+          },
+          "MIMTXRDATA47": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA47"
+          },
+          "MIMTXRDATA48": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA48"
+          },
+          "MIMTXRDATA49": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA49"
+          },
+          "MIMTXRDATA50": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA50"
+          },
+          "MIMTXRDATA51": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA51"
+          },
+          "MIMTXRDATA52": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA52"
+          },
+          "MIMTXRDATA53": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA53"
+          },
+          "MIMTXRDATA54": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA54"
+          },
+          "MIMTXRDATA55": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA55"
+          },
+          "MIMTXRDATA56": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA56"
+          },
+          "MIMTXRDATA57": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA57"
+          },
+          "MIMTXRDATA58": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA58"
+          },
+          "MIMTXRDATA59": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA59"
+          },
+          "MIMTXRDATA60": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA60"
+          },
+          "MIMTXRDATA61": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA61"
+          },
+          "MIMTXRDATA62": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA62"
+          },
+          "MIMTXRDATA63": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA63"
+          },
+          "MIMTXRDATA64": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA64"
+          },
+          "MIMTXRDATA65": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA65"
+          },
+          "MIMTXRDATA66": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA66"
+          },
+          "MIMTXRDATA67": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA67"
+          },
+          "MIMTXRDATA68": {
+            "dir": "INPUT",
+            "wire": "MIMTXRDATA68"
+          },
+          "MIMTXREN": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXREN"
+          },
+          "MIMTXWADDR0": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWADDR0"
+          },
+          "MIMTXWADDR1": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWADDR1"
+          },
+          "MIMTXWADDR2": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWADDR2"
+          },
+          "MIMTXWADDR3": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWADDR3"
+          },
+          "MIMTXWADDR4": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWADDR4"
+          },
+          "MIMTXWADDR5": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWADDR5"
+          },
+          "MIMTXWADDR6": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWADDR6"
+          },
+          "MIMTXWADDR7": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWADDR7"
+          },
+          "MIMTXWADDR8": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWADDR8"
+          },
+          "MIMTXWADDR9": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWADDR9"
+          },
+          "MIMTXWADDR10": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWADDR10"
+          },
+          "MIMTXWADDR11": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWADDR11"
+          },
+          "MIMTXWADDR12": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWADDR12"
+          },
+          "MIMTXWDATA0": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA0"
+          },
+          "MIMTXWDATA1": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA1"
+          },
+          "MIMTXWDATA2": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA2"
+          },
+          "MIMTXWDATA3": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA3"
+          },
+          "MIMTXWDATA4": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA4"
+          },
+          "MIMTXWDATA5": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA5"
+          },
+          "MIMTXWDATA6": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA6"
+          },
+          "MIMTXWDATA7": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA7"
+          },
+          "MIMTXWDATA8": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA8"
+          },
+          "MIMTXWDATA9": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA9"
+          },
+          "MIMTXWDATA10": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA10"
+          },
+          "MIMTXWDATA11": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA11"
+          },
+          "MIMTXWDATA12": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA12"
+          },
+          "MIMTXWDATA13": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA13"
+          },
+          "MIMTXWDATA14": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA14"
+          },
+          "MIMTXWDATA15": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA15"
+          },
+          "MIMTXWDATA16": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA16"
+          },
+          "MIMTXWDATA17": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA17"
+          },
+          "MIMTXWDATA18": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA18"
+          },
+          "MIMTXWDATA19": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA19"
+          },
+          "MIMTXWDATA20": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA20"
+          },
+          "MIMTXWDATA21": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA21"
+          },
+          "MIMTXWDATA22": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA22"
+          },
+          "MIMTXWDATA23": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA23"
+          },
+          "MIMTXWDATA24": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA24"
+          },
+          "MIMTXWDATA25": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA25"
+          },
+          "MIMTXWDATA26": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA26"
+          },
+          "MIMTXWDATA27": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA27"
+          },
+          "MIMTXWDATA28": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA28"
+          },
+          "MIMTXWDATA29": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA29"
+          },
+          "MIMTXWDATA30": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA30"
+          },
+          "MIMTXWDATA31": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA31"
+          },
+          "MIMTXWDATA32": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA32"
+          },
+          "MIMTXWDATA33": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA33"
+          },
+          "MIMTXWDATA34": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA34"
+          },
+          "MIMTXWDATA35": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA35"
+          },
+          "MIMTXWDATA36": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA36"
+          },
+          "MIMTXWDATA37": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA37"
+          },
+          "MIMTXWDATA38": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA38"
+          },
+          "MIMTXWDATA39": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA39"
+          },
+          "MIMTXWDATA40": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA40"
+          },
+          "MIMTXWDATA41": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA41"
+          },
+          "MIMTXWDATA42": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA42"
+          },
+          "MIMTXWDATA43": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA43"
+          },
+          "MIMTXWDATA44": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA44"
+          },
+          "MIMTXWDATA45": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA45"
+          },
+          "MIMTXWDATA46": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA46"
+          },
+          "MIMTXWDATA47": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA47"
+          },
+          "MIMTXWDATA48": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA48"
+          },
+          "MIMTXWDATA49": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA49"
+          },
+          "MIMTXWDATA50": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA50"
+          },
+          "MIMTXWDATA51": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA51"
+          },
+          "MIMTXWDATA52": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA52"
+          },
+          "MIMTXWDATA53": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA53"
+          },
+          "MIMTXWDATA54": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA54"
+          },
+          "MIMTXWDATA55": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA55"
+          },
+          "MIMTXWDATA56": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA56"
+          },
+          "MIMTXWDATA57": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA57"
+          },
+          "MIMTXWDATA58": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA58"
+          },
+          "MIMTXWDATA59": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA59"
+          },
+          "MIMTXWDATA60": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA60"
+          },
+          "MIMTXWDATA61": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA61"
+          },
+          "MIMTXWDATA62": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA62"
+          },
+          "MIMTXWDATA63": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA63"
+          },
+          "MIMTXWDATA64": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA64"
+          },
+          "MIMTXWDATA65": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA65"
+          },
+          "MIMTXWDATA66": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA66"
+          },
+          "MIMTXWDATA67": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA67"
+          },
+          "MIMTXWDATA68": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWDATA68"
+          },
+          "MIMTXWEN": {
+            "dir": "OUTPUT",
+            "wire": "MIMTXWEN"
+          },
+          "PIPECLK": {
+            "dir": "INPUT",
+            "wire": "PIPECLK"
+          },
+          "PIPERX0CHANISALIGNED": {
+            "dir": "INPUT",
+            "wire": "PIPERX0CHANISALIGNED"
+          },
+          "PIPERX0CHARISK0": {
+            "dir": "INPUT",
+            "wire": "PIPERX0CHARISK0"
+          },
+          "PIPERX0CHARISK1": {
+            "dir": "INPUT",
+            "wire": "PIPERX0CHARISK1"
+          },
+          "PIPERX0DATA0": {
+            "dir": "INPUT",
+            "wire": "PIPERX0DATA0"
+          },
+          "PIPERX0DATA1": {
+            "dir": "INPUT",
+            "wire": "PIPERX0DATA1"
+          },
+          "PIPERX0DATA2": {
+            "dir": "INPUT",
+            "wire": "PIPERX0DATA2"
+          },
+          "PIPERX0DATA3": {
+            "dir": "INPUT",
+            "wire": "PIPERX0DATA3"
+          },
+          "PIPERX0DATA4": {
+            "dir": "INPUT",
+            "wire": "PIPERX0DATA4"
+          },
+          "PIPERX0DATA5": {
+            "dir": "INPUT",
+            "wire": "PIPERX0DATA5"
+          },
+          "PIPERX0DATA6": {
+            "dir": "INPUT",
+            "wire": "PIPERX0DATA6"
+          },
+          "PIPERX0DATA7": {
+            "dir": "INPUT",
+            "wire": "PIPERX0DATA7"
+          },
+          "PIPERX0DATA8": {
+            "dir": "INPUT",
+            "wire": "PIPERX0DATA8"
+          },
+          "PIPERX0DATA9": {
+            "dir": "INPUT",
+            "wire": "PIPERX0DATA9"
+          },
+          "PIPERX0DATA10": {
+            "dir": "INPUT",
+            "wire": "PIPERX0DATA10"
+          },
+          "PIPERX0DATA11": {
+            "dir": "INPUT",
+            "wire": "PIPERX0DATA11"
+          },
+          "PIPERX0DATA12": {
+            "dir": "INPUT",
+            "wire": "PIPERX0DATA12"
+          },
+          "PIPERX0DATA13": {
+            "dir": "INPUT",
+            "wire": "PIPERX0DATA13"
+          },
+          "PIPERX0DATA14": {
+            "dir": "INPUT",
+            "wire": "PIPERX0DATA14"
+          },
+          "PIPERX0DATA15": {
+            "dir": "INPUT",
+            "wire": "PIPERX0DATA15"
+          },
+          "PIPERX0ELECIDLE": {
+            "dir": "INPUT",
+            "wire": "PIPERX0ELECIDLE"
+          },
+          "PIPERX0PHYSTATUS": {
+            "dir": "INPUT",
+            "wire": "PIPERX0PHYSTATUS"
+          },
+          "PIPERX0POLARITY": {
+            "dir": "OUTPUT",
+            "wire": "PIPERX0POLARITY"
+          },
+          "PIPERX0STATUS0": {
+            "dir": "INPUT",
+            "wire": "PIPERX0STATUS0"
+          },
+          "PIPERX0STATUS1": {
+            "dir": "INPUT",
+            "wire": "PIPERX0STATUS1"
+          },
+          "PIPERX0STATUS2": {
+            "dir": "INPUT",
+            "wire": "PIPERX0STATUS2"
+          },
+          "PIPERX0VALID": {
+            "dir": "INPUT",
+            "wire": "PIPERX0VALID"
+          },
+          "PIPERX1CHANISALIGNED": {
+            "dir": "INPUT",
+            "wire": "PIPERX1CHANISALIGNED"
+          },
+          "PIPERX1CHARISK0": {
+            "dir": "INPUT",
+            "wire": "PIPERX1CHARISK0"
+          },
+          "PIPERX1CHARISK1": {
+            "dir": "INPUT",
+            "wire": "PIPERX1CHARISK1"
+          },
+          "PIPERX1DATA0": {
+            "dir": "INPUT",
+            "wire": "PIPERX1DATA0"
+          },
+          "PIPERX1DATA1": {
+            "dir": "INPUT",
+            "wire": "PIPERX1DATA1"
+          },
+          "PIPERX1DATA2": {
+            "dir": "INPUT",
+            "wire": "PIPERX1DATA2"
+          },
+          "PIPERX1DATA3": {
+            "dir": "INPUT",
+            "wire": "PIPERX1DATA3"
+          },
+          "PIPERX1DATA4": {
+            "dir": "INPUT",
+            "wire": "PIPERX1DATA4"
+          },
+          "PIPERX1DATA5": {
+            "dir": "INPUT",
+            "wire": "PIPERX1DATA5"
+          },
+          "PIPERX1DATA6": {
+            "dir": "INPUT",
+            "wire": "PIPERX1DATA6"
+          },
+          "PIPERX1DATA7": {
+            "dir": "INPUT",
+            "wire": "PIPERX1DATA7"
+          },
+          "PIPERX1DATA8": {
+            "dir": "INPUT",
+            "wire": "PIPERX1DATA8"
+          },
+          "PIPERX1DATA9": {
+            "dir": "INPUT",
+            "wire": "PIPERX1DATA9"
+          },
+          "PIPERX1DATA10": {
+            "dir": "INPUT",
+            "wire": "PIPERX1DATA10"
+          },
+          "PIPERX1DATA11": {
+            "dir": "INPUT",
+            "wire": "PIPERX1DATA11"
+          },
+          "PIPERX1DATA12": {
+            "dir": "INPUT",
+            "wire": "PIPERX1DATA12"
+          },
+          "PIPERX1DATA13": {
+            "dir": "INPUT",
+            "wire": "PIPERX1DATA13"
+          },
+          "PIPERX1DATA14": {
+            "dir": "INPUT",
+            "wire": "PIPERX1DATA14"
+          },
+          "PIPERX1DATA15": {
+            "dir": "INPUT",
+            "wire": "PIPERX1DATA15"
+          },
+          "PIPERX1ELECIDLE": {
+            "dir": "INPUT",
+            "wire": "PIPERX1ELECIDLE"
+          },
+          "PIPERX1PHYSTATUS": {
+            "dir": "INPUT",
+            "wire": "PIPERX1PHYSTATUS"
+          },
+          "PIPERX1POLARITY": {
+            "dir": "OUTPUT",
+            "wire": "PIPERX1POLARITY"
+          },
+          "PIPERX1STATUS0": {
+            "dir": "INPUT",
+            "wire": "PIPERX1STATUS0"
+          },
+          "PIPERX1STATUS1": {
+            "dir": "INPUT",
+            "wire": "PIPERX1STATUS1"
+          },
+          "PIPERX1STATUS2": {
+            "dir": "INPUT",
+            "wire": "PIPERX1STATUS2"
+          },
+          "PIPERX1VALID": {
+            "dir": "INPUT",
+            "wire": "PIPERX1VALID"
+          },
+          "PIPERX2CHANISALIGNED": {
+            "dir": "INPUT",
+            "wire": "PIPERX2CHANISALIGNED"
+          },
+          "PIPERX2CHARISK0": {
+            "dir": "INPUT",
+            "wire": "PIPERX2CHARISK0"
+          },
+          "PIPERX2CHARISK1": {
+            "dir": "INPUT",
+            "wire": "PIPERX2CHARISK1"
+          },
+          "PIPERX2DATA0": {
+            "dir": "INPUT",
+            "wire": "PIPERX2DATA0"
+          },
+          "PIPERX2DATA1": {
+            "dir": "INPUT",
+            "wire": "PIPERX2DATA1"
+          },
+          "PIPERX2DATA2": {
+            "dir": "INPUT",
+            "wire": "PIPERX2DATA2"
+          },
+          "PIPERX2DATA3": {
+            "dir": "INPUT",
+            "wire": "PIPERX2DATA3"
+          },
+          "PIPERX2DATA4": {
+            "dir": "INPUT",
+            "wire": "PIPERX2DATA4"
+          },
+          "PIPERX2DATA5": {
+            "dir": "INPUT",
+            "wire": "PIPERX2DATA5"
+          },
+          "PIPERX2DATA6": {
+            "dir": "INPUT",
+            "wire": "PIPERX2DATA6"
+          },
+          "PIPERX2DATA7": {
+            "dir": "INPUT",
+            "wire": "PIPERX2DATA7"
+          },
+          "PIPERX2DATA8": {
+            "dir": "INPUT",
+            "wire": "PIPERX2DATA8"
+          },
+          "PIPERX2DATA9": {
+            "dir": "INPUT",
+            "wire": "PIPERX2DATA9"
+          },
+          "PIPERX2DATA10": {
+            "dir": "INPUT",
+            "wire": "PIPERX2DATA10"
+          },
+          "PIPERX2DATA11": {
+            "dir": "INPUT",
+            "wire": "PIPERX2DATA11"
+          },
+          "PIPERX2DATA12": {
+            "dir": "INPUT",
+            "wire": "PIPERX2DATA12"
+          },
+          "PIPERX2DATA13": {
+            "dir": "INPUT",
+            "wire": "PIPERX2DATA13"
+          },
+          "PIPERX2DATA14": {
+            "dir": "INPUT",
+            "wire": "PIPERX2DATA14"
+          },
+          "PIPERX2DATA15": {
+            "dir": "INPUT",
+            "wire": "PIPERX2DATA15"
+          },
+          "PIPERX2ELECIDLE": {
+            "dir": "INPUT",
+            "wire": "PIPERX2ELECIDLE"
+          },
+          "PIPERX2PHYSTATUS": {
+            "dir": "INPUT",
+            "wire": "PIPERX2PHYSTATUS"
+          },
+          "PIPERX2POLARITY": {
+            "dir": "OUTPUT",
+            "wire": "PIPERX2POLARITY"
+          },
+          "PIPERX2STATUS0": {
+            "dir": "INPUT",
+            "wire": "PIPERX2STATUS0"
+          },
+          "PIPERX2STATUS1": {
+            "dir": "INPUT",
+            "wire": "PIPERX2STATUS1"
+          },
+          "PIPERX2STATUS2": {
+            "dir": "INPUT",
+            "wire": "PIPERX2STATUS2"
+          },
+          "PIPERX2VALID": {
+            "dir": "INPUT",
+            "wire": "PIPERX2VALID"
+          },
+          "PIPERX3CHANISALIGNED": {
+            "dir": "INPUT",
+            "wire": "PIPERX3CHANISALIGNED"
+          },
+          "PIPERX3CHARISK0": {
+            "dir": "INPUT",
+            "wire": "PIPERX3CHARISK0"
+          },
+          "PIPERX3CHARISK1": {
+            "dir": "INPUT",
+            "wire": "PIPERX3CHARISK1"
+          },
+          "PIPERX3DATA0": {
+            "dir": "INPUT",
+            "wire": "PIPERX3DATA0"
+          },
+          "PIPERX3DATA1": {
+            "dir": "INPUT",
+            "wire": "PIPERX3DATA1"
+          },
+          "PIPERX3DATA2": {
+            "dir": "INPUT",
+            "wire": "PIPERX3DATA2"
+          },
+          "PIPERX3DATA3": {
+            "dir": "INPUT",
+            "wire": "PIPERX3DATA3"
+          },
+          "PIPERX3DATA4": {
+            "dir": "INPUT",
+            "wire": "PIPERX3DATA4"
+          },
+          "PIPERX3DATA5": {
+            "dir": "INPUT",
+            "wire": "PIPERX3DATA5"
+          },
+          "PIPERX3DATA6": {
+            "dir": "INPUT",
+            "wire": "PIPERX3DATA6"
+          },
+          "PIPERX3DATA7": {
+            "dir": "INPUT",
+            "wire": "PIPERX3DATA7"
+          },
+          "PIPERX3DATA8": {
+            "dir": "INPUT",
+            "wire": "PIPERX3DATA8"
+          },
+          "PIPERX3DATA9": {
+            "dir": "INPUT",
+            "wire": "PIPERX3DATA9"
+          },
+          "PIPERX3DATA10": {
+            "dir": "INPUT",
+            "wire": "PIPERX3DATA10"
+          },
+          "PIPERX3DATA11": {
+            "dir": "INPUT",
+            "wire": "PIPERX3DATA11"
+          },
+          "PIPERX3DATA12": {
+            "dir": "INPUT",
+            "wire": "PIPERX3DATA12"
+          },
+          "PIPERX3DATA13": {
+            "dir": "INPUT",
+            "wire": "PIPERX3DATA13"
+          },
+          "PIPERX3DATA14": {
+            "dir": "INPUT",
+            "wire": "PIPERX3DATA14"
+          },
+          "PIPERX3DATA15": {
+            "dir": "INPUT",
+            "wire": "PIPERX3DATA15"
+          },
+          "PIPERX3ELECIDLE": {
+            "dir": "INPUT",
+            "wire": "PIPERX3ELECIDLE"
+          },
+          "PIPERX3PHYSTATUS": {
+            "dir": "INPUT",
+            "wire": "PIPERX3PHYSTATUS"
+          },
+          "PIPERX3POLARITY": {
+            "dir": "OUTPUT",
+            "wire": "PIPERX3POLARITY"
+          },
+          "PIPERX3STATUS0": {
+            "dir": "INPUT",
+            "wire": "PIPERX3STATUS0"
+          },
+          "PIPERX3STATUS1": {
+            "dir": "INPUT",
+            "wire": "PIPERX3STATUS1"
+          },
+          "PIPERX3STATUS2": {
+            "dir": "INPUT",
+            "wire": "PIPERX3STATUS2"
+          },
+          "PIPERX3VALID": {
+            "dir": "INPUT",
+            "wire": "PIPERX3VALID"
+          },
+          "PIPERX4CHANISALIGNED": {
+            "dir": "INPUT",
+            "wire": "PIPERX4CHANISALIGNED"
+          },
+          "PIPERX4CHARISK0": {
+            "dir": "INPUT",
+            "wire": "PIPERX4CHARISK0"
+          },
+          "PIPERX4CHARISK1": {
+            "dir": "INPUT",
+            "wire": "PIPERX4CHARISK1"
+          },
+          "PIPERX4DATA0": {
+            "dir": "INPUT",
+            "wire": "PIPERX4DATA0"
+          },
+          "PIPERX4DATA1": {
+            "dir": "INPUT",
+            "wire": "PIPERX4DATA1"
+          },
+          "PIPERX4DATA2": {
+            "dir": "INPUT",
+            "wire": "PIPERX4DATA2"
+          },
+          "PIPERX4DATA3": {
+            "dir": "INPUT",
+            "wire": "PIPERX4DATA3"
+          },
+          "PIPERX4DATA4": {
+            "dir": "INPUT",
+            "wire": "PIPERX4DATA4"
+          },
+          "PIPERX4DATA5": {
+            "dir": "INPUT",
+            "wire": "PIPERX4DATA5"
+          },
+          "PIPERX4DATA6": {
+            "dir": "INPUT",
+            "wire": "PIPERX4DATA6"
+          },
+          "PIPERX4DATA7": {
+            "dir": "INPUT",
+            "wire": "PIPERX4DATA7"
+          },
+          "PIPERX4DATA8": {
+            "dir": "INPUT",
+            "wire": "PIPERX4DATA8"
+          },
+          "PIPERX4DATA9": {
+            "dir": "INPUT",
+            "wire": "PIPERX4DATA9"
+          },
+          "PIPERX4DATA10": {
+            "dir": "INPUT",
+            "wire": "PIPERX4DATA10"
+          },
+          "PIPERX4DATA11": {
+            "dir": "INPUT",
+            "wire": "PIPERX4DATA11"
+          },
+          "PIPERX4DATA12": {
+            "dir": "INPUT",
+            "wire": "PIPERX4DATA12"
+          },
+          "PIPERX4DATA13": {
+            "dir": "INPUT",
+            "wire": "PIPERX4DATA13"
+          },
+          "PIPERX4DATA14": {
+            "dir": "INPUT",
+            "wire": "PIPERX4DATA14"
+          },
+          "PIPERX4DATA15": {
+            "dir": "INPUT",
+            "wire": "PIPERX4DATA15"
+          },
+          "PIPERX4ELECIDLE": {
+            "dir": "INPUT",
+            "wire": "PIPERX4ELECIDLE"
+          },
+          "PIPERX4PHYSTATUS": {
+            "dir": "INPUT",
+            "wire": "PIPERX4PHYSTATUS"
+          },
+          "PIPERX4POLARITY": {
+            "dir": "OUTPUT",
+            "wire": "PIPERX4POLARITY"
+          },
+          "PIPERX4STATUS0": {
+            "dir": "INPUT",
+            "wire": "PIPERX4STATUS0"
+          },
+          "PIPERX4STATUS1": {
+            "dir": "INPUT",
+            "wire": "PIPERX4STATUS1"
+          },
+          "PIPERX4STATUS2": {
+            "dir": "INPUT",
+            "wire": "PIPERX4STATUS2"
+          },
+          "PIPERX4VALID": {
+            "dir": "INPUT",
+            "wire": "PIPERX4VALID"
+          },
+          "PIPERX5CHANISALIGNED": {
+            "dir": "INPUT",
+            "wire": "PIPERX5CHANISALIGNED"
+          },
+          "PIPERX5CHARISK0": {
+            "dir": "INPUT",
+            "wire": "PIPERX5CHARISK0"
+          },
+          "PIPERX5CHARISK1": {
+            "dir": "INPUT",
+            "wire": "PIPERX5CHARISK1"
+          },
+          "PIPERX5DATA0": {
+            "dir": "INPUT",
+            "wire": "PIPERX5DATA0"
+          },
+          "PIPERX5DATA1": {
+            "dir": "INPUT",
+            "wire": "PIPERX5DATA1"
+          },
+          "PIPERX5DATA2": {
+            "dir": "INPUT",
+            "wire": "PIPERX5DATA2"
+          },
+          "PIPERX5DATA3": {
+            "dir": "INPUT",
+            "wire": "PIPERX5DATA3"
+          },
+          "PIPERX5DATA4": {
+            "dir": "INPUT",
+            "wire": "PIPERX5DATA4"
+          },
+          "PIPERX5DATA5": {
+            "dir": "INPUT",
+            "wire": "PIPERX5DATA5"
+          },
+          "PIPERX5DATA6": {
+            "dir": "INPUT",
+            "wire": "PIPERX5DATA6"
+          },
+          "PIPERX5DATA7": {
+            "dir": "INPUT",
+            "wire": "PIPERX5DATA7"
+          },
+          "PIPERX5DATA8": {
+            "dir": "INPUT",
+            "wire": "PIPERX5DATA8"
+          },
+          "PIPERX5DATA9": {
+            "dir": "INPUT",
+            "wire": "PIPERX5DATA9"
+          },
+          "PIPERX5DATA10": {
+            "dir": "INPUT",
+            "wire": "PIPERX5DATA10"
+          },
+          "PIPERX5DATA11": {
+            "dir": "INPUT",
+            "wire": "PIPERX5DATA11"
+          },
+          "PIPERX5DATA12": {
+            "dir": "INPUT",
+            "wire": "PIPERX5DATA12"
+          },
+          "PIPERX5DATA13": {
+            "dir": "INPUT",
+            "wire": "PIPERX5DATA13"
+          },
+          "PIPERX5DATA14": {
+            "dir": "INPUT",
+            "wire": "PIPERX5DATA14"
+          },
+          "PIPERX5DATA15": {
+            "dir": "INPUT",
+            "wire": "PIPERX5DATA15"
+          },
+          "PIPERX5ELECIDLE": {
+            "dir": "INPUT",
+            "wire": "PIPERX5ELECIDLE"
+          },
+          "PIPERX5PHYSTATUS": {
+            "dir": "INPUT",
+            "wire": "PIPERX5PHYSTATUS"
+          },
+          "PIPERX5POLARITY": {
+            "dir": "OUTPUT",
+            "wire": "PIPERX5POLARITY"
+          },
+          "PIPERX5STATUS0": {
+            "dir": "INPUT",
+            "wire": "PIPERX5STATUS0"
+          },
+          "PIPERX5STATUS1": {
+            "dir": "INPUT",
+            "wire": "PIPERX5STATUS1"
+          },
+          "PIPERX5STATUS2": {
+            "dir": "INPUT",
+            "wire": "PIPERX5STATUS2"
+          },
+          "PIPERX5VALID": {
+            "dir": "INPUT",
+            "wire": "PIPERX5VALID"
+          },
+          "PIPERX6CHANISALIGNED": {
+            "dir": "INPUT",
+            "wire": "PIPERX6CHANISALIGNED"
+          },
+          "PIPERX6CHARISK0": {
+            "dir": "INPUT",
+            "wire": "PIPERX6CHARISK0"
+          },
+          "PIPERX6CHARISK1": {
+            "dir": "INPUT",
+            "wire": "PIPERX6CHARISK1"
+          },
+          "PIPERX6DATA0": {
+            "dir": "INPUT",
+            "wire": "PIPERX6DATA0"
+          },
+          "PIPERX6DATA1": {
+            "dir": "INPUT",
+            "wire": "PIPERX6DATA1"
+          },
+          "PIPERX6DATA2": {
+            "dir": "INPUT",
+            "wire": "PIPERX6DATA2"
+          },
+          "PIPERX6DATA3": {
+            "dir": "INPUT",
+            "wire": "PIPERX6DATA3"
+          },
+          "PIPERX6DATA4": {
+            "dir": "INPUT",
+            "wire": "PIPERX6DATA4"
+          },
+          "PIPERX6DATA5": {
+            "dir": "INPUT",
+            "wire": "PIPERX6DATA5"
+          },
+          "PIPERX6DATA6": {
+            "dir": "INPUT",
+            "wire": "PIPERX6DATA6"
+          },
+          "PIPERX6DATA7": {
+            "dir": "INPUT",
+            "wire": "PIPERX6DATA7"
+          },
+          "PIPERX6DATA8": {
+            "dir": "INPUT",
+            "wire": "PIPERX6DATA8"
+          },
+          "PIPERX6DATA9": {
+            "dir": "INPUT",
+            "wire": "PIPERX6DATA9"
+          },
+          "PIPERX6DATA10": {
+            "dir": "INPUT",
+            "wire": "PIPERX6DATA10"
+          },
+          "PIPERX6DATA11": {
+            "dir": "INPUT",
+            "wire": "PIPERX6DATA11"
+          },
+          "PIPERX6DATA12": {
+            "dir": "INPUT",
+            "wire": "PIPERX6DATA12"
+          },
+          "PIPERX6DATA13": {
+            "dir": "INPUT",
+            "wire": "PIPERX6DATA13"
+          },
+          "PIPERX6DATA14": {
+            "dir": "INPUT",
+            "wire": "PIPERX6DATA14"
+          },
+          "PIPERX6DATA15": {
+            "dir": "INPUT",
+            "wire": "PIPERX6DATA15"
+          },
+          "PIPERX6ELECIDLE": {
+            "dir": "INPUT",
+            "wire": "PIPERX6ELECIDLE"
+          },
+          "PIPERX6PHYSTATUS": {
+            "dir": "INPUT",
+            "wire": "PIPERX6PHYSTATUS"
+          },
+          "PIPERX6POLARITY": {
+            "dir": "OUTPUT",
+            "wire": "PIPERX6POLARITY"
+          },
+          "PIPERX6STATUS0": {
+            "dir": "INPUT",
+            "wire": "PIPERX6STATUS0"
+          },
+          "PIPERX6STATUS1": {
+            "dir": "INPUT",
+            "wire": "PIPERX6STATUS1"
+          },
+          "PIPERX6STATUS2": {
+            "dir": "INPUT",
+            "wire": "PIPERX6STATUS2"
+          },
+          "PIPERX6VALID": {
+            "dir": "INPUT",
+            "wire": "PIPERX6VALID"
+          },
+          "PIPERX7CHANISALIGNED": {
+            "dir": "INPUT",
+            "wire": "PIPERX7CHANISALIGNED"
+          },
+          "PIPERX7CHARISK0": {
+            "dir": "INPUT",
+            "wire": "PIPERX7CHARISK0"
+          },
+          "PIPERX7CHARISK1": {
+            "dir": "INPUT",
+            "wire": "PIPERX7CHARISK1"
+          },
+          "PIPERX7DATA0": {
+            "dir": "INPUT",
+            "wire": "PIPERX7DATA0"
+          },
+          "PIPERX7DATA1": {
+            "dir": "INPUT",
+            "wire": "PIPERX7DATA1"
+          },
+          "PIPERX7DATA2": {
+            "dir": "INPUT",
+            "wire": "PIPERX7DATA2"
+          },
+          "PIPERX7DATA3": {
+            "dir": "INPUT",
+            "wire": "PIPERX7DATA3"
+          },
+          "PIPERX7DATA4": {
+            "dir": "INPUT",
+            "wire": "PIPERX7DATA4"
+          },
+          "PIPERX7DATA5": {
+            "dir": "INPUT",
+            "wire": "PIPERX7DATA5"
+          },
+          "PIPERX7DATA6": {
+            "dir": "INPUT",
+            "wire": "PIPERX7DATA6"
+          },
+          "PIPERX7DATA7": {
+            "dir": "INPUT",
+            "wire": "PIPERX7DATA7"
+          },
+          "PIPERX7DATA8": {
+            "dir": "INPUT",
+            "wire": "PIPERX7DATA8"
+          },
+          "PIPERX7DATA9": {
+            "dir": "INPUT",
+            "wire": "PIPERX7DATA9"
+          },
+          "PIPERX7DATA10": {
+            "dir": "INPUT",
+            "wire": "PIPERX7DATA10"
+          },
+          "PIPERX7DATA11": {
+            "dir": "INPUT",
+            "wire": "PIPERX7DATA11"
+          },
+          "PIPERX7DATA12": {
+            "dir": "INPUT",
+            "wire": "PIPERX7DATA12"
+          },
+          "PIPERX7DATA13": {
+            "dir": "INPUT",
+            "wire": "PIPERX7DATA13"
+          },
+          "PIPERX7DATA14": {
+            "dir": "INPUT",
+            "wire": "PIPERX7DATA14"
+          },
+          "PIPERX7DATA15": {
+            "dir": "INPUT",
+            "wire": "PIPERX7DATA15"
+          },
+          "PIPERX7ELECIDLE": {
+            "dir": "INPUT",
+            "wire": "PIPERX7ELECIDLE"
+          },
+          "PIPERX7PHYSTATUS": {
+            "dir": "INPUT",
+            "wire": "PIPERX7PHYSTATUS"
+          },
+          "PIPERX7POLARITY": {
+            "dir": "OUTPUT",
+            "wire": "PIPERX7POLARITY"
+          },
+          "PIPERX7STATUS0": {
+            "dir": "INPUT",
+            "wire": "PIPERX7STATUS0"
+          },
+          "PIPERX7STATUS1": {
+            "dir": "INPUT",
+            "wire": "PIPERX7STATUS1"
+          },
+          "PIPERX7STATUS2": {
+            "dir": "INPUT",
+            "wire": "PIPERX7STATUS2"
+          },
+          "PIPERX7VALID": {
+            "dir": "INPUT",
+            "wire": "PIPERX7VALID"
+          },
+          "PIPETX0CHARISK0": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX0CHARISK0"
+          },
+          "PIPETX0CHARISK1": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX0CHARISK1"
+          },
+          "PIPETX0COMPLIANCE": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX0COMPLIANCE"
+          },
+          "PIPETX0DATA0": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX0DATA0"
+          },
+          "PIPETX0DATA1": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX0DATA1"
+          },
+          "PIPETX0DATA2": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX0DATA2"
+          },
+          "PIPETX0DATA3": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX0DATA3"
+          },
+          "PIPETX0DATA4": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX0DATA4"
+          },
+          "PIPETX0DATA5": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX0DATA5"
+          },
+          "PIPETX0DATA6": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX0DATA6"
+          },
+          "PIPETX0DATA7": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX0DATA7"
+          },
+          "PIPETX0DATA8": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX0DATA8"
+          },
+          "PIPETX0DATA9": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX0DATA9"
+          },
+          "PIPETX0DATA10": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX0DATA10"
+          },
+          "PIPETX0DATA11": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX0DATA11"
+          },
+          "PIPETX0DATA12": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX0DATA12"
+          },
+          "PIPETX0DATA13": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX0DATA13"
+          },
+          "PIPETX0DATA14": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX0DATA14"
+          },
+          "PIPETX0DATA15": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX0DATA15"
+          },
+          "PIPETX0ELECIDLE": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX0ELECIDLE"
+          },
+          "PIPETX0POWERDOWN0": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX0POWERDOWN0"
+          },
+          "PIPETX0POWERDOWN1": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX0POWERDOWN1"
+          },
+          "PIPETX1CHARISK0": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX1CHARISK0"
+          },
+          "PIPETX1CHARISK1": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX1CHARISK1"
+          },
+          "PIPETX1COMPLIANCE": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX1COMPLIANCE"
+          },
+          "PIPETX1DATA0": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX1DATA0"
+          },
+          "PIPETX1DATA1": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX1DATA1"
+          },
+          "PIPETX1DATA2": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX1DATA2"
+          },
+          "PIPETX1DATA3": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX1DATA3"
+          },
+          "PIPETX1DATA4": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX1DATA4"
+          },
+          "PIPETX1DATA5": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX1DATA5"
+          },
+          "PIPETX1DATA6": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX1DATA6"
+          },
+          "PIPETX1DATA7": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX1DATA7"
+          },
+          "PIPETX1DATA8": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX1DATA8"
+          },
+          "PIPETX1DATA9": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX1DATA9"
+          },
+          "PIPETX1DATA10": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX1DATA10"
+          },
+          "PIPETX1DATA11": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX1DATA11"
+          },
+          "PIPETX1DATA12": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX1DATA12"
+          },
+          "PIPETX1DATA13": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX1DATA13"
+          },
+          "PIPETX1DATA14": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX1DATA14"
+          },
+          "PIPETX1DATA15": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX1DATA15"
+          },
+          "PIPETX1ELECIDLE": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX1ELECIDLE"
+          },
+          "PIPETX1POWERDOWN0": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX1POWERDOWN0"
+          },
+          "PIPETX1POWERDOWN1": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX1POWERDOWN1"
+          },
+          "PIPETX2CHARISK0": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX2CHARISK0"
+          },
+          "PIPETX2CHARISK1": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX2CHARISK1"
+          },
+          "PIPETX2COMPLIANCE": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX2COMPLIANCE"
+          },
+          "PIPETX2DATA0": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX2DATA0"
+          },
+          "PIPETX2DATA1": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX2DATA1"
+          },
+          "PIPETX2DATA2": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX2DATA2"
+          },
+          "PIPETX2DATA3": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX2DATA3"
+          },
+          "PIPETX2DATA4": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX2DATA4"
+          },
+          "PIPETX2DATA5": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX2DATA5"
+          },
+          "PIPETX2DATA6": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX2DATA6"
+          },
+          "PIPETX2DATA7": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX2DATA7"
+          },
+          "PIPETX2DATA8": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX2DATA8"
+          },
+          "PIPETX2DATA9": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX2DATA9"
+          },
+          "PIPETX2DATA10": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX2DATA10"
+          },
+          "PIPETX2DATA11": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX2DATA11"
+          },
+          "PIPETX2DATA12": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX2DATA12"
+          },
+          "PIPETX2DATA13": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX2DATA13"
+          },
+          "PIPETX2DATA14": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX2DATA14"
+          },
+          "PIPETX2DATA15": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX2DATA15"
+          },
+          "PIPETX2ELECIDLE": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX2ELECIDLE"
+          },
+          "PIPETX2POWERDOWN0": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX2POWERDOWN0"
+          },
+          "PIPETX2POWERDOWN1": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX2POWERDOWN1"
+          },
+          "PIPETX3CHARISK0": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX3CHARISK0"
+          },
+          "PIPETX3CHARISK1": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX3CHARISK1"
+          },
+          "PIPETX3COMPLIANCE": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX3COMPLIANCE"
+          },
+          "PIPETX3DATA0": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX3DATA0"
+          },
+          "PIPETX3DATA1": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX3DATA1"
+          },
+          "PIPETX3DATA2": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX3DATA2"
+          },
+          "PIPETX3DATA3": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX3DATA3"
+          },
+          "PIPETX3DATA4": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX3DATA4"
+          },
+          "PIPETX3DATA5": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX3DATA5"
+          },
+          "PIPETX3DATA6": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX3DATA6"
+          },
+          "PIPETX3DATA7": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX3DATA7"
+          },
+          "PIPETX3DATA8": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX3DATA8"
+          },
+          "PIPETX3DATA9": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX3DATA9"
+          },
+          "PIPETX3DATA10": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX3DATA10"
+          },
+          "PIPETX3DATA11": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX3DATA11"
+          },
+          "PIPETX3DATA12": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX3DATA12"
+          },
+          "PIPETX3DATA13": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX3DATA13"
+          },
+          "PIPETX3DATA14": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX3DATA14"
+          },
+          "PIPETX3DATA15": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX3DATA15"
+          },
+          "PIPETX3ELECIDLE": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX3ELECIDLE"
+          },
+          "PIPETX3POWERDOWN0": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX3POWERDOWN0"
+          },
+          "PIPETX3POWERDOWN1": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX3POWERDOWN1"
+          },
+          "PIPETX4CHARISK0": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX4CHARISK0"
+          },
+          "PIPETX4CHARISK1": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX4CHARISK1"
+          },
+          "PIPETX4COMPLIANCE": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX4COMPLIANCE"
+          },
+          "PIPETX4DATA0": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX4DATA0"
+          },
+          "PIPETX4DATA1": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX4DATA1"
+          },
+          "PIPETX4DATA2": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX4DATA2"
+          },
+          "PIPETX4DATA3": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX4DATA3"
+          },
+          "PIPETX4DATA4": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX4DATA4"
+          },
+          "PIPETX4DATA5": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX4DATA5"
+          },
+          "PIPETX4DATA6": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX4DATA6"
+          },
+          "PIPETX4DATA7": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX4DATA7"
+          },
+          "PIPETX4DATA8": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX4DATA8"
+          },
+          "PIPETX4DATA9": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX4DATA9"
+          },
+          "PIPETX4DATA10": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX4DATA10"
+          },
+          "PIPETX4DATA11": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX4DATA11"
+          },
+          "PIPETX4DATA12": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX4DATA12"
+          },
+          "PIPETX4DATA13": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX4DATA13"
+          },
+          "PIPETX4DATA14": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX4DATA14"
+          },
+          "PIPETX4DATA15": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX4DATA15"
+          },
+          "PIPETX4ELECIDLE": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX4ELECIDLE"
+          },
+          "PIPETX4POWERDOWN0": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX4POWERDOWN0"
+          },
+          "PIPETX4POWERDOWN1": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX4POWERDOWN1"
+          },
+          "PIPETX5CHARISK0": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX5CHARISK0"
+          },
+          "PIPETX5CHARISK1": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX5CHARISK1"
+          },
+          "PIPETX5COMPLIANCE": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX5COMPLIANCE"
+          },
+          "PIPETX5DATA0": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX5DATA0"
+          },
+          "PIPETX5DATA1": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX5DATA1"
+          },
+          "PIPETX5DATA2": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX5DATA2"
+          },
+          "PIPETX5DATA3": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX5DATA3"
+          },
+          "PIPETX5DATA4": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX5DATA4"
+          },
+          "PIPETX5DATA5": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX5DATA5"
+          },
+          "PIPETX5DATA6": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX5DATA6"
+          },
+          "PIPETX5DATA7": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX5DATA7"
+          },
+          "PIPETX5DATA8": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX5DATA8"
+          },
+          "PIPETX5DATA9": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX5DATA9"
+          },
+          "PIPETX5DATA10": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX5DATA10"
+          },
+          "PIPETX5DATA11": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX5DATA11"
+          },
+          "PIPETX5DATA12": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX5DATA12"
+          },
+          "PIPETX5DATA13": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX5DATA13"
+          },
+          "PIPETX5DATA14": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX5DATA14"
+          },
+          "PIPETX5DATA15": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX5DATA15"
+          },
+          "PIPETX5ELECIDLE": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX5ELECIDLE"
+          },
+          "PIPETX5POWERDOWN0": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX5POWERDOWN0"
+          },
+          "PIPETX5POWERDOWN1": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX5POWERDOWN1"
+          },
+          "PIPETX6CHARISK0": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX6CHARISK0"
+          },
+          "PIPETX6CHARISK1": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX6CHARISK1"
+          },
+          "PIPETX6COMPLIANCE": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX6COMPLIANCE"
+          },
+          "PIPETX6DATA0": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX6DATA0"
+          },
+          "PIPETX6DATA1": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX6DATA1"
+          },
+          "PIPETX6DATA2": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX6DATA2"
+          },
+          "PIPETX6DATA3": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX6DATA3"
+          },
+          "PIPETX6DATA4": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX6DATA4"
+          },
+          "PIPETX6DATA5": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX6DATA5"
+          },
+          "PIPETX6DATA6": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX6DATA6"
+          },
+          "PIPETX6DATA7": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX6DATA7"
+          },
+          "PIPETX6DATA8": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX6DATA8"
+          },
+          "PIPETX6DATA9": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX6DATA9"
+          },
+          "PIPETX6DATA10": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX6DATA10"
+          },
+          "PIPETX6DATA11": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX6DATA11"
+          },
+          "PIPETX6DATA12": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX6DATA12"
+          },
+          "PIPETX6DATA13": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX6DATA13"
+          },
+          "PIPETX6DATA14": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX6DATA14"
+          },
+          "PIPETX6DATA15": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX6DATA15"
+          },
+          "PIPETX6ELECIDLE": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX6ELECIDLE"
+          },
+          "PIPETX6POWERDOWN0": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX6POWERDOWN0"
+          },
+          "PIPETX6POWERDOWN1": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX6POWERDOWN1"
+          },
+          "PIPETX7CHARISK0": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX7CHARISK0"
+          },
+          "PIPETX7CHARISK1": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX7CHARISK1"
+          },
+          "PIPETX7COMPLIANCE": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX7COMPLIANCE"
+          },
+          "PIPETX7DATA0": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX7DATA0"
+          },
+          "PIPETX7DATA1": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX7DATA1"
+          },
+          "PIPETX7DATA2": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX7DATA2"
+          },
+          "PIPETX7DATA3": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX7DATA3"
+          },
+          "PIPETX7DATA4": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX7DATA4"
+          },
+          "PIPETX7DATA5": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX7DATA5"
+          },
+          "PIPETX7DATA6": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX7DATA6"
+          },
+          "PIPETX7DATA7": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX7DATA7"
+          },
+          "PIPETX7DATA8": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX7DATA8"
+          },
+          "PIPETX7DATA9": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX7DATA9"
+          },
+          "PIPETX7DATA10": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX7DATA10"
+          },
+          "PIPETX7DATA11": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX7DATA11"
+          },
+          "PIPETX7DATA12": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX7DATA12"
+          },
+          "PIPETX7DATA13": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX7DATA13"
+          },
+          "PIPETX7DATA14": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX7DATA14"
+          },
+          "PIPETX7DATA15": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX7DATA15"
+          },
+          "PIPETX7ELECIDLE": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX7ELECIDLE"
+          },
+          "PIPETX7POWERDOWN0": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX7POWERDOWN0"
+          },
+          "PIPETX7POWERDOWN1": {
+            "dir": "OUTPUT",
+            "wire": "PIPETX7POWERDOWN1"
+          },
+          "PIPETXDEEMPH": {
+            "dir": "OUTPUT",
+            "wire": "PIPETXDEEMPH"
+          },
+          "PIPETXMARGIN0": {
+            "dir": "OUTPUT",
+            "wire": "PIPETXMARGIN0"
+          },
+          "PIPETXMARGIN1": {
+            "dir": "OUTPUT",
+            "wire": "PIPETXMARGIN1"
+          },
+          "PIPETXMARGIN2": {
+            "dir": "OUTPUT",
+            "wire": "PIPETXMARGIN2"
+          },
+          "PIPETXRATE": {
+            "dir": "OUTPUT",
+            "wire": "PIPETXRATE"
+          },
+          "PIPETXRCVRDET": {
+            "dir": "OUTPUT",
+            "wire": "PIPETXRCVRDET"
+          },
+          "PIPETXRESET": {
+            "dir": "OUTPUT",
+            "wire": "PIPETXRESET"
+          },
+          "PL2DIRECTEDLSTATE0": {
+            "dir": "INPUT",
+            "wire": "PL2DIRECTEDLSTATE0"
+          },
+          "PL2DIRECTEDLSTATE1": {
+            "dir": "INPUT",
+            "wire": "PL2DIRECTEDLSTATE1"
+          },
+          "PL2DIRECTEDLSTATE2": {
+            "dir": "INPUT",
+            "wire": "PL2DIRECTEDLSTATE2"
+          },
+          "PL2DIRECTEDLSTATE3": {
+            "dir": "INPUT",
+            "wire": "PL2DIRECTEDLSTATE3"
+          },
+          "PL2DIRECTEDLSTATE4": {
+            "dir": "INPUT",
+            "wire": "PL2DIRECTEDLSTATE4"
+          },
+          "PL2L0REQ": {
+            "dir": "OUTPUT",
+            "wire": "PL2L0REQ"
+          },
+          "PL2LINKUP": {
+            "dir": "OUTPUT",
+            "wire": "PL2LINKUP"
+          },
+          "PL2RECEIVERERR": {
+            "dir": "OUTPUT",
+            "wire": "PL2RECEIVERERR"
+          },
+          "PL2RECOVERY": {
+            "dir": "OUTPUT",
+            "wire": "PL2RECOVERY"
+          },
+          "PL2RXELECIDLE": {
+            "dir": "OUTPUT",
+            "wire": "PL2RXELECIDLE"
+          },
+          "PL2RXPMSTATE0": {
+            "dir": "OUTPUT",
+            "wire": "PL2RXPMSTATE0"
+          },
+          "PL2RXPMSTATE1": {
+            "dir": "OUTPUT",
+            "wire": "PL2RXPMSTATE1"
+          },
+          "PL2SUSPENDOK": {
+            "dir": "OUTPUT",
+            "wire": "PL2SUSPENDOK"
+          },
+          "PLDBGMODE0": {
+            "dir": "INPUT",
+            "wire": "PLDBGMODE0"
+          },
+          "PLDBGMODE1": {
+            "dir": "INPUT",
+            "wire": "PLDBGMODE1"
+          },
+          "PLDBGMODE2": {
+            "dir": "INPUT",
+            "wire": "PLDBGMODE2"
+          },
+          "PLDBGVEC0": {
+            "dir": "OUTPUT",
+            "wire": "PLDBGVEC0"
+          },
+          "PLDBGVEC1": {
+            "dir": "OUTPUT",
+            "wire": "PLDBGVEC1"
+          },
+          "PLDBGVEC2": {
+            "dir": "OUTPUT",
+            "wire": "PLDBGVEC2"
+          },
+          "PLDBGVEC3": {
+            "dir": "OUTPUT",
+            "wire": "PLDBGVEC3"
+          },
+          "PLDBGVEC4": {
+            "dir": "OUTPUT",
+            "wire": "PLDBGVEC4"
+          },
+          "PLDBGVEC5": {
+            "dir": "OUTPUT",
+            "wire": "PLDBGVEC5"
+          },
+          "PLDBGVEC6": {
+            "dir": "OUTPUT",
+            "wire": "PLDBGVEC6"
+          },
+          "PLDBGVEC7": {
+            "dir": "OUTPUT",
+            "wire": "PLDBGVEC7"
+          },
+          "PLDBGVEC8": {
+            "dir": "OUTPUT",
+            "wire": "PLDBGVEC8"
+          },
+          "PLDBGVEC9": {
+            "dir": "OUTPUT",
+            "wire": "PLDBGVEC9"
+          },
+          "PLDBGVEC10": {
+            "dir": "OUTPUT",
+            "wire": "PLDBGVEC10"
+          },
+          "PLDBGVEC11": {
+            "dir": "OUTPUT",
+            "wire": "PLDBGVEC11"
+          },
+          "PLDIRECTEDCHANGEDONE": {
+            "dir": "OUTPUT",
+            "wire": "PLDIRECTEDCHANGEDONE"
+          },
+          "PLDIRECTEDLINKAUTON": {
+            "dir": "INPUT",
+            "wire": "PLDIRECTEDLINKAUTON"
+          },
+          "PLDIRECTEDLINKCHANGE0": {
+            "dir": "INPUT",
+            "wire": "PLDIRECTEDLINKCHANGE0"
+          },
+          "PLDIRECTEDLINKCHANGE1": {
+            "dir": "INPUT",
+            "wire": "PLDIRECTEDLINKCHANGE1"
+          },
+          "PLDIRECTEDLINKSPEED": {
+            "dir": "INPUT",
+            "wire": "PLDIRECTEDLINKSPEED"
+          },
+          "PLDIRECTEDLINKWIDTH0": {
+            "dir": "INPUT",
+            "wire": "PLDIRECTEDLINKWIDTH0"
+          },
+          "PLDIRECTEDLINKWIDTH1": {
+            "dir": "INPUT",
+            "wire": "PLDIRECTEDLINKWIDTH1"
+          },
+          "PLDIRECTEDLTSSMNEW0": {
+            "dir": "INPUT",
+            "wire": "PLDIRECTEDLTSSMNEW0"
+          },
+          "PLDIRECTEDLTSSMNEW1": {
+            "dir": "INPUT",
+            "wire": "PLDIRECTEDLTSSMNEW1"
+          },
+          "PLDIRECTEDLTSSMNEW2": {
+            "dir": "INPUT",
+            "wire": "PLDIRECTEDLTSSMNEW2"
+          },
+          "PLDIRECTEDLTSSMNEW3": {
+            "dir": "INPUT",
+            "wire": "PLDIRECTEDLTSSMNEW3"
+          },
+          "PLDIRECTEDLTSSMNEW4": {
+            "dir": "INPUT",
+            "wire": "PLDIRECTEDLTSSMNEW4"
+          },
+          "PLDIRECTEDLTSSMNEW5": {
+            "dir": "INPUT",
+            "wire": "PLDIRECTEDLTSSMNEW5"
+          },
+          "PLDIRECTEDLTSSMNEWVLD": {
+            "dir": "INPUT",
+            "wire": "PLDIRECTEDLTSSMNEWVLD"
+          },
+          "PLDIRECTEDLTSSMSTALL": {
+            "dir": "INPUT",
+            "wire": "PLDIRECTEDLTSSMSTALL"
+          },
+          "PLDOWNSTREAMDEEMPHSOURCE": {
+            "dir": "INPUT",
+            "wire": "PLDOWNSTREAMDEEMPHSOURCE"
+          },
+          "PLINITIALLINKWIDTH0": {
+            "dir": "OUTPUT",
+            "wire": "PLINITIALLINKWIDTH0"
+          },
+          "PLINITIALLINKWIDTH1": {
+            "dir": "OUTPUT",
+            "wire": "PLINITIALLINKWIDTH1"
+          },
+          "PLINITIALLINKWIDTH2": {
+            "dir": "OUTPUT",
+            "wire": "PLINITIALLINKWIDTH2"
+          },
+          "PLLANEREVERSALMODE0": {
+            "dir": "OUTPUT",
+            "wire": "PLLANEREVERSALMODE0"
+          },
+          "PLLANEREVERSALMODE1": {
+            "dir": "OUTPUT",
+            "wire": "PLLANEREVERSALMODE1"
+          },
+          "PLLINKGEN2CAP": {
+            "dir": "OUTPUT",
+            "wire": "PLLINKGEN2CAP"
+          },
+          "PLLINKPARTNERGEN2SUPPORTED": {
+            "dir": "OUTPUT",
+            "wire": "PLLINKPARTNERGEN2SUPPORTED"
+          },
+          "PLLINKUPCFGCAP": {
+            "dir": "OUTPUT",
+            "wire": "PLLINKUPCFGCAP"
+          },
+          "PLLTSSMSTATE0": {
+            "dir": "OUTPUT",
+            "wire": "PLLTSSMSTATE0"
+          },
+          "PLLTSSMSTATE1": {
+            "dir": "OUTPUT",
+            "wire": "PLLTSSMSTATE1"
+          },
+          "PLLTSSMSTATE2": {
+            "dir": "OUTPUT",
+            "wire": "PLLTSSMSTATE2"
+          },
+          "PLLTSSMSTATE3": {
+            "dir": "OUTPUT",
+            "wire": "PLLTSSMSTATE3"
+          },
+          "PLLTSSMSTATE4": {
+            "dir": "OUTPUT",
+            "wire": "PLLTSSMSTATE4"
+          },
+          "PLLTSSMSTATE5": {
+            "dir": "OUTPUT",
+            "wire": "PLLTSSMSTATE5"
+          },
+          "PLPHYLNKUPN": {
+            "dir": "OUTPUT",
+            "wire": "PLPHYLNKUPN"
+          },
+          "PLRECEIVEDHOTRST": {
+            "dir": "OUTPUT",
+            "wire": "PLRECEIVEDHOTRST"
+          },
+          "PLRSTN": {
+            "dir": "INPUT",
+            "wire": "PLRSTN"
+          },
+          "PLRXPMSTATE0": {
+            "dir": "OUTPUT",
+            "wire": "PLRXPMSTATE0"
+          },
+          "PLRXPMSTATE1": {
+            "dir": "OUTPUT",
+            "wire": "PLRXPMSTATE1"
+          },
+          "PLSELLNKRATE": {
+            "dir": "OUTPUT",
+            "wire": "PLSELLNKRATE"
+          },
+          "PLSELLNKWIDTH0": {
+            "dir": "OUTPUT",
+            "wire": "PLSELLNKWIDTH0"
+          },
+          "PLSELLNKWIDTH1": {
+            "dir": "OUTPUT",
+            "wire": "PLSELLNKWIDTH1"
+          },
+          "PLTRANSMITHOTRST": {
+            "dir": "INPUT",
+            "wire": "PLTRANSMITHOTRST"
+          },
+          "PLTXPMSTATE0": {
+            "dir": "OUTPUT",
+            "wire": "PLTXPMSTATE0"
+          },
+          "PLTXPMSTATE1": {
+            "dir": "OUTPUT",
+            "wire": "PLTXPMSTATE1"
+          },
+          "PLTXPMSTATE2": {
+            "dir": "OUTPUT",
+            "wire": "PLTXPMSTATE2"
+          },
+          "PLUPSTREAMPREFERDEEMPH": {
+            "dir": "INPUT",
+            "wire": "PLUPSTREAMPREFERDEEMPH"
+          },
+          "PMVDIVIDE0": {
+            "dir": "INPUT",
+            "wire": "PMVDIVIDE0"
+          },
+          "PMVDIVIDE1": {
+            "dir": "INPUT",
+            "wire": "PMVDIVIDE1"
+          },
+          "PMVENABLEN": {
+            "dir": "INPUT",
+            "wire": "PMVENABLEN"
+          },
+          "PMVOUT": {
+            "dir": "OUTPUT",
+            "wire": "PMVOUT"
+          },
+          "PMVSELECT0": {
+            "dir": "INPUT",
+            "wire": "PMVSELECT0"
+          },
+          "PMVSELECT1": {
+            "dir": "INPUT",
+            "wire": "PMVSELECT1"
+          },
+          "PMVSELECT2": {
+            "dir": "INPUT",
+            "wire": "PMVSELECT2"
+          },
+          "RECEIVEDFUNCLVLRSTN": {
+            "dir": "OUTPUT",
+            "wire": "RECEIVEDFUNCLVLRSTN"
+          },
+          "SCANENABLEN": {
+            "dir": "INPUT",
+            "wire": "SCANENABLEN"
+          },
+          "SCANMODEN": {
+            "dir": "INPUT",
+            "wire": "SCANMODEN"
+          },
+          "SYSRSTN": {
+            "dir": "INPUT",
+            "wire": "SYSRSTN"
+          },
+          "TL2ASPMSUSPENDCREDITCHECK": {
+            "dir": "INPUT",
+            "wire": "TL2ASPMSUSPENDCREDITCHECK"
+          },
+          "TL2ASPMSUSPENDCREDITCHECKOK": {
+            "dir": "OUTPUT",
+            "wire": "TL2ASPMSUSPENDCREDITCHECKOK"
+          },
+          "TL2ASPMSUSPENDREQ": {
+            "dir": "OUTPUT",
+            "wire": "TL2ASPMSUSPENDREQ"
+          },
+          "TL2ERRFCPE": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRFCPE"
+          },
+          "TL2ERRHDR0": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR0"
+          },
+          "TL2ERRHDR1": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR1"
+          },
+          "TL2ERRHDR2": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR2"
+          },
+          "TL2ERRHDR3": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR3"
+          },
+          "TL2ERRHDR4": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR4"
+          },
+          "TL2ERRHDR5": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR5"
+          },
+          "TL2ERRHDR6": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR6"
+          },
+          "TL2ERRHDR7": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR7"
+          },
+          "TL2ERRHDR8": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR8"
+          },
+          "TL2ERRHDR9": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR9"
+          },
+          "TL2ERRHDR10": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR10"
+          },
+          "TL2ERRHDR11": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR11"
+          },
+          "TL2ERRHDR12": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR12"
+          },
+          "TL2ERRHDR13": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR13"
+          },
+          "TL2ERRHDR14": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR14"
+          },
+          "TL2ERRHDR15": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR15"
+          },
+          "TL2ERRHDR16": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR16"
+          },
+          "TL2ERRHDR17": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR17"
+          },
+          "TL2ERRHDR18": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR18"
+          },
+          "TL2ERRHDR19": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR19"
+          },
+          "TL2ERRHDR20": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR20"
+          },
+          "TL2ERRHDR21": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR21"
+          },
+          "TL2ERRHDR22": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR22"
+          },
+          "TL2ERRHDR23": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR23"
+          },
+          "TL2ERRHDR24": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR24"
+          },
+          "TL2ERRHDR25": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR25"
+          },
+          "TL2ERRHDR26": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR26"
+          },
+          "TL2ERRHDR27": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR27"
+          },
+          "TL2ERRHDR28": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR28"
+          },
+          "TL2ERRHDR29": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR29"
+          },
+          "TL2ERRHDR30": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR30"
+          },
+          "TL2ERRHDR31": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR31"
+          },
+          "TL2ERRHDR32": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR32"
+          },
+          "TL2ERRHDR33": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR33"
+          },
+          "TL2ERRHDR34": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR34"
+          },
+          "TL2ERRHDR35": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR35"
+          },
+          "TL2ERRHDR36": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR36"
+          },
+          "TL2ERRHDR37": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR37"
+          },
+          "TL2ERRHDR38": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR38"
+          },
+          "TL2ERRHDR39": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR39"
+          },
+          "TL2ERRHDR40": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR40"
+          },
+          "TL2ERRHDR41": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR41"
+          },
+          "TL2ERRHDR42": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR42"
+          },
+          "TL2ERRHDR43": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR43"
+          },
+          "TL2ERRHDR44": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR44"
+          },
+          "TL2ERRHDR45": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR45"
+          },
+          "TL2ERRHDR46": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR46"
+          },
+          "TL2ERRHDR47": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR47"
+          },
+          "TL2ERRHDR48": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR48"
+          },
+          "TL2ERRHDR49": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR49"
+          },
+          "TL2ERRHDR50": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR50"
+          },
+          "TL2ERRHDR51": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR51"
+          },
+          "TL2ERRHDR52": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR52"
+          },
+          "TL2ERRHDR53": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR53"
+          },
+          "TL2ERRHDR54": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR54"
+          },
+          "TL2ERRHDR55": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR55"
+          },
+          "TL2ERRHDR56": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR56"
+          },
+          "TL2ERRHDR57": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR57"
+          },
+          "TL2ERRHDR58": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR58"
+          },
+          "TL2ERRHDR59": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR59"
+          },
+          "TL2ERRHDR60": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR60"
+          },
+          "TL2ERRHDR61": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR61"
+          },
+          "TL2ERRHDR62": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR62"
+          },
+          "TL2ERRHDR63": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRHDR63"
+          },
+          "TL2ERRMALFORMED": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRMALFORMED"
+          },
+          "TL2ERRRXOVERFLOW": {
+            "dir": "OUTPUT",
+            "wire": "TL2ERRRXOVERFLOW"
+          },
+          "TL2PPMSUSPENDOK": {
+            "dir": "OUTPUT",
+            "wire": "TL2PPMSUSPENDOK"
+          },
+          "TL2PPMSUSPENDREQ": {
+            "dir": "INPUT",
+            "wire": "TL2PPMSUSPENDREQ"
+          },
+          "TLRSTN": {
+            "dir": "INPUT",
+            "wire": "TLRSTN"
+          },
+          "TRNFCCPLD0": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCCPLD0"
+          },
+          "TRNFCCPLD1": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCCPLD1"
+          },
+          "TRNFCCPLD2": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCCPLD2"
+          },
+          "TRNFCCPLD3": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCCPLD3"
+          },
+          "TRNFCCPLD4": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCCPLD4"
+          },
+          "TRNFCCPLD5": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCCPLD5"
+          },
+          "TRNFCCPLD6": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCCPLD6"
+          },
+          "TRNFCCPLD7": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCCPLD7"
+          },
+          "TRNFCCPLD8": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCCPLD8"
+          },
+          "TRNFCCPLD9": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCCPLD9"
+          },
+          "TRNFCCPLD10": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCCPLD10"
+          },
+          "TRNFCCPLD11": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCCPLD11"
+          },
+          "TRNFCCPLH0": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCCPLH0"
+          },
+          "TRNFCCPLH1": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCCPLH1"
+          },
+          "TRNFCCPLH2": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCCPLH2"
+          },
+          "TRNFCCPLH3": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCCPLH3"
+          },
+          "TRNFCCPLH4": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCCPLH4"
+          },
+          "TRNFCCPLH5": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCCPLH5"
+          },
+          "TRNFCCPLH6": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCCPLH6"
+          },
+          "TRNFCCPLH7": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCCPLH7"
+          },
+          "TRNFCNPD0": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCNPD0"
+          },
+          "TRNFCNPD1": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCNPD1"
+          },
+          "TRNFCNPD2": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCNPD2"
+          },
+          "TRNFCNPD3": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCNPD3"
+          },
+          "TRNFCNPD4": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCNPD4"
+          },
+          "TRNFCNPD5": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCNPD5"
+          },
+          "TRNFCNPD6": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCNPD6"
+          },
+          "TRNFCNPD7": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCNPD7"
+          },
+          "TRNFCNPD8": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCNPD8"
+          },
+          "TRNFCNPD9": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCNPD9"
+          },
+          "TRNFCNPD10": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCNPD10"
+          },
+          "TRNFCNPD11": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCNPD11"
+          },
+          "TRNFCNPH0": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCNPH0"
+          },
+          "TRNFCNPH1": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCNPH1"
+          },
+          "TRNFCNPH2": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCNPH2"
+          },
+          "TRNFCNPH3": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCNPH3"
+          },
+          "TRNFCNPH4": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCNPH4"
+          },
+          "TRNFCNPH5": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCNPH5"
+          },
+          "TRNFCNPH6": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCNPH6"
+          },
+          "TRNFCNPH7": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCNPH7"
+          },
+          "TRNFCPD0": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCPD0"
+          },
+          "TRNFCPD1": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCPD1"
+          },
+          "TRNFCPD2": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCPD2"
+          },
+          "TRNFCPD3": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCPD3"
+          },
+          "TRNFCPD4": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCPD4"
+          },
+          "TRNFCPD5": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCPD5"
+          },
+          "TRNFCPD6": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCPD6"
+          },
+          "TRNFCPD7": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCPD7"
+          },
+          "TRNFCPD8": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCPD8"
+          },
+          "TRNFCPD9": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCPD9"
+          },
+          "TRNFCPD10": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCPD10"
+          },
+          "TRNFCPD11": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCPD11"
+          },
+          "TRNFCPH0": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCPH0"
+          },
+          "TRNFCPH1": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCPH1"
+          },
+          "TRNFCPH2": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCPH2"
+          },
+          "TRNFCPH3": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCPH3"
+          },
+          "TRNFCPH4": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCPH4"
+          },
+          "TRNFCPH5": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCPH5"
+          },
+          "TRNFCPH6": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCPH6"
+          },
+          "TRNFCPH7": {
+            "dir": "OUTPUT",
+            "wire": "TRNFCPH7"
+          },
+          "TRNFCSEL0": {
+            "dir": "INPUT",
+            "wire": "TRNFCSEL0"
+          },
+          "TRNFCSEL1": {
+            "dir": "INPUT",
+            "wire": "TRNFCSEL1"
+          },
+          "TRNFCSEL2": {
+            "dir": "INPUT",
+            "wire": "TRNFCSEL2"
+          },
+          "TRNLNKUP": {
+            "dir": "OUTPUT",
+            "wire": "TRNLNKUP"
+          },
+          "TRNRBARHIT0": {
+            "dir": "OUTPUT",
+            "wire": "TRNRBARHIT0"
+          },
+          "TRNRBARHIT1": {
+            "dir": "OUTPUT",
+            "wire": "TRNRBARHIT1"
+          },
+          "TRNRBARHIT2": {
+            "dir": "OUTPUT",
+            "wire": "TRNRBARHIT2"
+          },
+          "TRNRBARHIT3": {
+            "dir": "OUTPUT",
+            "wire": "TRNRBARHIT3"
+          },
+          "TRNRBARHIT4": {
+            "dir": "OUTPUT",
+            "wire": "TRNRBARHIT4"
+          },
+          "TRNRBARHIT5": {
+            "dir": "OUTPUT",
+            "wire": "TRNRBARHIT5"
+          },
+          "TRNRBARHIT6": {
+            "dir": "OUTPUT",
+            "wire": "TRNRBARHIT6"
+          },
+          "TRNRBARHIT7": {
+            "dir": "OUTPUT",
+            "wire": "TRNRBARHIT7"
+          },
+          "TRNRD0": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD0"
+          },
+          "TRNRD1": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD1"
+          },
+          "TRNRD2": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD2"
+          },
+          "TRNRD3": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD3"
+          },
+          "TRNRD4": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD4"
+          },
+          "TRNRD5": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD5"
+          },
+          "TRNRD6": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD6"
+          },
+          "TRNRD7": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD7"
+          },
+          "TRNRD8": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD8"
+          },
+          "TRNRD9": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD9"
+          },
+          "TRNRD10": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD10"
+          },
+          "TRNRD11": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD11"
+          },
+          "TRNRD12": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD12"
+          },
+          "TRNRD13": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD13"
+          },
+          "TRNRD14": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD14"
+          },
+          "TRNRD15": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD15"
+          },
+          "TRNRD16": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD16"
+          },
+          "TRNRD17": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD17"
+          },
+          "TRNRD18": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD18"
+          },
+          "TRNRD19": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD19"
+          },
+          "TRNRD20": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD20"
+          },
+          "TRNRD21": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD21"
+          },
+          "TRNRD22": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD22"
+          },
+          "TRNRD23": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD23"
+          },
+          "TRNRD24": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD24"
+          },
+          "TRNRD25": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD25"
+          },
+          "TRNRD26": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD26"
+          },
+          "TRNRD27": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD27"
+          },
+          "TRNRD28": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD28"
+          },
+          "TRNRD29": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD29"
+          },
+          "TRNRD30": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD30"
+          },
+          "TRNRD31": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD31"
+          },
+          "TRNRD32": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD32"
+          },
+          "TRNRD33": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD33"
+          },
+          "TRNRD34": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD34"
+          },
+          "TRNRD35": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD35"
+          },
+          "TRNRD36": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD36"
+          },
+          "TRNRD37": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD37"
+          },
+          "TRNRD38": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD38"
+          },
+          "TRNRD39": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD39"
+          },
+          "TRNRD40": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD40"
+          },
+          "TRNRD41": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD41"
+          },
+          "TRNRD42": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD42"
+          },
+          "TRNRD43": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD43"
+          },
+          "TRNRD44": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD44"
+          },
+          "TRNRD45": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD45"
+          },
+          "TRNRD46": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD46"
+          },
+          "TRNRD47": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD47"
+          },
+          "TRNRD48": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD48"
+          },
+          "TRNRD49": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD49"
+          },
+          "TRNRD50": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD50"
+          },
+          "TRNRD51": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD51"
+          },
+          "TRNRD52": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD52"
+          },
+          "TRNRD53": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD53"
+          },
+          "TRNRD54": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD54"
+          },
+          "TRNRD55": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD55"
+          },
+          "TRNRD56": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD56"
+          },
+          "TRNRD57": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD57"
+          },
+          "TRNRD58": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD58"
+          },
+          "TRNRD59": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD59"
+          },
+          "TRNRD60": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD60"
+          },
+          "TRNRD61": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD61"
+          },
+          "TRNRD62": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD62"
+          },
+          "TRNRD63": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD63"
+          },
+          "TRNRD64": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD64"
+          },
+          "TRNRD65": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD65"
+          },
+          "TRNRD66": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD66"
+          },
+          "TRNRD67": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD67"
+          },
+          "TRNRD68": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD68"
+          },
+          "TRNRD69": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD69"
+          },
+          "TRNRD70": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD70"
+          },
+          "TRNRD71": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD71"
+          },
+          "TRNRD72": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD72"
+          },
+          "TRNRD73": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD73"
+          },
+          "TRNRD74": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD74"
+          },
+          "TRNRD75": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD75"
+          },
+          "TRNRD76": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD76"
+          },
+          "TRNRD77": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD77"
+          },
+          "TRNRD78": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD78"
+          },
+          "TRNRD79": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD79"
+          },
+          "TRNRD80": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD80"
+          },
+          "TRNRD81": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD81"
+          },
+          "TRNRD82": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD82"
+          },
+          "TRNRD83": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD83"
+          },
+          "TRNRD84": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD84"
+          },
+          "TRNRD85": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD85"
+          },
+          "TRNRD86": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD86"
+          },
+          "TRNRD87": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD87"
+          },
+          "TRNRD88": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD88"
+          },
+          "TRNRD89": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD89"
+          },
+          "TRNRD90": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD90"
+          },
+          "TRNRD91": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD91"
+          },
+          "TRNRD92": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD92"
+          },
+          "TRNRD93": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD93"
+          },
+          "TRNRD94": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD94"
+          },
+          "TRNRD95": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD95"
+          },
+          "TRNRD96": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD96"
+          },
+          "TRNRD97": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD97"
+          },
+          "TRNRD98": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD98"
+          },
+          "TRNRD99": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD99"
+          },
+          "TRNRD100": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD100"
+          },
+          "TRNRD101": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD101"
+          },
+          "TRNRD102": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD102"
+          },
+          "TRNRD103": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD103"
+          },
+          "TRNRD104": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD104"
+          },
+          "TRNRD105": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD105"
+          },
+          "TRNRD106": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD106"
+          },
+          "TRNRD107": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD107"
+          },
+          "TRNRD108": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD108"
+          },
+          "TRNRD109": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD109"
+          },
+          "TRNRD110": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD110"
+          },
+          "TRNRD111": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD111"
+          },
+          "TRNRD112": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD112"
+          },
+          "TRNRD113": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD113"
+          },
+          "TRNRD114": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD114"
+          },
+          "TRNRD115": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD115"
+          },
+          "TRNRD116": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD116"
+          },
+          "TRNRD117": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD117"
+          },
+          "TRNRD118": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD118"
+          },
+          "TRNRD119": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD119"
+          },
+          "TRNRD120": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD120"
+          },
+          "TRNRD121": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD121"
+          },
+          "TRNRD122": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD122"
+          },
+          "TRNRD123": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD123"
+          },
+          "TRNRD124": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD124"
+          },
+          "TRNRD125": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD125"
+          },
+          "TRNRD126": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD126"
+          },
+          "TRNRD127": {
+            "dir": "OUTPUT",
+            "wire": "TRNRD127"
+          },
+          "TRNRDLLPDATA0": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA0"
+          },
+          "TRNRDLLPDATA1": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA1"
+          },
+          "TRNRDLLPDATA2": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA2"
+          },
+          "TRNRDLLPDATA3": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA3"
+          },
+          "TRNRDLLPDATA4": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA4"
+          },
+          "TRNRDLLPDATA5": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA5"
+          },
+          "TRNRDLLPDATA6": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA6"
+          },
+          "TRNRDLLPDATA7": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA7"
+          },
+          "TRNRDLLPDATA8": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA8"
+          },
+          "TRNRDLLPDATA9": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA9"
+          },
+          "TRNRDLLPDATA10": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA10"
+          },
+          "TRNRDLLPDATA11": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA11"
+          },
+          "TRNRDLLPDATA12": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA12"
+          },
+          "TRNRDLLPDATA13": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA13"
+          },
+          "TRNRDLLPDATA14": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA14"
+          },
+          "TRNRDLLPDATA15": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA15"
+          },
+          "TRNRDLLPDATA16": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA16"
+          },
+          "TRNRDLLPDATA17": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA17"
+          },
+          "TRNRDLLPDATA18": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA18"
+          },
+          "TRNRDLLPDATA19": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA19"
+          },
+          "TRNRDLLPDATA20": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA20"
+          },
+          "TRNRDLLPDATA21": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA21"
+          },
+          "TRNRDLLPDATA22": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA22"
+          },
+          "TRNRDLLPDATA23": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA23"
+          },
+          "TRNRDLLPDATA24": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA24"
+          },
+          "TRNRDLLPDATA25": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA25"
+          },
+          "TRNRDLLPDATA26": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA26"
+          },
+          "TRNRDLLPDATA27": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA27"
+          },
+          "TRNRDLLPDATA28": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA28"
+          },
+          "TRNRDLLPDATA29": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA29"
+          },
+          "TRNRDLLPDATA30": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA30"
+          },
+          "TRNRDLLPDATA31": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA31"
+          },
+          "TRNRDLLPDATA32": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA32"
+          },
+          "TRNRDLLPDATA33": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA33"
+          },
+          "TRNRDLLPDATA34": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA34"
+          },
+          "TRNRDLLPDATA35": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA35"
+          },
+          "TRNRDLLPDATA36": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA36"
+          },
+          "TRNRDLLPDATA37": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA37"
+          },
+          "TRNRDLLPDATA38": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA38"
+          },
+          "TRNRDLLPDATA39": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA39"
+          },
+          "TRNRDLLPDATA40": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA40"
+          },
+          "TRNRDLLPDATA41": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA41"
+          },
+          "TRNRDLLPDATA42": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA42"
+          },
+          "TRNRDLLPDATA43": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA43"
+          },
+          "TRNRDLLPDATA44": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA44"
+          },
+          "TRNRDLLPDATA45": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA45"
+          },
+          "TRNRDLLPDATA46": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA46"
+          },
+          "TRNRDLLPDATA47": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA47"
+          },
+          "TRNRDLLPDATA48": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA48"
+          },
+          "TRNRDLLPDATA49": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA49"
+          },
+          "TRNRDLLPDATA50": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA50"
+          },
+          "TRNRDLLPDATA51": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA51"
+          },
+          "TRNRDLLPDATA52": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA52"
+          },
+          "TRNRDLLPDATA53": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA53"
+          },
+          "TRNRDLLPDATA54": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA54"
+          },
+          "TRNRDLLPDATA55": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA55"
+          },
+          "TRNRDLLPDATA56": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA56"
+          },
+          "TRNRDLLPDATA57": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA57"
+          },
+          "TRNRDLLPDATA58": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA58"
+          },
+          "TRNRDLLPDATA59": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA59"
+          },
+          "TRNRDLLPDATA60": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA60"
+          },
+          "TRNRDLLPDATA61": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA61"
+          },
+          "TRNRDLLPDATA62": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA62"
+          },
+          "TRNRDLLPDATA63": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPDATA63"
+          },
+          "TRNRDLLPSRCRDY0": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPSRCRDY0"
+          },
+          "TRNRDLLPSRCRDY1": {
+            "dir": "OUTPUT",
+            "wire": "TRNRDLLPSRCRDY1"
+          },
+          "TRNRDSTRDY": {
+            "dir": "INPUT",
+            "wire": "TRNRDSTRDY"
+          },
+          "TRNRECRCERR": {
+            "dir": "OUTPUT",
+            "wire": "TRNRECRCERR"
+          },
+          "TRNREOF": {
+            "dir": "OUTPUT",
+            "wire": "TRNREOF"
+          },
+          "TRNRERRFWD": {
+            "dir": "OUTPUT",
+            "wire": "TRNRERRFWD"
+          },
+          "TRNRFCPRET": {
+            "dir": "INPUT",
+            "wire": "TRNRFCPRET"
+          },
+          "TRNRNPOK": {
+            "dir": "INPUT",
+            "wire": "TRNRNPOK"
+          },
+          "TRNRNPREQ": {
+            "dir": "INPUT",
+            "wire": "TRNRNPREQ"
+          },
+          "TRNRREM0": {
+            "dir": "OUTPUT",
+            "wire": "TRNRREM0"
+          },
+          "TRNRREM1": {
+            "dir": "OUTPUT",
+            "wire": "TRNRREM1"
+          },
+          "TRNRSOF": {
+            "dir": "OUTPUT",
+            "wire": "TRNRSOF"
+          },
+          "TRNRSRCDSC": {
+            "dir": "OUTPUT",
+            "wire": "TRNRSRCDSC"
+          },
+          "TRNRSRCRDY": {
+            "dir": "OUTPUT",
+            "wire": "TRNRSRCRDY"
+          },
+          "TRNTBUFAV0": {
+            "dir": "OUTPUT",
+            "wire": "TRNTBUFAV0"
+          },
+          "TRNTBUFAV1": {
+            "dir": "OUTPUT",
+            "wire": "TRNTBUFAV1"
+          },
+          "TRNTBUFAV2": {
+            "dir": "OUTPUT",
+            "wire": "TRNTBUFAV2"
+          },
+          "TRNTBUFAV3": {
+            "dir": "OUTPUT",
+            "wire": "TRNTBUFAV3"
+          },
+          "TRNTBUFAV4": {
+            "dir": "OUTPUT",
+            "wire": "TRNTBUFAV4"
+          },
+          "TRNTBUFAV5": {
+            "dir": "OUTPUT",
+            "wire": "TRNTBUFAV5"
+          },
+          "TRNTCFGGNT": {
+            "dir": "INPUT",
+            "wire": "TRNTCFGGNT"
+          },
+          "TRNTCFGREQ": {
+            "dir": "OUTPUT",
+            "wire": "TRNTCFGREQ"
+          },
+          "TRNTD0": {
+            "dir": "INPUT",
+            "wire": "TRNTD0"
+          },
+          "TRNTD1": {
+            "dir": "INPUT",
+            "wire": "TRNTD1"
+          },
+          "TRNTD2": {
+            "dir": "INPUT",
+            "wire": "TRNTD2"
+          },
+          "TRNTD3": {
+            "dir": "INPUT",
+            "wire": "TRNTD3"
+          },
+          "TRNTD4": {
+            "dir": "INPUT",
+            "wire": "TRNTD4"
+          },
+          "TRNTD5": {
+            "dir": "INPUT",
+            "wire": "TRNTD5"
+          },
+          "TRNTD6": {
+            "dir": "INPUT",
+            "wire": "TRNTD6"
+          },
+          "TRNTD7": {
+            "dir": "INPUT",
+            "wire": "TRNTD7"
+          },
+          "TRNTD8": {
+            "dir": "INPUT",
+            "wire": "TRNTD8"
+          },
+          "TRNTD9": {
+            "dir": "INPUT",
+            "wire": "TRNTD9"
+          },
+          "TRNTD10": {
+            "dir": "INPUT",
+            "wire": "TRNTD10"
+          },
+          "TRNTD11": {
+            "dir": "INPUT",
+            "wire": "TRNTD11"
+          },
+          "TRNTD12": {
+            "dir": "INPUT",
+            "wire": "TRNTD12"
+          },
+          "TRNTD13": {
+            "dir": "INPUT",
+            "wire": "TRNTD13"
+          },
+          "TRNTD14": {
+            "dir": "INPUT",
+            "wire": "TRNTD14"
+          },
+          "TRNTD15": {
+            "dir": "INPUT",
+            "wire": "TRNTD15"
+          },
+          "TRNTD16": {
+            "dir": "INPUT",
+            "wire": "TRNTD16"
+          },
+          "TRNTD17": {
+            "dir": "INPUT",
+            "wire": "TRNTD17"
+          },
+          "TRNTD18": {
+            "dir": "INPUT",
+            "wire": "TRNTD18"
+          },
+          "TRNTD19": {
+            "dir": "INPUT",
+            "wire": "TRNTD19"
+          },
+          "TRNTD20": {
+            "dir": "INPUT",
+            "wire": "TRNTD20"
+          },
+          "TRNTD21": {
+            "dir": "INPUT",
+            "wire": "TRNTD21"
+          },
+          "TRNTD22": {
+            "dir": "INPUT",
+            "wire": "TRNTD22"
+          },
+          "TRNTD23": {
+            "dir": "INPUT",
+            "wire": "TRNTD23"
+          },
+          "TRNTD24": {
+            "dir": "INPUT",
+            "wire": "TRNTD24"
+          },
+          "TRNTD25": {
+            "dir": "INPUT",
+            "wire": "TRNTD25"
+          },
+          "TRNTD26": {
+            "dir": "INPUT",
+            "wire": "TRNTD26"
+          },
+          "TRNTD27": {
+            "dir": "INPUT",
+            "wire": "TRNTD27"
+          },
+          "TRNTD28": {
+            "dir": "INPUT",
+            "wire": "TRNTD28"
+          },
+          "TRNTD29": {
+            "dir": "INPUT",
+            "wire": "TRNTD29"
+          },
+          "TRNTD30": {
+            "dir": "INPUT",
+            "wire": "TRNTD30"
+          },
+          "TRNTD31": {
+            "dir": "INPUT",
+            "wire": "TRNTD31"
+          },
+          "TRNTD32": {
+            "dir": "INPUT",
+            "wire": "TRNTD32"
+          },
+          "TRNTD33": {
+            "dir": "INPUT",
+            "wire": "TRNTD33"
+          },
+          "TRNTD34": {
+            "dir": "INPUT",
+            "wire": "TRNTD34"
+          },
+          "TRNTD35": {
+            "dir": "INPUT",
+            "wire": "TRNTD35"
+          },
+          "TRNTD36": {
+            "dir": "INPUT",
+            "wire": "TRNTD36"
+          },
+          "TRNTD37": {
+            "dir": "INPUT",
+            "wire": "TRNTD37"
+          },
+          "TRNTD38": {
+            "dir": "INPUT",
+            "wire": "TRNTD38"
+          },
+          "TRNTD39": {
+            "dir": "INPUT",
+            "wire": "TRNTD39"
+          },
+          "TRNTD40": {
+            "dir": "INPUT",
+            "wire": "TRNTD40"
+          },
+          "TRNTD41": {
+            "dir": "INPUT",
+            "wire": "TRNTD41"
+          },
+          "TRNTD42": {
+            "dir": "INPUT",
+            "wire": "TRNTD42"
+          },
+          "TRNTD43": {
+            "dir": "INPUT",
+            "wire": "TRNTD43"
+          },
+          "TRNTD44": {
+            "dir": "INPUT",
+            "wire": "TRNTD44"
+          },
+          "TRNTD45": {
+            "dir": "INPUT",
+            "wire": "TRNTD45"
+          },
+          "TRNTD46": {
+            "dir": "INPUT",
+            "wire": "TRNTD46"
+          },
+          "TRNTD47": {
+            "dir": "INPUT",
+            "wire": "TRNTD47"
+          },
+          "TRNTD48": {
+            "dir": "INPUT",
+            "wire": "TRNTD48"
+          },
+          "TRNTD49": {
+            "dir": "INPUT",
+            "wire": "TRNTD49"
+          },
+          "TRNTD50": {
+            "dir": "INPUT",
+            "wire": "TRNTD50"
+          },
+          "TRNTD51": {
+            "dir": "INPUT",
+            "wire": "TRNTD51"
+          },
+          "TRNTD52": {
+            "dir": "INPUT",
+            "wire": "TRNTD52"
+          },
+          "TRNTD53": {
+            "dir": "INPUT",
+            "wire": "TRNTD53"
+          },
+          "TRNTD54": {
+            "dir": "INPUT",
+            "wire": "TRNTD54"
+          },
+          "TRNTD55": {
+            "dir": "INPUT",
+            "wire": "TRNTD55"
+          },
+          "TRNTD56": {
+            "dir": "INPUT",
+            "wire": "TRNTD56"
+          },
+          "TRNTD57": {
+            "dir": "INPUT",
+            "wire": "TRNTD57"
+          },
+          "TRNTD58": {
+            "dir": "INPUT",
+            "wire": "TRNTD58"
+          },
+          "TRNTD59": {
+            "dir": "INPUT",
+            "wire": "TRNTD59"
+          },
+          "TRNTD60": {
+            "dir": "INPUT",
+            "wire": "TRNTD60"
+          },
+          "TRNTD61": {
+            "dir": "INPUT",
+            "wire": "TRNTD61"
+          },
+          "TRNTD62": {
+            "dir": "INPUT",
+            "wire": "TRNTD62"
+          },
+          "TRNTD63": {
+            "dir": "INPUT",
+            "wire": "TRNTD63"
+          },
+          "TRNTD64": {
+            "dir": "INPUT",
+            "wire": "TRNTD64"
+          },
+          "TRNTD65": {
+            "dir": "INPUT",
+            "wire": "TRNTD65"
+          },
+          "TRNTD66": {
+            "dir": "INPUT",
+            "wire": "TRNTD66"
+          },
+          "TRNTD67": {
+            "dir": "INPUT",
+            "wire": "TRNTD67"
+          },
+          "TRNTD68": {
+            "dir": "INPUT",
+            "wire": "TRNTD68"
+          },
+          "TRNTD69": {
+            "dir": "INPUT",
+            "wire": "TRNTD69"
+          },
+          "TRNTD70": {
+            "dir": "INPUT",
+            "wire": "TRNTD70"
+          },
+          "TRNTD71": {
+            "dir": "INPUT",
+            "wire": "TRNTD71"
+          },
+          "TRNTD72": {
+            "dir": "INPUT",
+            "wire": "TRNTD72"
+          },
+          "TRNTD73": {
+            "dir": "INPUT",
+            "wire": "TRNTD73"
+          },
+          "TRNTD74": {
+            "dir": "INPUT",
+            "wire": "TRNTD74"
+          },
+          "TRNTD75": {
+            "dir": "INPUT",
+            "wire": "TRNTD75"
+          },
+          "TRNTD76": {
+            "dir": "INPUT",
+            "wire": "TRNTD76"
+          },
+          "TRNTD77": {
+            "dir": "INPUT",
+            "wire": "TRNTD77"
+          },
+          "TRNTD78": {
+            "dir": "INPUT",
+            "wire": "TRNTD78"
+          },
+          "TRNTD79": {
+            "dir": "INPUT",
+            "wire": "TRNTD79"
+          },
+          "TRNTD80": {
+            "dir": "INPUT",
+            "wire": "TRNTD80"
+          },
+          "TRNTD81": {
+            "dir": "INPUT",
+            "wire": "TRNTD81"
+          },
+          "TRNTD82": {
+            "dir": "INPUT",
+            "wire": "TRNTD82"
+          },
+          "TRNTD83": {
+            "dir": "INPUT",
+            "wire": "TRNTD83"
+          },
+          "TRNTD84": {
+            "dir": "INPUT",
+            "wire": "TRNTD84"
+          },
+          "TRNTD85": {
+            "dir": "INPUT",
+            "wire": "TRNTD85"
+          },
+          "TRNTD86": {
+            "dir": "INPUT",
+            "wire": "TRNTD86"
+          },
+          "TRNTD87": {
+            "dir": "INPUT",
+            "wire": "TRNTD87"
+          },
+          "TRNTD88": {
+            "dir": "INPUT",
+            "wire": "TRNTD88"
+          },
+          "TRNTD89": {
+            "dir": "INPUT",
+            "wire": "TRNTD89"
+          },
+          "TRNTD90": {
+            "dir": "INPUT",
+            "wire": "TRNTD90"
+          },
+          "TRNTD91": {
+            "dir": "INPUT",
+            "wire": "TRNTD91"
+          },
+          "TRNTD92": {
+            "dir": "INPUT",
+            "wire": "TRNTD92"
+          },
+          "TRNTD93": {
+            "dir": "INPUT",
+            "wire": "TRNTD93"
+          },
+          "TRNTD94": {
+            "dir": "INPUT",
+            "wire": "TRNTD94"
+          },
+          "TRNTD95": {
+            "dir": "INPUT",
+            "wire": "TRNTD95"
+          },
+          "TRNTD96": {
+            "dir": "INPUT",
+            "wire": "TRNTD96"
+          },
+          "TRNTD97": {
+            "dir": "INPUT",
+            "wire": "TRNTD97"
+          },
+          "TRNTD98": {
+            "dir": "INPUT",
+            "wire": "TRNTD98"
+          },
+          "TRNTD99": {
+            "dir": "INPUT",
+            "wire": "TRNTD99"
+          },
+          "TRNTD100": {
+            "dir": "INPUT",
+            "wire": "TRNTD100"
+          },
+          "TRNTD101": {
+            "dir": "INPUT",
+            "wire": "TRNTD101"
+          },
+          "TRNTD102": {
+            "dir": "INPUT",
+            "wire": "TRNTD102"
+          },
+          "TRNTD103": {
+            "dir": "INPUT",
+            "wire": "TRNTD103"
+          },
+          "TRNTD104": {
+            "dir": "INPUT",
+            "wire": "TRNTD104"
+          },
+          "TRNTD105": {
+            "dir": "INPUT",
+            "wire": "TRNTD105"
+          },
+          "TRNTD106": {
+            "dir": "INPUT",
+            "wire": "TRNTD106"
+          },
+          "TRNTD107": {
+            "dir": "INPUT",
+            "wire": "TRNTD107"
+          },
+          "TRNTD108": {
+            "dir": "INPUT",
+            "wire": "TRNTD108"
+          },
+          "TRNTD109": {
+            "dir": "INPUT",
+            "wire": "TRNTD109"
+          },
+          "TRNTD110": {
+            "dir": "INPUT",
+            "wire": "TRNTD110"
+          },
+          "TRNTD111": {
+            "dir": "INPUT",
+            "wire": "TRNTD111"
+          },
+          "TRNTD112": {
+            "dir": "INPUT",
+            "wire": "TRNTD112"
+          },
+          "TRNTD113": {
+            "dir": "INPUT",
+            "wire": "TRNTD113"
+          },
+          "TRNTD114": {
+            "dir": "INPUT",
+            "wire": "TRNTD114"
+          },
+          "TRNTD115": {
+            "dir": "INPUT",
+            "wire": "TRNTD115"
+          },
+          "TRNTD116": {
+            "dir": "INPUT",
+            "wire": "TRNTD116"
+          },
+          "TRNTD117": {
+            "dir": "INPUT",
+            "wire": "TRNTD117"
+          },
+          "TRNTD118": {
+            "dir": "INPUT",
+            "wire": "TRNTD118"
+          },
+          "TRNTD119": {
+            "dir": "INPUT",
+            "wire": "TRNTD119"
+          },
+          "TRNTD120": {
+            "dir": "INPUT",
+            "wire": "TRNTD120"
+          },
+          "TRNTD121": {
+            "dir": "INPUT",
+            "wire": "TRNTD121"
+          },
+          "TRNTD122": {
+            "dir": "INPUT",
+            "wire": "TRNTD122"
+          },
+          "TRNTD123": {
+            "dir": "INPUT",
+            "wire": "TRNTD123"
+          },
+          "TRNTD124": {
+            "dir": "INPUT",
+            "wire": "TRNTD124"
+          },
+          "TRNTD125": {
+            "dir": "INPUT",
+            "wire": "TRNTD125"
+          },
+          "TRNTD126": {
+            "dir": "INPUT",
+            "wire": "TRNTD126"
+          },
+          "TRNTD127": {
+            "dir": "INPUT",
+            "wire": "TRNTD127"
+          },
+          "TRNTDLLPDATA0": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPDATA0"
+          },
+          "TRNTDLLPDATA1": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPDATA1"
+          },
+          "TRNTDLLPDATA2": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPDATA2"
+          },
+          "TRNTDLLPDATA3": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPDATA3"
+          },
+          "TRNTDLLPDATA4": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPDATA4"
+          },
+          "TRNTDLLPDATA5": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPDATA5"
+          },
+          "TRNTDLLPDATA6": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPDATA6"
+          },
+          "TRNTDLLPDATA7": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPDATA7"
+          },
+          "TRNTDLLPDATA8": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPDATA8"
+          },
+          "TRNTDLLPDATA9": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPDATA9"
+          },
+          "TRNTDLLPDATA10": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPDATA10"
+          },
+          "TRNTDLLPDATA11": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPDATA11"
+          },
+          "TRNTDLLPDATA12": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPDATA12"
+          },
+          "TRNTDLLPDATA13": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPDATA13"
+          },
+          "TRNTDLLPDATA14": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPDATA14"
+          },
+          "TRNTDLLPDATA15": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPDATA15"
+          },
+          "TRNTDLLPDATA16": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPDATA16"
+          },
+          "TRNTDLLPDATA17": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPDATA17"
+          },
+          "TRNTDLLPDATA18": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPDATA18"
+          },
+          "TRNTDLLPDATA19": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPDATA19"
+          },
+          "TRNTDLLPDATA20": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPDATA20"
+          },
+          "TRNTDLLPDATA21": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPDATA21"
+          },
+          "TRNTDLLPDATA22": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPDATA22"
+          },
+          "TRNTDLLPDATA23": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPDATA23"
+          },
+          "TRNTDLLPDATA24": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPDATA24"
+          },
+          "TRNTDLLPDATA25": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPDATA25"
+          },
+          "TRNTDLLPDATA26": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPDATA26"
+          },
+          "TRNTDLLPDATA27": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPDATA27"
+          },
+          "TRNTDLLPDATA28": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPDATA28"
+          },
+          "TRNTDLLPDATA29": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPDATA29"
+          },
+          "TRNTDLLPDATA30": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPDATA30"
+          },
+          "TRNTDLLPDATA31": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPDATA31"
+          },
+          "TRNTDLLPDSTRDY": {
+            "dir": "OUTPUT",
+            "wire": "TRNTDLLPDSTRDY"
+          },
+          "TRNTDLLPSRCRDY": {
+            "dir": "INPUT",
+            "wire": "TRNTDLLPSRCRDY"
+          },
+          "TRNTDSTRDY0": {
+            "dir": "OUTPUT",
+            "wire": "TRNTDSTRDY0"
+          },
+          "TRNTDSTRDY1": {
+            "dir": "OUTPUT",
+            "wire": "TRNTDSTRDY1"
+          },
+          "TRNTDSTRDY2": {
+            "dir": "OUTPUT",
+            "wire": "TRNTDSTRDY2"
+          },
+          "TRNTDSTRDY3": {
+            "dir": "OUTPUT",
+            "wire": "TRNTDSTRDY3"
+          },
+          "TRNTECRCGEN": {
+            "dir": "INPUT",
+            "wire": "TRNTECRCGEN"
+          },
+          "TRNTEOF": {
+            "dir": "INPUT",
+            "wire": "TRNTEOF"
+          },
+          "TRNTERRDROP": {
+            "dir": "OUTPUT",
+            "wire": "TRNTERRDROP"
+          },
+          "TRNTERRFWD": {
+            "dir": "INPUT",
+            "wire": "TRNTERRFWD"
+          },
+          "TRNTREM0": {
+            "dir": "INPUT",
+            "wire": "TRNTREM0"
+          },
+          "TRNTREM1": {
+            "dir": "INPUT",
+            "wire": "TRNTREM1"
+          },
+          "TRNTSOF": {
+            "dir": "INPUT",
+            "wire": "TRNTSOF"
+          },
+          "TRNTSRCDSC": {
+            "dir": "INPUT",
+            "wire": "TRNTSRCDSC"
+          },
+          "TRNTSRCRDY": {
+            "dir": "INPUT",
+            "wire": "TRNTSRCRDY"
+          },
+          "TRNTSTR": {
+            "dir": "INPUT",
+            "wire": "TRNTSTR"
+          },
+          "USERCLK": {
+            "dir": "INPUT",
+            "wire": "USERCLK"
+          },
+          "USERCLK2": {
+            "dir": "INPUT",
+            "wire": "USERCLK2"
+          },
+          "USERCLKPREBUF": {
+            "dir": "INPUT",
+            "wire": "USERCLKPREBUF"
+          },
+          "USERCLKPREBUFEN": {
+            "dir": "INPUT",
+            "wire": "USERCLKPREBUFEN"
+          },
+          "USERRSTN": {
+            "dir": "OUTPUT",
+            "wire": "USERRSTN"
+          },
+          "XILUNCONNOUT0": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT0"
+          },
+          "XILUNCONNOUT1": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT1"
+          },
+          "XILUNCONNOUT2": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT2"
+          },
+          "XILUNCONNOUT3": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT3"
+          },
+          "XILUNCONNOUT4": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT4"
+          },
+          "XILUNCONNOUT5": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT5"
+          },
+          "XILUNCONNOUT6": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT6"
+          },
+          "XILUNCONNOUT7": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT7"
+          },
+          "XILUNCONNOUT8": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT8"
+          },
+          "XILUNCONNOUT9": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT9"
+          },
+          "XILUNCONNOUT10": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT10"
+          },
+          "XILUNCONNOUT11": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT11"
+          },
+          "XILUNCONNOUT12": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT12"
+          },
+          "XILUNCONNOUT13": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT13"
+          },
+          "XILUNCONNOUT14": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT14"
+          },
+          "XILUNCONNOUT15": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT15"
+          },
+          "XILUNCONNOUT16": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT16"
+          },
+          "XILUNCONNOUT17": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT17"
+          },
+          "XILUNCONNOUT18": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT18"
+          },
+          "XILUNCONNOUT19": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT19"
+          },
+          "XILUNCONNOUT20": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT20"
+          },
+          "XILUNCONNOUT21": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT21"
+          },
+          "XILUNCONNOUT22": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT22"
+          },
+          "XILUNCONNOUT23": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT23"
+          },
+          "XILUNCONNOUT24": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT24"
+          },
+          "XILUNCONNOUT25": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT25"
+          },
+          "XILUNCONNOUT26": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT26"
+          },
+          "XILUNCONNOUT27": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT27"
+          },
+          "XILUNCONNOUT28": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT28"
+          },
+          "XILUNCONNOUT29": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT29"
+          },
+          "XILUNCONNOUT30": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT30"
+          },
+          "XILUNCONNOUT31": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT31"
+          },
+          "XILUNCONNOUT32": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT32"
+          },
+          "XILUNCONNOUT33": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT33"
+          },
+          "XILUNCONNOUT34": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT34"
+          },
+          "XILUNCONNOUT35": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT35"
+          },
+          "XILUNCONNOUT36": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT36"
+          },
+          "XILUNCONNOUT37": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT37"
+          },
+          "XILUNCONNOUT38": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT38"
+          },
+          "XILUNCONNOUT39": {
+            "dir": "OUTPUT",
+            "wire": "XILUNCONNOUT39"
+          }
+        }
+      }
+    },
+    "pips": [],
+    "pins": {
+      "CFGAERECRCCHECKEN": {
+        "primary": "CFGAERECRCCHECKEN",
+        "wire": "CFGAERECRCCHECKEN",
+        "dir": "OUTPUT"
+      },
+      "CFGAERECRCGENEN": {
+        "primary": "CFGAERECRCGENEN",
+        "wire": "CFGAERECRCGENEN",
+        "dir": "OUTPUT"
+      },
+      "CFGAERINTERRUPTMSGNUM0": {
+        "primary": "CFGAERINTERRUPTMSGNUM0",
+        "wire": "CFGAERINTERRUPTMSGNUM0",
+        "dir": "INPUT"
+      },
+      "CFGAERINTERRUPTMSGNUM1": {
+        "primary": "CFGAERINTERRUPTMSGNUM1",
+        "wire": "CFGAERINTERRUPTMSGNUM1",
+        "dir": "INPUT"
+      },
+      "CFGAERINTERRUPTMSGNUM2": {
+        "primary": "CFGAERINTERRUPTMSGNUM2",
+        "wire": "CFGAERINTERRUPTMSGNUM2",
+        "dir": "INPUT"
+      },
+      "CFGAERINTERRUPTMSGNUM3": {
+        "primary": "CFGAERINTERRUPTMSGNUM3",
+        "wire": "CFGAERINTERRUPTMSGNUM3",
+        "dir": "INPUT"
+      },
+      "CFGAERINTERRUPTMSGNUM4": {
+        "primary": "CFGAERINTERRUPTMSGNUM4",
+        "wire": "CFGAERINTERRUPTMSGNUM4",
+        "dir": "INPUT"
+      },
+      "CFGAERROOTERRCORRERRRECEIVED": {
+        "primary": "CFGAERROOTERRCORRERRRECEIVED",
+        "wire": "CFGAERROOTERRCORRERRRECEIVED",
+        "dir": "OUTPUT"
+      },
+      "CFGAERROOTERRCORRERRREPORTINGEN": {
+        "primary": "CFGAERROOTERRCORRERRREPORTINGEN",
+        "wire": "CFGAERROOTERRCORRERRREPORTINGEN",
+        "dir": "OUTPUT"
+      },
+      "CFGAERROOTERRFATALERRRECEIVED": {
+        "primary": "CFGAERROOTERRFATALERRRECEIVED",
+        "wire": "CFGAERROOTERRFATALERRRECEIVED",
+        "dir": "OUTPUT"
+      },
+      "CFGAERROOTERRFATALERRREPORTINGEN": {
+        "primary": "CFGAERROOTERRFATALERRREPORTINGEN",
+        "wire": "CFGAERROOTERRFATALERRREPORTINGEN",
+        "dir": "OUTPUT"
+      },
+      "CFGAERROOTERRNONFATALERRRECEIVED": {
+        "primary": "CFGAERROOTERRNONFATALERRRECEIVED",
+        "wire": "CFGAERROOTERRNONFATALERRRECEIVED",
+        "dir": "OUTPUT"
+      },
+      "CFGAERROOTERRNONFATALERRREPORTINGEN": {
+        "primary": "CFGAERROOTERRNONFATALERRREPORTINGEN",
+        "wire": "CFGAERROOTERRNONFATALERRREPORTINGEN",
+        "dir": "OUTPUT"
+      },
+      "CFGBRIDGESERREN": {
+        "primary": "CFGBRIDGESERREN",
+        "wire": "CFGBRIDGESERREN",
+        "dir": "OUTPUT"
+      },
+      "CFGCOMMANDBUSMASTERENABLE": {
+        "primary": "CFGCOMMANDBUSMASTERENABLE",
+        "wire": "CFGCOMMANDBUSMASTERENABLE",
+        "dir": "OUTPUT"
+      },
+      "CFGCOMMANDINTERRUPTDISABLE": {
+        "primary": "CFGCOMMANDINTERRUPTDISABLE",
+        "wire": "CFGCOMMANDINTERRUPTDISABLE",
+        "dir": "OUTPUT"
+      },
+      "CFGCOMMANDIOENABLE": {
+        "primary": "CFGCOMMANDIOENABLE",
+        "wire": "CFGCOMMANDIOENABLE",
+        "dir": "OUTPUT"
+      },
+      "CFGCOMMANDMEMENABLE": {
+        "primary": "CFGCOMMANDMEMENABLE",
+        "wire": "CFGCOMMANDMEMENABLE",
+        "dir": "OUTPUT"
+      },
+      "CFGCOMMANDSERREN": {
+        "primary": "CFGCOMMANDSERREN",
+        "wire": "CFGCOMMANDSERREN",
+        "dir": "OUTPUT"
+      },
+      "CFGDEVCONTROL2ARIFORWARDEN": {
+        "primary": "CFGDEVCONTROL2ARIFORWARDEN",
+        "wire": "CFGDEVCONTROL2ARIFORWARDEN",
+        "dir": "OUTPUT"
+      },
+      "CFGDEVCONTROL2ATOMICEGRESSBLOCK": {
+        "primary": "CFGDEVCONTROL2ATOMICEGRESSBLOCK",
+        "wire": "CFGDEVCONTROL2ATOMICEGRESSBLOCK",
+        "dir": "OUTPUT"
+      },
+      "CFGDEVCONTROL2ATOMICREQUESTEREN": {
+        "primary": "CFGDEVCONTROL2ATOMICREQUESTEREN",
+        "wire": "CFGDEVCONTROL2ATOMICREQUESTEREN",
+        "dir": "OUTPUT"
+      },
+      "CFGDEVCONTROL2CPLTIMEOUTDIS": {
+        "primary": "CFGDEVCONTROL2CPLTIMEOUTDIS",
+        "wire": "CFGDEVCONTROL2CPLTIMEOUTDIS",
+        "dir": "OUTPUT"
+      },
+      "CFGDEVCONTROL2CPLTIMEOUTVAL0": {
+        "primary": "CFGDEVCONTROL2CPLTIMEOUTVAL0",
+        "wire": "CFGDEVCONTROL2CPLTIMEOUTVAL0",
+        "dir": "OUTPUT"
+      },
+      "CFGDEVCONTROL2CPLTIMEOUTVAL1": {
+        "primary": "CFGDEVCONTROL2CPLTIMEOUTVAL1",
+        "wire": "CFGDEVCONTROL2CPLTIMEOUTVAL1",
+        "dir": "OUTPUT"
+      },
+      "CFGDEVCONTROL2CPLTIMEOUTVAL2": {
+        "primary": "CFGDEVCONTROL2CPLTIMEOUTVAL2",
+        "wire": "CFGDEVCONTROL2CPLTIMEOUTVAL2",
+        "dir": "OUTPUT"
+      },
+      "CFGDEVCONTROL2CPLTIMEOUTVAL3": {
+        "primary": "CFGDEVCONTROL2CPLTIMEOUTVAL3",
+        "wire": "CFGDEVCONTROL2CPLTIMEOUTVAL3",
+        "dir": "OUTPUT"
+      },
+      "CFGDEVCONTROL2IDOCPLEN": {
+        "primary": "CFGDEVCONTROL2IDOCPLEN",
+        "wire": "CFGDEVCONTROL2IDOCPLEN",
+        "dir": "OUTPUT"
+      },
+      "CFGDEVCONTROL2IDOREQEN": {
+        "primary": "CFGDEVCONTROL2IDOREQEN",
+        "wire": "CFGDEVCONTROL2IDOREQEN",
+        "dir": "OUTPUT"
+      },
+      "CFGDEVCONTROL2LTREN": {
+        "primary": "CFGDEVCONTROL2LTREN",
+        "wire": "CFGDEVCONTROL2LTREN",
+        "dir": "OUTPUT"
+      },
+      "CFGDEVCONTROL2TLPPREFIXBLOCK": {
+        "primary": "CFGDEVCONTROL2TLPPREFIXBLOCK",
+        "wire": "CFGDEVCONTROL2TLPPREFIXBLOCK",
+        "dir": "OUTPUT"
+      },
+      "CFGDEVCONTROLAUXPOWEREN": {
+        "primary": "CFGDEVCONTROLAUXPOWEREN",
+        "wire": "CFGDEVCONTROLAUXPOWEREN",
+        "dir": "OUTPUT"
+      },
+      "CFGDEVCONTROLCORRERRREPORTINGEN": {
+        "primary": "CFGDEVCONTROLCORRERRREPORTINGEN",
+        "wire": "CFGDEVCONTROLCORRERRREPORTINGEN",
+        "dir": "OUTPUT"
+      },
+      "CFGDEVCONTROLENABLERO": {
+        "primary": "CFGDEVCONTROLENABLERO",
+        "wire": "CFGDEVCONTROLENABLERO",
+        "dir": "OUTPUT"
+      },
+      "CFGDEVCONTROLEXTTAGEN": {
+        "primary": "CFGDEVCONTROLEXTTAGEN",
+        "wire": "CFGDEVCONTROLEXTTAGEN",
+        "dir": "OUTPUT"
+      },
+      "CFGDEVCONTROLFATALERRREPORTINGEN": {
+        "primary": "CFGDEVCONTROLFATALERRREPORTINGEN",
+        "wire": "CFGDEVCONTROLFATALERRREPORTINGEN",
+        "dir": "OUTPUT"
+      },
+      "CFGDEVCONTROLMAXPAYLOAD0": {
+        "primary": "CFGDEVCONTROLMAXPAYLOAD0",
+        "wire": "CFGDEVCONTROLMAXPAYLOAD0",
+        "dir": "OUTPUT"
+      },
+      "CFGDEVCONTROLMAXPAYLOAD1": {
+        "primary": "CFGDEVCONTROLMAXPAYLOAD1",
+        "wire": "CFGDEVCONTROLMAXPAYLOAD1",
+        "dir": "OUTPUT"
+      },
+      "CFGDEVCONTROLMAXPAYLOAD2": {
+        "primary": "CFGDEVCONTROLMAXPAYLOAD2",
+        "wire": "CFGDEVCONTROLMAXPAYLOAD2",
+        "dir": "OUTPUT"
+      },
+      "CFGDEVCONTROLMAXREADREQ0": {
+        "primary": "CFGDEVCONTROLMAXREADREQ0",
+        "wire": "CFGDEVCONTROLMAXREADREQ0",
+        "dir": "OUTPUT"
+      },
+      "CFGDEVCONTROLMAXREADREQ1": {
+        "primary": "CFGDEVCONTROLMAXREADREQ1",
+        "wire": "CFGDEVCONTROLMAXREADREQ1",
+        "dir": "OUTPUT"
+      },
+      "CFGDEVCONTROLMAXREADREQ2": {
+        "primary": "CFGDEVCONTROLMAXREADREQ2",
+        "wire": "CFGDEVCONTROLMAXREADREQ2",
+        "dir": "OUTPUT"
+      },
+      "CFGDEVCONTROLNONFATALREPORTINGEN": {
+        "primary": "CFGDEVCONTROLNONFATALREPORTINGEN",
+        "wire": "CFGDEVCONTROLNONFATALREPORTINGEN",
+        "dir": "OUTPUT"
+      },
+      "CFGDEVCONTROLNOSNOOPEN": {
+        "primary": "CFGDEVCONTROLNOSNOOPEN",
+        "wire": "CFGDEVCONTROLNOSNOOPEN",
+        "dir": "OUTPUT"
+      },
+      "CFGDEVCONTROLPHANTOMEN": {
+        "primary": "CFGDEVCONTROLPHANTOMEN",
+        "wire": "CFGDEVCONTROLPHANTOMEN",
+        "dir": "OUTPUT"
+      },
+      "CFGDEVCONTROLURERRREPORTINGEN": {
+        "primary": "CFGDEVCONTROLURERRREPORTINGEN",
+        "wire": "CFGDEVCONTROLURERRREPORTINGEN",
+        "dir": "OUTPUT"
+      },
+      "CFGDEVID0": {
+        "primary": "CFGDEVID0",
+        "wire": "CFGDEVID0",
+        "dir": "INPUT"
+      },
+      "CFGDEVID1": {
+        "primary": "CFGDEVID1",
+        "wire": "CFGDEVID1",
+        "dir": "INPUT"
+      },
+      "CFGDEVID2": {
+        "primary": "CFGDEVID2",
+        "wire": "CFGDEVID2",
+        "dir": "INPUT"
+      },
+      "CFGDEVID3": {
+        "primary": "CFGDEVID3",
+        "wire": "CFGDEVID3",
+        "dir": "INPUT"
+      },
+      "CFGDEVID4": {
+        "primary": "CFGDEVID4",
+        "wire": "CFGDEVID4",
+        "dir": "INPUT"
+      },
+      "CFGDEVID5": {
+        "primary": "CFGDEVID5",
+        "wire": "CFGDEVID5",
+        "dir": "INPUT"
+      },
+      "CFGDEVID6": {
+        "primary": "CFGDEVID6",
+        "wire": "CFGDEVID6",
+        "dir": "INPUT"
+      },
+      "CFGDEVID7": {
+        "primary": "CFGDEVID7",
+        "wire": "CFGDEVID7",
+        "dir": "INPUT"
+      },
+      "CFGDEVID8": {
+        "primary": "CFGDEVID8",
+        "wire": "CFGDEVID8",
+        "dir": "INPUT"
+      },
+      "CFGDEVID9": {
+        "primary": "CFGDEVID9",
+        "wire": "CFGDEVID9",
+        "dir": "INPUT"
+      },
+      "CFGDEVID10": {
+        "primary": "CFGDEVID10",
+        "wire": "CFGDEVID10",
+        "dir": "INPUT"
+      },
+      "CFGDEVID11": {
+        "primary": "CFGDEVID11",
+        "wire": "CFGDEVID11",
+        "dir": "INPUT"
+      },
+      "CFGDEVID12": {
+        "primary": "CFGDEVID12",
+        "wire": "CFGDEVID12",
+        "dir": "INPUT"
+      },
+      "CFGDEVID13": {
+        "primary": "CFGDEVID13",
+        "wire": "CFGDEVID13",
+        "dir": "INPUT"
+      },
+      "CFGDEVID14": {
+        "primary": "CFGDEVID14",
+        "wire": "CFGDEVID14",
+        "dir": "INPUT"
+      },
+      "CFGDEVID15": {
+        "primary": "CFGDEVID15",
+        "wire": "CFGDEVID15",
+        "dir": "INPUT"
+      },
+      "CFGDEVSTATUSCORRERRDETECTED": {
+        "primary": "CFGDEVSTATUSCORRERRDETECTED",
+        "wire": "CFGDEVSTATUSCORRERRDETECTED",
+        "dir": "OUTPUT"
+      },
+      "CFGDEVSTATUSFATALERRDETECTED": {
+        "primary": "CFGDEVSTATUSFATALERRDETECTED",
+        "wire": "CFGDEVSTATUSFATALERRDETECTED",
+        "dir": "OUTPUT"
+      },
+      "CFGDEVSTATUSNONFATALERRDETECTED": {
+        "primary": "CFGDEVSTATUSNONFATALERRDETECTED",
+        "wire": "CFGDEVSTATUSNONFATALERRDETECTED",
+        "dir": "OUTPUT"
+      },
+      "CFGDEVSTATUSURDETECTED": {
+        "primary": "CFGDEVSTATUSURDETECTED",
+        "wire": "CFGDEVSTATUSURDETECTED",
+        "dir": "OUTPUT"
+      },
+      "CFGDSBUSNUMBER0": {
+        "primary": "CFGDSBUSNUMBER0",
+        "wire": "CFGDSBUSNUMBER0",
+        "dir": "INPUT"
+      },
+      "CFGDSBUSNUMBER1": {
+        "primary": "CFGDSBUSNUMBER1",
+        "wire": "CFGDSBUSNUMBER1",
+        "dir": "INPUT"
+      },
+      "CFGDSBUSNUMBER2": {
+        "primary": "CFGDSBUSNUMBER2",
+        "wire": "CFGDSBUSNUMBER2",
+        "dir": "INPUT"
+      },
+      "CFGDSBUSNUMBER3": {
+        "primary": "CFGDSBUSNUMBER3",
+        "wire": "CFGDSBUSNUMBER3",
+        "dir": "INPUT"
+      },
+      "CFGDSBUSNUMBER4": {
+        "primary": "CFGDSBUSNUMBER4",
+        "wire": "CFGDSBUSNUMBER4",
+        "dir": "INPUT"
+      },
+      "CFGDSBUSNUMBER5": {
+        "primary": "CFGDSBUSNUMBER5",
+        "wire": "CFGDSBUSNUMBER5",
+        "dir": "INPUT"
+      },
+      "CFGDSBUSNUMBER6": {
+        "primary": "CFGDSBUSNUMBER6",
+        "wire": "CFGDSBUSNUMBER6",
+        "dir": "INPUT"
+      },
+      "CFGDSBUSNUMBER7": {
+        "primary": "CFGDSBUSNUMBER7",
+        "wire": "CFGDSBUSNUMBER7",
+        "dir": "INPUT"
+      },
+      "CFGDSDEVICENUMBER0": {
+        "primary": "CFGDSDEVICENUMBER0",
+        "wire": "CFGDSDEVICENUMBER0",
+        "dir": "INPUT"
+      },
+      "CFGDSDEVICENUMBER1": {
+        "primary": "CFGDSDEVICENUMBER1",
+        "wire": "CFGDSDEVICENUMBER1",
+        "dir": "INPUT"
+      },
+      "CFGDSDEVICENUMBER2": {
+        "primary": "CFGDSDEVICENUMBER2",
+        "wire": "CFGDSDEVICENUMBER2",
+        "dir": "INPUT"
+      },
+      "CFGDSDEVICENUMBER3": {
+        "primary": "CFGDSDEVICENUMBER3",
+        "wire": "CFGDSDEVICENUMBER3",
+        "dir": "INPUT"
+      },
+      "CFGDSDEVICENUMBER4": {
+        "primary": "CFGDSDEVICENUMBER4",
+        "wire": "CFGDSDEVICENUMBER4",
+        "dir": "INPUT"
+      },
+      "CFGDSFUNCTIONNUMBER0": {
+        "primary": "CFGDSFUNCTIONNUMBER0",
+        "wire": "CFGDSFUNCTIONNUMBER0",
+        "dir": "INPUT"
+      },
+      "CFGDSFUNCTIONNUMBER1": {
+        "primary": "CFGDSFUNCTIONNUMBER1",
+        "wire": "CFGDSFUNCTIONNUMBER1",
+        "dir": "INPUT"
+      },
+      "CFGDSFUNCTIONNUMBER2": {
+        "primary": "CFGDSFUNCTIONNUMBER2",
+        "wire": "CFGDSFUNCTIONNUMBER2",
+        "dir": "INPUT"
+      },
+      "CFGDSN0": {
+        "primary": "CFGDSN0",
+        "wire": "CFGDSN0",
+        "dir": "INPUT"
+      },
+      "CFGDSN1": {
+        "primary": "CFGDSN1",
+        "wire": "CFGDSN1",
+        "dir": "INPUT"
+      },
+      "CFGDSN2": {
+        "primary": "CFGDSN2",
+        "wire": "CFGDSN2",
+        "dir": "INPUT"
+      },
+      "CFGDSN3": {
+        "primary": "CFGDSN3",
+        "wire": "CFGDSN3",
+        "dir": "INPUT"
+      },
+      "CFGDSN4": {
+        "primary": "CFGDSN4",
+        "wire": "CFGDSN4",
+        "dir": "INPUT"
+      },
+      "CFGDSN5": {
+        "primary": "CFGDSN5",
+        "wire": "CFGDSN5",
+        "dir": "INPUT"
+      },
+      "CFGDSN6": {
+        "primary": "CFGDSN6",
+        "wire": "CFGDSN6",
+        "dir": "INPUT"
+      },
+      "CFGDSN7": {
+        "primary": "CFGDSN7",
+        "wire": "CFGDSN7",
+        "dir": "INPUT"
+      },
+      "CFGDSN8": {
+        "primary": "CFGDSN8",
+        "wire": "CFGDSN8",
+        "dir": "INPUT"
+      },
+      "CFGDSN9": {
+        "primary": "CFGDSN9",
+        "wire": "CFGDSN9",
+        "dir": "INPUT"
+      },
+      "CFGDSN10": {
+        "primary": "CFGDSN10",
+        "wire": "CFGDSN10",
+        "dir": "INPUT"
+      },
+      "CFGDSN11": {
+        "primary": "CFGDSN11",
+        "wire": "CFGDSN11",
+        "dir": "INPUT"
+      },
+      "CFGDSN12": {
+        "primary": "CFGDSN12",
+        "wire": "CFGDSN12",
+        "dir": "INPUT"
+      },
+      "CFGDSN13": {
+        "primary": "CFGDSN13",
+        "wire": "CFGDSN13",
+        "dir": "INPUT"
+      },
+      "CFGDSN14": {
+        "primary": "CFGDSN14",
+        "wire": "CFGDSN14",
+        "dir": "INPUT"
+      },
+      "CFGDSN15": {
+        "primary": "CFGDSN15",
+        "wire": "CFGDSN15",
+        "dir": "INPUT"
+      },
+      "CFGDSN16": {
+        "primary": "CFGDSN16",
+        "wire": "CFGDSN16",
+        "dir": "INPUT"
+      },
+      "CFGDSN17": {
+        "primary": "CFGDSN17",
+        "wire": "CFGDSN17",
+        "dir": "INPUT"
+      },
+      "CFGDSN18": {
+        "primary": "CFGDSN18",
+        "wire": "CFGDSN18",
+        "dir": "INPUT"
+      },
+      "CFGDSN19": {
+        "primary": "CFGDSN19",
+        "wire": "CFGDSN19",
+        "dir": "INPUT"
+      },
+      "CFGDSN20": {
+        "primary": "CFGDSN20",
+        "wire": "CFGDSN20",
+        "dir": "INPUT"
+      },
+      "CFGDSN21": {
+        "primary": "CFGDSN21",
+        "wire": "CFGDSN21",
+        "dir": "INPUT"
+      },
+      "CFGDSN22": {
+        "primary": "CFGDSN22",
+        "wire": "CFGDSN22",
+        "dir": "INPUT"
+      },
+      "CFGDSN23": {
+        "primary": "CFGDSN23",
+        "wire": "CFGDSN23",
+        "dir": "INPUT"
+      },
+      "CFGDSN24": {
+        "primary": "CFGDSN24",
+        "wire": "CFGDSN24",
+        "dir": "INPUT"
+      },
+      "CFGDSN25": {
+        "primary": "CFGDSN25",
+        "wire": "CFGDSN25",
+        "dir": "INPUT"
+      },
+      "CFGDSN26": {
+        "primary": "CFGDSN26",
+        "wire": "CFGDSN26",
+        "dir": "INPUT"
+      },
+      "CFGDSN27": {
+        "primary": "CFGDSN27",
+        "wire": "CFGDSN27",
+        "dir": "INPUT"
+      },
+      "CFGDSN28": {
+        "primary": "CFGDSN28",
+        "wire": "CFGDSN28",
+        "dir": "INPUT"
+      },
+      "CFGDSN29": {
+        "primary": "CFGDSN29",
+        "wire": "CFGDSN29",
+        "dir": "INPUT"
+      },
+      "CFGDSN30": {
+        "primary": "CFGDSN30",
+        "wire": "CFGDSN30",
+        "dir": "INPUT"
+      },
+      "CFGDSN31": {
+        "primary": "CFGDSN31",
+        "wire": "CFGDSN31",
+        "dir": "INPUT"
+      },
+      "CFGDSN32": {
+        "primary": "CFGDSN32",
+        "wire": "CFGDSN32",
+        "dir": "INPUT"
+      },
+      "CFGDSN33": {
+        "primary": "CFGDSN33",
+        "wire": "CFGDSN33",
+        "dir": "INPUT"
+      },
+      "CFGDSN34": {
+        "primary": "CFGDSN34",
+        "wire": "CFGDSN34",
+        "dir": "INPUT"
+      },
+      "CFGDSN35": {
+        "primary": "CFGDSN35",
+        "wire": "CFGDSN35",
+        "dir": "INPUT"
+      },
+      "CFGDSN36": {
+        "primary": "CFGDSN36",
+        "wire": "CFGDSN36",
+        "dir": "INPUT"
+      },
+      "CFGDSN37": {
+        "primary": "CFGDSN37",
+        "wire": "CFGDSN37",
+        "dir": "INPUT"
+      },
+      "CFGDSN38": {
+        "primary": "CFGDSN38",
+        "wire": "CFGDSN38",
+        "dir": "INPUT"
+      },
+      "CFGDSN39": {
+        "primary": "CFGDSN39",
+        "wire": "CFGDSN39",
+        "dir": "INPUT"
+      },
+      "CFGDSN40": {
+        "primary": "CFGDSN40",
+        "wire": "CFGDSN40",
+        "dir": "INPUT"
+      },
+      "CFGDSN41": {
+        "primary": "CFGDSN41",
+        "wire": "CFGDSN41",
+        "dir": "INPUT"
+      },
+      "CFGDSN42": {
+        "primary": "CFGDSN42",
+        "wire": "CFGDSN42",
+        "dir": "INPUT"
+      },
+      "CFGDSN43": {
+        "primary": "CFGDSN43",
+        "wire": "CFGDSN43",
+        "dir": "INPUT"
+      },
+      "CFGDSN44": {
+        "primary": "CFGDSN44",
+        "wire": "CFGDSN44",
+        "dir": "INPUT"
+      },
+      "CFGDSN45": {
+        "primary": "CFGDSN45",
+        "wire": "CFGDSN45",
+        "dir": "INPUT"
+      },
+      "CFGDSN46": {
+        "primary": "CFGDSN46",
+        "wire": "CFGDSN46",
+        "dir": "INPUT"
+      },
+      "CFGDSN47": {
+        "primary": "CFGDSN47",
+        "wire": "CFGDSN47",
+        "dir": "INPUT"
+      },
+      "CFGDSN48": {
+        "primary": "CFGDSN48",
+        "wire": "CFGDSN48",
+        "dir": "INPUT"
+      },
+      "CFGDSN49": {
+        "primary": "CFGDSN49",
+        "wire": "CFGDSN49",
+        "dir": "INPUT"
+      },
+      "CFGDSN50": {
+        "primary": "CFGDSN50",
+        "wire": "CFGDSN50",
+        "dir": "INPUT"
+      },
+      "CFGDSN51": {
+        "primary": "CFGDSN51",
+        "wire": "CFGDSN51",
+        "dir": "INPUT"
+      },
+      "CFGDSN52": {
+        "primary": "CFGDSN52",
+        "wire": "CFGDSN52",
+        "dir": "INPUT"
+      },
+      "CFGDSN53": {
+        "primary": "CFGDSN53",
+        "wire": "CFGDSN53",
+        "dir": "INPUT"
+      },
+      "CFGDSN54": {
+        "primary": "CFGDSN54",
+        "wire": "CFGDSN54",
+        "dir": "INPUT"
+      },
+      "CFGDSN55": {
+        "primary": "CFGDSN55",
+        "wire": "CFGDSN55",
+        "dir": "INPUT"
+      },
+      "CFGDSN56": {
+        "primary": "CFGDSN56",
+        "wire": "CFGDSN56",
+        "dir": "INPUT"
+      },
+      "CFGDSN57": {
+        "primary": "CFGDSN57",
+        "wire": "CFGDSN57",
+        "dir": "INPUT"
+      },
+      "CFGDSN58": {
+        "primary": "CFGDSN58",
+        "wire": "CFGDSN58",
+        "dir": "INPUT"
+      },
+      "CFGDSN59": {
+        "primary": "CFGDSN59",
+        "wire": "CFGDSN59",
+        "dir": "INPUT"
+      },
+      "CFGDSN60": {
+        "primary": "CFGDSN60",
+        "wire": "CFGDSN60",
+        "dir": "INPUT"
+      },
+      "CFGDSN61": {
+        "primary": "CFGDSN61",
+        "wire": "CFGDSN61",
+        "dir": "INPUT"
+      },
+      "CFGDSN62": {
+        "primary": "CFGDSN62",
+        "wire": "CFGDSN62",
+        "dir": "INPUT"
+      },
+      "CFGDSN63": {
+        "primary": "CFGDSN63",
+        "wire": "CFGDSN63",
+        "dir": "INPUT"
+      },
+      "CFGERRACSN": {
+        "primary": "CFGERRACSN",
+        "wire": "CFGERRACSN",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG0": {
+        "primary": "CFGERRAERHEADERLOG0",
+        "wire": "CFGERRAERHEADERLOG0",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG1": {
+        "primary": "CFGERRAERHEADERLOG1",
+        "wire": "CFGERRAERHEADERLOG1",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG2": {
+        "primary": "CFGERRAERHEADERLOG2",
+        "wire": "CFGERRAERHEADERLOG2",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG3": {
+        "primary": "CFGERRAERHEADERLOG3",
+        "wire": "CFGERRAERHEADERLOG3",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG4": {
+        "primary": "CFGERRAERHEADERLOG4",
+        "wire": "CFGERRAERHEADERLOG4",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG5": {
+        "primary": "CFGERRAERHEADERLOG5",
+        "wire": "CFGERRAERHEADERLOG5",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG6": {
+        "primary": "CFGERRAERHEADERLOG6",
+        "wire": "CFGERRAERHEADERLOG6",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG7": {
+        "primary": "CFGERRAERHEADERLOG7",
+        "wire": "CFGERRAERHEADERLOG7",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG8": {
+        "primary": "CFGERRAERHEADERLOG8",
+        "wire": "CFGERRAERHEADERLOG8",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG9": {
+        "primary": "CFGERRAERHEADERLOG9",
+        "wire": "CFGERRAERHEADERLOG9",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG10": {
+        "primary": "CFGERRAERHEADERLOG10",
+        "wire": "CFGERRAERHEADERLOG10",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG11": {
+        "primary": "CFGERRAERHEADERLOG11",
+        "wire": "CFGERRAERHEADERLOG11",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG12": {
+        "primary": "CFGERRAERHEADERLOG12",
+        "wire": "CFGERRAERHEADERLOG12",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG13": {
+        "primary": "CFGERRAERHEADERLOG13",
+        "wire": "CFGERRAERHEADERLOG13",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG14": {
+        "primary": "CFGERRAERHEADERLOG14",
+        "wire": "CFGERRAERHEADERLOG14",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG15": {
+        "primary": "CFGERRAERHEADERLOG15",
+        "wire": "CFGERRAERHEADERLOG15",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG16": {
+        "primary": "CFGERRAERHEADERLOG16",
+        "wire": "CFGERRAERHEADERLOG16",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG17": {
+        "primary": "CFGERRAERHEADERLOG17",
+        "wire": "CFGERRAERHEADERLOG17",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG18": {
+        "primary": "CFGERRAERHEADERLOG18",
+        "wire": "CFGERRAERHEADERLOG18",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG19": {
+        "primary": "CFGERRAERHEADERLOG19",
+        "wire": "CFGERRAERHEADERLOG19",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG20": {
+        "primary": "CFGERRAERHEADERLOG20",
+        "wire": "CFGERRAERHEADERLOG20",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG21": {
+        "primary": "CFGERRAERHEADERLOG21",
+        "wire": "CFGERRAERHEADERLOG21",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG22": {
+        "primary": "CFGERRAERHEADERLOG22",
+        "wire": "CFGERRAERHEADERLOG22",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG23": {
+        "primary": "CFGERRAERHEADERLOG23",
+        "wire": "CFGERRAERHEADERLOG23",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG24": {
+        "primary": "CFGERRAERHEADERLOG24",
+        "wire": "CFGERRAERHEADERLOG24",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG25": {
+        "primary": "CFGERRAERHEADERLOG25",
+        "wire": "CFGERRAERHEADERLOG25",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG26": {
+        "primary": "CFGERRAERHEADERLOG26",
+        "wire": "CFGERRAERHEADERLOG26",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG27": {
+        "primary": "CFGERRAERHEADERLOG27",
+        "wire": "CFGERRAERHEADERLOG27",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG28": {
+        "primary": "CFGERRAERHEADERLOG28",
+        "wire": "CFGERRAERHEADERLOG28",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG29": {
+        "primary": "CFGERRAERHEADERLOG29",
+        "wire": "CFGERRAERHEADERLOG29",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG30": {
+        "primary": "CFGERRAERHEADERLOG30",
+        "wire": "CFGERRAERHEADERLOG30",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG31": {
+        "primary": "CFGERRAERHEADERLOG31",
+        "wire": "CFGERRAERHEADERLOG31",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG32": {
+        "primary": "CFGERRAERHEADERLOG32",
+        "wire": "CFGERRAERHEADERLOG32",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG33": {
+        "primary": "CFGERRAERHEADERLOG33",
+        "wire": "CFGERRAERHEADERLOG33",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG34": {
+        "primary": "CFGERRAERHEADERLOG34",
+        "wire": "CFGERRAERHEADERLOG34",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG35": {
+        "primary": "CFGERRAERHEADERLOG35",
+        "wire": "CFGERRAERHEADERLOG35",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG36": {
+        "primary": "CFGERRAERHEADERLOG36",
+        "wire": "CFGERRAERHEADERLOG36",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG37": {
+        "primary": "CFGERRAERHEADERLOG37",
+        "wire": "CFGERRAERHEADERLOG37",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG38": {
+        "primary": "CFGERRAERHEADERLOG38",
+        "wire": "CFGERRAERHEADERLOG38",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG39": {
+        "primary": "CFGERRAERHEADERLOG39",
+        "wire": "CFGERRAERHEADERLOG39",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG40": {
+        "primary": "CFGERRAERHEADERLOG40",
+        "wire": "CFGERRAERHEADERLOG40",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG41": {
+        "primary": "CFGERRAERHEADERLOG41",
+        "wire": "CFGERRAERHEADERLOG41",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG42": {
+        "primary": "CFGERRAERHEADERLOG42",
+        "wire": "CFGERRAERHEADERLOG42",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG43": {
+        "primary": "CFGERRAERHEADERLOG43",
+        "wire": "CFGERRAERHEADERLOG43",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG44": {
+        "primary": "CFGERRAERHEADERLOG44",
+        "wire": "CFGERRAERHEADERLOG44",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG45": {
+        "primary": "CFGERRAERHEADERLOG45",
+        "wire": "CFGERRAERHEADERLOG45",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG46": {
+        "primary": "CFGERRAERHEADERLOG46",
+        "wire": "CFGERRAERHEADERLOG46",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG47": {
+        "primary": "CFGERRAERHEADERLOG47",
+        "wire": "CFGERRAERHEADERLOG47",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG48": {
+        "primary": "CFGERRAERHEADERLOG48",
+        "wire": "CFGERRAERHEADERLOG48",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG49": {
+        "primary": "CFGERRAERHEADERLOG49",
+        "wire": "CFGERRAERHEADERLOG49",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG50": {
+        "primary": "CFGERRAERHEADERLOG50",
+        "wire": "CFGERRAERHEADERLOG50",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG51": {
+        "primary": "CFGERRAERHEADERLOG51",
+        "wire": "CFGERRAERHEADERLOG51",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG52": {
+        "primary": "CFGERRAERHEADERLOG52",
+        "wire": "CFGERRAERHEADERLOG52",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG53": {
+        "primary": "CFGERRAERHEADERLOG53",
+        "wire": "CFGERRAERHEADERLOG53",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG54": {
+        "primary": "CFGERRAERHEADERLOG54",
+        "wire": "CFGERRAERHEADERLOG54",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG55": {
+        "primary": "CFGERRAERHEADERLOG55",
+        "wire": "CFGERRAERHEADERLOG55",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG56": {
+        "primary": "CFGERRAERHEADERLOG56",
+        "wire": "CFGERRAERHEADERLOG56",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG57": {
+        "primary": "CFGERRAERHEADERLOG57",
+        "wire": "CFGERRAERHEADERLOG57",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG58": {
+        "primary": "CFGERRAERHEADERLOG58",
+        "wire": "CFGERRAERHEADERLOG58",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG59": {
+        "primary": "CFGERRAERHEADERLOG59",
+        "wire": "CFGERRAERHEADERLOG59",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG60": {
+        "primary": "CFGERRAERHEADERLOG60",
+        "wire": "CFGERRAERHEADERLOG60",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG61": {
+        "primary": "CFGERRAERHEADERLOG61",
+        "wire": "CFGERRAERHEADERLOG61",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG62": {
+        "primary": "CFGERRAERHEADERLOG62",
+        "wire": "CFGERRAERHEADERLOG62",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG63": {
+        "primary": "CFGERRAERHEADERLOG63",
+        "wire": "CFGERRAERHEADERLOG63",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG64": {
+        "primary": "CFGERRAERHEADERLOG64",
+        "wire": "CFGERRAERHEADERLOG64",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG65": {
+        "primary": "CFGERRAERHEADERLOG65",
+        "wire": "CFGERRAERHEADERLOG65",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG66": {
+        "primary": "CFGERRAERHEADERLOG66",
+        "wire": "CFGERRAERHEADERLOG66",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG67": {
+        "primary": "CFGERRAERHEADERLOG67",
+        "wire": "CFGERRAERHEADERLOG67",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG68": {
+        "primary": "CFGERRAERHEADERLOG68",
+        "wire": "CFGERRAERHEADERLOG68",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG69": {
+        "primary": "CFGERRAERHEADERLOG69",
+        "wire": "CFGERRAERHEADERLOG69",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG70": {
+        "primary": "CFGERRAERHEADERLOG70",
+        "wire": "CFGERRAERHEADERLOG70",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG71": {
+        "primary": "CFGERRAERHEADERLOG71",
+        "wire": "CFGERRAERHEADERLOG71",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG72": {
+        "primary": "CFGERRAERHEADERLOG72",
+        "wire": "CFGERRAERHEADERLOG72",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG73": {
+        "primary": "CFGERRAERHEADERLOG73",
+        "wire": "CFGERRAERHEADERLOG73",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG74": {
+        "primary": "CFGERRAERHEADERLOG74",
+        "wire": "CFGERRAERHEADERLOG74",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG75": {
+        "primary": "CFGERRAERHEADERLOG75",
+        "wire": "CFGERRAERHEADERLOG75",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG76": {
+        "primary": "CFGERRAERHEADERLOG76",
+        "wire": "CFGERRAERHEADERLOG76",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG77": {
+        "primary": "CFGERRAERHEADERLOG77",
+        "wire": "CFGERRAERHEADERLOG77",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG78": {
+        "primary": "CFGERRAERHEADERLOG78",
+        "wire": "CFGERRAERHEADERLOG78",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG79": {
+        "primary": "CFGERRAERHEADERLOG79",
+        "wire": "CFGERRAERHEADERLOG79",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG80": {
+        "primary": "CFGERRAERHEADERLOG80",
+        "wire": "CFGERRAERHEADERLOG80",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG81": {
+        "primary": "CFGERRAERHEADERLOG81",
+        "wire": "CFGERRAERHEADERLOG81",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG82": {
+        "primary": "CFGERRAERHEADERLOG82",
+        "wire": "CFGERRAERHEADERLOG82",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG83": {
+        "primary": "CFGERRAERHEADERLOG83",
+        "wire": "CFGERRAERHEADERLOG83",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG84": {
+        "primary": "CFGERRAERHEADERLOG84",
+        "wire": "CFGERRAERHEADERLOG84",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG85": {
+        "primary": "CFGERRAERHEADERLOG85",
+        "wire": "CFGERRAERHEADERLOG85",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG86": {
+        "primary": "CFGERRAERHEADERLOG86",
+        "wire": "CFGERRAERHEADERLOG86",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG87": {
+        "primary": "CFGERRAERHEADERLOG87",
+        "wire": "CFGERRAERHEADERLOG87",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG88": {
+        "primary": "CFGERRAERHEADERLOG88",
+        "wire": "CFGERRAERHEADERLOG88",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG89": {
+        "primary": "CFGERRAERHEADERLOG89",
+        "wire": "CFGERRAERHEADERLOG89",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG90": {
+        "primary": "CFGERRAERHEADERLOG90",
+        "wire": "CFGERRAERHEADERLOG90",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG91": {
+        "primary": "CFGERRAERHEADERLOG91",
+        "wire": "CFGERRAERHEADERLOG91",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG92": {
+        "primary": "CFGERRAERHEADERLOG92",
+        "wire": "CFGERRAERHEADERLOG92",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG93": {
+        "primary": "CFGERRAERHEADERLOG93",
+        "wire": "CFGERRAERHEADERLOG93",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG94": {
+        "primary": "CFGERRAERHEADERLOG94",
+        "wire": "CFGERRAERHEADERLOG94",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG95": {
+        "primary": "CFGERRAERHEADERLOG95",
+        "wire": "CFGERRAERHEADERLOG95",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG96": {
+        "primary": "CFGERRAERHEADERLOG96",
+        "wire": "CFGERRAERHEADERLOG96",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG97": {
+        "primary": "CFGERRAERHEADERLOG97",
+        "wire": "CFGERRAERHEADERLOG97",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG98": {
+        "primary": "CFGERRAERHEADERLOG98",
+        "wire": "CFGERRAERHEADERLOG98",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG99": {
+        "primary": "CFGERRAERHEADERLOG99",
+        "wire": "CFGERRAERHEADERLOG99",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG100": {
+        "primary": "CFGERRAERHEADERLOG100",
+        "wire": "CFGERRAERHEADERLOG100",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG101": {
+        "primary": "CFGERRAERHEADERLOG101",
+        "wire": "CFGERRAERHEADERLOG101",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG102": {
+        "primary": "CFGERRAERHEADERLOG102",
+        "wire": "CFGERRAERHEADERLOG102",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG103": {
+        "primary": "CFGERRAERHEADERLOG103",
+        "wire": "CFGERRAERHEADERLOG103",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG104": {
+        "primary": "CFGERRAERHEADERLOG104",
+        "wire": "CFGERRAERHEADERLOG104",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG105": {
+        "primary": "CFGERRAERHEADERLOG105",
+        "wire": "CFGERRAERHEADERLOG105",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG106": {
+        "primary": "CFGERRAERHEADERLOG106",
+        "wire": "CFGERRAERHEADERLOG106",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG107": {
+        "primary": "CFGERRAERHEADERLOG107",
+        "wire": "CFGERRAERHEADERLOG107",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG108": {
+        "primary": "CFGERRAERHEADERLOG108",
+        "wire": "CFGERRAERHEADERLOG108",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG109": {
+        "primary": "CFGERRAERHEADERLOG109",
+        "wire": "CFGERRAERHEADERLOG109",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG110": {
+        "primary": "CFGERRAERHEADERLOG110",
+        "wire": "CFGERRAERHEADERLOG110",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG111": {
+        "primary": "CFGERRAERHEADERLOG111",
+        "wire": "CFGERRAERHEADERLOG111",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG112": {
+        "primary": "CFGERRAERHEADERLOG112",
+        "wire": "CFGERRAERHEADERLOG112",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG113": {
+        "primary": "CFGERRAERHEADERLOG113",
+        "wire": "CFGERRAERHEADERLOG113",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG114": {
+        "primary": "CFGERRAERHEADERLOG114",
+        "wire": "CFGERRAERHEADERLOG114",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG115": {
+        "primary": "CFGERRAERHEADERLOG115",
+        "wire": "CFGERRAERHEADERLOG115",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG116": {
+        "primary": "CFGERRAERHEADERLOG116",
+        "wire": "CFGERRAERHEADERLOG116",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG117": {
+        "primary": "CFGERRAERHEADERLOG117",
+        "wire": "CFGERRAERHEADERLOG117",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG118": {
+        "primary": "CFGERRAERHEADERLOG118",
+        "wire": "CFGERRAERHEADERLOG118",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG119": {
+        "primary": "CFGERRAERHEADERLOG119",
+        "wire": "CFGERRAERHEADERLOG119",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG120": {
+        "primary": "CFGERRAERHEADERLOG120",
+        "wire": "CFGERRAERHEADERLOG120",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG121": {
+        "primary": "CFGERRAERHEADERLOG121",
+        "wire": "CFGERRAERHEADERLOG121",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG122": {
+        "primary": "CFGERRAERHEADERLOG122",
+        "wire": "CFGERRAERHEADERLOG122",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG123": {
+        "primary": "CFGERRAERHEADERLOG123",
+        "wire": "CFGERRAERHEADERLOG123",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG124": {
+        "primary": "CFGERRAERHEADERLOG124",
+        "wire": "CFGERRAERHEADERLOG124",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG125": {
+        "primary": "CFGERRAERHEADERLOG125",
+        "wire": "CFGERRAERHEADERLOG125",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG126": {
+        "primary": "CFGERRAERHEADERLOG126",
+        "wire": "CFGERRAERHEADERLOG126",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOG127": {
+        "primary": "CFGERRAERHEADERLOG127",
+        "wire": "CFGERRAERHEADERLOG127",
+        "dir": "INPUT"
+      },
+      "CFGERRAERHEADERLOGSETN": {
+        "primary": "CFGERRAERHEADERLOGSETN",
+        "wire": "CFGERRAERHEADERLOGSETN",
+        "dir": "OUTPUT"
+      },
+      "CFGERRATOMICEGRESSBLOCKEDN": {
+        "primary": "CFGERRATOMICEGRESSBLOCKEDN",
+        "wire": "CFGERRATOMICEGRESSBLOCKEDN",
+        "dir": "INPUT"
+      },
+      "CFGERRCORN": {
+        "primary": "CFGERRCORN",
+        "wire": "CFGERRCORN",
+        "dir": "INPUT"
+      },
+      "CFGERRCPLABORTN": {
+        "primary": "CFGERRCPLABORTN",
+        "wire": "CFGERRCPLABORTN",
+        "dir": "INPUT"
+      },
+      "CFGERRCPLRDYN": {
+        "primary": "CFGERRCPLRDYN",
+        "wire": "CFGERRCPLRDYN",
+        "dir": "OUTPUT"
+      },
+      "CFGERRCPLTIMEOUTN": {
+        "primary": "CFGERRCPLTIMEOUTN",
+        "wire": "CFGERRCPLTIMEOUTN",
+        "dir": "INPUT"
+      },
+      "CFGERRCPLUNEXPECTN": {
+        "primary": "CFGERRCPLUNEXPECTN",
+        "wire": "CFGERRCPLUNEXPECTN",
+        "dir": "INPUT"
+      },
+      "CFGERRECRCN": {
+        "primary": "CFGERRECRCN",
+        "wire": "CFGERRECRCN",
+        "dir": "INPUT"
+      },
+      "CFGERRINTERNALCORN": {
+        "primary": "CFGERRINTERNALCORN",
+        "wire": "CFGERRINTERNALCORN",
+        "dir": "INPUT"
+      },
+      "CFGERRINTERNALUNCORN": {
+        "primary": "CFGERRINTERNALUNCORN",
+        "wire": "CFGERRINTERNALUNCORN",
+        "dir": "INPUT"
+      },
+      "CFGERRLOCKEDN": {
+        "primary": "CFGERRLOCKEDN",
+        "wire": "CFGERRLOCKEDN",
+        "dir": "INPUT"
+      },
+      "CFGERRMALFORMEDN": {
+        "primary": "CFGERRMALFORMEDN",
+        "wire": "CFGERRMALFORMEDN",
+        "dir": "INPUT"
+      },
+      "CFGERRMCBLOCKEDN": {
+        "primary": "CFGERRMCBLOCKEDN",
+        "wire": "CFGERRMCBLOCKEDN",
+        "dir": "INPUT"
+      },
+      "CFGERRNORECOVERYN": {
+        "primary": "CFGERRNORECOVERYN",
+        "wire": "CFGERRNORECOVERYN",
+        "dir": "INPUT"
+      },
+      "CFGERRPOISONEDN": {
+        "primary": "CFGERRPOISONEDN",
+        "wire": "CFGERRPOISONEDN",
+        "dir": "INPUT"
+      },
+      "CFGERRPOSTEDN": {
+        "primary": "CFGERRPOSTEDN",
+        "wire": "CFGERRPOSTEDN",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER0": {
+        "primary": "CFGERRTLPCPLHEADER0",
+        "wire": "CFGERRTLPCPLHEADER0",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER1": {
+        "primary": "CFGERRTLPCPLHEADER1",
+        "wire": "CFGERRTLPCPLHEADER1",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER2": {
+        "primary": "CFGERRTLPCPLHEADER2",
+        "wire": "CFGERRTLPCPLHEADER2",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER3": {
+        "primary": "CFGERRTLPCPLHEADER3",
+        "wire": "CFGERRTLPCPLHEADER3",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER4": {
+        "primary": "CFGERRTLPCPLHEADER4",
+        "wire": "CFGERRTLPCPLHEADER4",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER5": {
+        "primary": "CFGERRTLPCPLHEADER5",
+        "wire": "CFGERRTLPCPLHEADER5",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER6": {
+        "primary": "CFGERRTLPCPLHEADER6",
+        "wire": "CFGERRTLPCPLHEADER6",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER7": {
+        "primary": "CFGERRTLPCPLHEADER7",
+        "wire": "CFGERRTLPCPLHEADER7",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER8": {
+        "primary": "CFGERRTLPCPLHEADER8",
+        "wire": "CFGERRTLPCPLHEADER8",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER9": {
+        "primary": "CFGERRTLPCPLHEADER9",
+        "wire": "CFGERRTLPCPLHEADER9",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER10": {
+        "primary": "CFGERRTLPCPLHEADER10",
+        "wire": "CFGERRTLPCPLHEADER10",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER11": {
+        "primary": "CFGERRTLPCPLHEADER11",
+        "wire": "CFGERRTLPCPLHEADER11",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER12": {
+        "primary": "CFGERRTLPCPLHEADER12",
+        "wire": "CFGERRTLPCPLHEADER12",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER13": {
+        "primary": "CFGERRTLPCPLHEADER13",
+        "wire": "CFGERRTLPCPLHEADER13",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER14": {
+        "primary": "CFGERRTLPCPLHEADER14",
+        "wire": "CFGERRTLPCPLHEADER14",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER15": {
+        "primary": "CFGERRTLPCPLHEADER15",
+        "wire": "CFGERRTLPCPLHEADER15",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER16": {
+        "primary": "CFGERRTLPCPLHEADER16",
+        "wire": "CFGERRTLPCPLHEADER16",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER17": {
+        "primary": "CFGERRTLPCPLHEADER17",
+        "wire": "CFGERRTLPCPLHEADER17",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER18": {
+        "primary": "CFGERRTLPCPLHEADER18",
+        "wire": "CFGERRTLPCPLHEADER18",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER19": {
+        "primary": "CFGERRTLPCPLHEADER19",
+        "wire": "CFGERRTLPCPLHEADER19",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER20": {
+        "primary": "CFGERRTLPCPLHEADER20",
+        "wire": "CFGERRTLPCPLHEADER20",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER21": {
+        "primary": "CFGERRTLPCPLHEADER21",
+        "wire": "CFGERRTLPCPLHEADER21",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER22": {
+        "primary": "CFGERRTLPCPLHEADER22",
+        "wire": "CFGERRTLPCPLHEADER22",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER23": {
+        "primary": "CFGERRTLPCPLHEADER23",
+        "wire": "CFGERRTLPCPLHEADER23",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER24": {
+        "primary": "CFGERRTLPCPLHEADER24",
+        "wire": "CFGERRTLPCPLHEADER24",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER25": {
+        "primary": "CFGERRTLPCPLHEADER25",
+        "wire": "CFGERRTLPCPLHEADER25",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER26": {
+        "primary": "CFGERRTLPCPLHEADER26",
+        "wire": "CFGERRTLPCPLHEADER26",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER27": {
+        "primary": "CFGERRTLPCPLHEADER27",
+        "wire": "CFGERRTLPCPLHEADER27",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER28": {
+        "primary": "CFGERRTLPCPLHEADER28",
+        "wire": "CFGERRTLPCPLHEADER28",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER29": {
+        "primary": "CFGERRTLPCPLHEADER29",
+        "wire": "CFGERRTLPCPLHEADER29",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER30": {
+        "primary": "CFGERRTLPCPLHEADER30",
+        "wire": "CFGERRTLPCPLHEADER30",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER31": {
+        "primary": "CFGERRTLPCPLHEADER31",
+        "wire": "CFGERRTLPCPLHEADER31",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER32": {
+        "primary": "CFGERRTLPCPLHEADER32",
+        "wire": "CFGERRTLPCPLHEADER32",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER33": {
+        "primary": "CFGERRTLPCPLHEADER33",
+        "wire": "CFGERRTLPCPLHEADER33",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER34": {
+        "primary": "CFGERRTLPCPLHEADER34",
+        "wire": "CFGERRTLPCPLHEADER34",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER35": {
+        "primary": "CFGERRTLPCPLHEADER35",
+        "wire": "CFGERRTLPCPLHEADER35",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER36": {
+        "primary": "CFGERRTLPCPLHEADER36",
+        "wire": "CFGERRTLPCPLHEADER36",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER37": {
+        "primary": "CFGERRTLPCPLHEADER37",
+        "wire": "CFGERRTLPCPLHEADER37",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER38": {
+        "primary": "CFGERRTLPCPLHEADER38",
+        "wire": "CFGERRTLPCPLHEADER38",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER39": {
+        "primary": "CFGERRTLPCPLHEADER39",
+        "wire": "CFGERRTLPCPLHEADER39",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER40": {
+        "primary": "CFGERRTLPCPLHEADER40",
+        "wire": "CFGERRTLPCPLHEADER40",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER41": {
+        "primary": "CFGERRTLPCPLHEADER41",
+        "wire": "CFGERRTLPCPLHEADER41",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER42": {
+        "primary": "CFGERRTLPCPLHEADER42",
+        "wire": "CFGERRTLPCPLHEADER42",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER43": {
+        "primary": "CFGERRTLPCPLHEADER43",
+        "wire": "CFGERRTLPCPLHEADER43",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER44": {
+        "primary": "CFGERRTLPCPLHEADER44",
+        "wire": "CFGERRTLPCPLHEADER44",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER45": {
+        "primary": "CFGERRTLPCPLHEADER45",
+        "wire": "CFGERRTLPCPLHEADER45",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER46": {
+        "primary": "CFGERRTLPCPLHEADER46",
+        "wire": "CFGERRTLPCPLHEADER46",
+        "dir": "INPUT"
+      },
+      "CFGERRTLPCPLHEADER47": {
+        "primary": "CFGERRTLPCPLHEADER47",
+        "wire": "CFGERRTLPCPLHEADER47",
+        "dir": "INPUT"
+      },
+      "CFGERRURN": {
+        "primary": "CFGERRURN",
+        "wire": "CFGERRURN",
+        "dir": "INPUT"
+      },
+      "CFGFORCECOMMONCLOCKOFF": {
+        "primary": "CFGFORCECOMMONCLOCKOFF",
+        "wire": "CFGFORCECOMMONCLOCKOFF",
+        "dir": "INPUT"
+      },
+      "CFGFORCEEXTENDEDSYNCON": {
+        "primary": "CFGFORCEEXTENDEDSYNCON",
+        "wire": "CFGFORCEEXTENDEDSYNCON",
+        "dir": "INPUT"
+      },
+      "CFGFORCEMPS0": {
+        "primary": "CFGFORCEMPS0",
+        "wire": "CFGFORCEMPS0",
+        "dir": "INPUT"
+      },
+      "CFGFORCEMPS1": {
+        "primary": "CFGFORCEMPS1",
+        "wire": "CFGFORCEMPS1",
+        "dir": "INPUT"
+      },
+      "CFGFORCEMPS2": {
+        "primary": "CFGFORCEMPS2",
+        "wire": "CFGFORCEMPS2",
+        "dir": "INPUT"
+      },
+      "CFGINTERRUPTASSERTN": {
+        "primary": "CFGINTERRUPTASSERTN",
+        "wire": "CFGINTERRUPTASSERTN",
+        "dir": "INPUT"
+      },
+      "CFGINTERRUPTDI0": {
+        "primary": "CFGINTERRUPTDI0",
+        "wire": "CFGINTERRUPTDI0",
+        "dir": "INPUT"
+      },
+      "CFGINTERRUPTDI1": {
+        "primary": "CFGINTERRUPTDI1",
+        "wire": "CFGINTERRUPTDI1",
+        "dir": "INPUT"
+      },
+      "CFGINTERRUPTDI2": {
+        "primary": "CFGINTERRUPTDI2",
+        "wire": "CFGINTERRUPTDI2",
+        "dir": "INPUT"
+      },
+      "CFGINTERRUPTDI3": {
+        "primary": "CFGINTERRUPTDI3",
+        "wire": "CFGINTERRUPTDI3",
+        "dir": "INPUT"
+      },
+      "CFGINTERRUPTDI4": {
+        "primary": "CFGINTERRUPTDI4",
+        "wire": "CFGINTERRUPTDI4",
+        "dir": "INPUT"
+      },
+      "CFGINTERRUPTDI5": {
+        "primary": "CFGINTERRUPTDI5",
+        "wire": "CFGINTERRUPTDI5",
+        "dir": "INPUT"
+      },
+      "CFGINTERRUPTDI6": {
+        "primary": "CFGINTERRUPTDI6",
+        "wire": "CFGINTERRUPTDI6",
+        "dir": "INPUT"
+      },
+      "CFGINTERRUPTDI7": {
+        "primary": "CFGINTERRUPTDI7",
+        "wire": "CFGINTERRUPTDI7",
+        "dir": "INPUT"
+      },
+      "CFGINTERRUPTDO0": {
+        "primary": "CFGINTERRUPTDO0",
+        "wire": "CFGINTERRUPTDO0",
+        "dir": "OUTPUT"
+      },
+      "CFGINTERRUPTDO1": {
+        "primary": "CFGINTERRUPTDO1",
+        "wire": "CFGINTERRUPTDO1",
+        "dir": "OUTPUT"
+      },
+      "CFGINTERRUPTDO2": {
+        "primary": "CFGINTERRUPTDO2",
+        "wire": "CFGINTERRUPTDO2",
+        "dir": "OUTPUT"
+      },
+      "CFGINTERRUPTDO3": {
+        "primary": "CFGINTERRUPTDO3",
+        "wire": "CFGINTERRUPTDO3",
+        "dir": "OUTPUT"
+      },
+      "CFGINTERRUPTDO4": {
+        "primary": "CFGINTERRUPTDO4",
+        "wire": "CFGINTERRUPTDO4",
+        "dir": "OUTPUT"
+      },
+      "CFGINTERRUPTDO5": {
+        "primary": "CFGINTERRUPTDO5",
+        "wire": "CFGINTERRUPTDO5",
+        "dir": "OUTPUT"
+      },
+      "CFGINTERRUPTDO6": {
+        "primary": "CFGINTERRUPTDO6",
+        "wire": "CFGINTERRUPTDO6",
+        "dir": "OUTPUT"
+      },
+      "CFGINTERRUPTDO7": {
+        "primary": "CFGINTERRUPTDO7",
+        "wire": "CFGINTERRUPTDO7",
+        "dir": "OUTPUT"
+      },
+      "CFGINTERRUPTMMENABLE0": {
+        "primary": "CFGINTERRUPTMMENABLE0",
+        "wire": "CFGINTERRUPTMMENABLE0",
+        "dir": "OUTPUT"
+      },
+      "CFGINTERRUPTMMENABLE1": {
+        "primary": "CFGINTERRUPTMMENABLE1",
+        "wire": "CFGINTERRUPTMMENABLE1",
+        "dir": "OUTPUT"
+      },
+      "CFGINTERRUPTMMENABLE2": {
+        "primary": "CFGINTERRUPTMMENABLE2",
+        "wire": "CFGINTERRUPTMMENABLE2",
+        "dir": "OUTPUT"
+      },
+      "CFGINTERRUPTMSIENABLE": {
+        "primary": "CFGINTERRUPTMSIENABLE",
+        "wire": "CFGINTERRUPTMSIENABLE",
+        "dir": "OUTPUT"
+      },
+      "CFGINTERRUPTMSIXENABLE": {
+        "primary": "CFGINTERRUPTMSIXENABLE",
+        "wire": "CFGINTERRUPTMSIXENABLE",
+        "dir": "OUTPUT"
+      },
+      "CFGINTERRUPTMSIXFM": {
+        "primary": "CFGINTERRUPTMSIXFM",
+        "wire": "CFGINTERRUPTMSIXFM",
+        "dir": "OUTPUT"
+      },
+      "CFGINTERRUPTN": {
+        "primary": "CFGINTERRUPTN",
+        "wire": "CFGINTERRUPTN",
+        "dir": "INPUT"
+      },
+      "CFGINTERRUPTRDYN": {
+        "primary": "CFGINTERRUPTRDYN",
+        "wire": "CFGINTERRUPTRDYN",
+        "dir": "OUTPUT"
+      },
+      "CFGINTERRUPTSTATN": {
+        "primary": "CFGINTERRUPTSTATN",
+        "wire": "CFGINTERRUPTSTATN",
+        "dir": "INPUT"
+      },
+      "CFGLINKCONTROLASPMCONTROL0": {
+        "primary": "CFGLINKCONTROLASPMCONTROL0",
+        "wire": "CFGLINKCONTROLASPMCONTROL0",
+        "dir": "OUTPUT"
+      },
+      "CFGLINKCONTROLASPMCONTROL1": {
+        "primary": "CFGLINKCONTROLASPMCONTROL1",
+        "wire": "CFGLINKCONTROLASPMCONTROL1",
+        "dir": "OUTPUT"
+      },
+      "CFGLINKCONTROLAUTOBANDWIDTHINTEN": {
+        "primary": "CFGLINKCONTROLAUTOBANDWIDTHINTEN",
+        "wire": "CFGLINKCONTROLAUTOBANDWIDTHINTEN",
+        "dir": "OUTPUT"
+      },
+      "CFGLINKCONTROLBANDWIDTHINTEN": {
+        "primary": "CFGLINKCONTROLBANDWIDTHINTEN",
+        "wire": "CFGLINKCONTROLBANDWIDTHINTEN",
+        "dir": "OUTPUT"
+      },
+      "CFGLINKCONTROLCLOCKPMEN": {
+        "primary": "CFGLINKCONTROLCLOCKPMEN",
+        "wire": "CFGLINKCONTROLCLOCKPMEN",
+        "dir": "OUTPUT"
+      },
+      "CFGLINKCONTROLCOMMONCLOCK": {
+        "primary": "CFGLINKCONTROLCOMMONCLOCK",
+        "wire": "CFGLINKCONTROLCOMMONCLOCK",
+        "dir": "OUTPUT"
+      },
+      "CFGLINKCONTROLEXTENDEDSYNC": {
+        "primary": "CFGLINKCONTROLEXTENDEDSYNC",
+        "wire": "CFGLINKCONTROLEXTENDEDSYNC",
+        "dir": "OUTPUT"
+      },
+      "CFGLINKCONTROLHWAUTOWIDTHDIS": {
+        "primary": "CFGLINKCONTROLHWAUTOWIDTHDIS",
+        "wire": "CFGLINKCONTROLHWAUTOWIDTHDIS",
+        "dir": "OUTPUT"
+      },
+      "CFGLINKCONTROLLINKDISABLE": {
+        "primary": "CFGLINKCONTROLLINKDISABLE",
+        "wire": "CFGLINKCONTROLLINKDISABLE",
+        "dir": "OUTPUT"
+      },
+      "CFGLINKCONTROLRCB": {
+        "primary": "CFGLINKCONTROLRCB",
+        "wire": "CFGLINKCONTROLRCB",
+        "dir": "OUTPUT"
+      },
+      "CFGLINKCONTROLRETRAINLINK": {
+        "primary": "CFGLINKCONTROLRETRAINLINK",
+        "wire": "CFGLINKCONTROLRETRAINLINK",
+        "dir": "OUTPUT"
+      },
+      "CFGLINKSTATUSAUTOBANDWIDTHSTATUS": {
+        "primary": "CFGLINKSTATUSAUTOBANDWIDTHSTATUS",
+        "wire": "CFGLINKSTATUSAUTOBANDWIDTHSTATUS",
+        "dir": "OUTPUT"
+      },
+      "CFGLINKSTATUSBANDWIDTHSTATUS": {
+        "primary": "CFGLINKSTATUSBANDWIDTHSTATUS",
+        "wire": "CFGLINKSTATUSBANDWIDTHSTATUS",
+        "dir": "OUTPUT"
+      },
+      "CFGLINKSTATUSCURRENTSPEED0": {
+        "primary": "CFGLINKSTATUSCURRENTSPEED0",
+        "wire": "CFGLINKSTATUSCURRENTSPEED0",
+        "dir": "OUTPUT"
+      },
+      "CFGLINKSTATUSCURRENTSPEED1": {
+        "primary": "CFGLINKSTATUSCURRENTSPEED1",
+        "wire": "CFGLINKSTATUSCURRENTSPEED1",
+        "dir": "OUTPUT"
+      },
+      "CFGLINKSTATUSDLLACTIVE": {
+        "primary": "CFGLINKSTATUSDLLACTIVE",
+        "wire": "CFGLINKSTATUSDLLACTIVE",
+        "dir": "OUTPUT"
+      },
+      "CFGLINKSTATUSLINKTRAINING": {
+        "primary": "CFGLINKSTATUSLINKTRAINING",
+        "wire": "CFGLINKSTATUSLINKTRAINING",
+        "dir": "OUTPUT"
+      },
+      "CFGLINKSTATUSNEGOTIATEDWIDTH0": {
+        "primary": "CFGLINKSTATUSNEGOTIATEDWIDTH0",
+        "wire": "CFGLINKSTATUSNEGOTIATEDWIDTH0",
+        "dir": "OUTPUT"
+      },
+      "CFGLINKSTATUSNEGOTIATEDWIDTH1": {
+        "primary": "CFGLINKSTATUSNEGOTIATEDWIDTH1",
+        "wire": "CFGLINKSTATUSNEGOTIATEDWIDTH1",
+        "dir": "OUTPUT"
+      },
+      "CFGLINKSTATUSNEGOTIATEDWIDTH2": {
+        "primary": "CFGLINKSTATUSNEGOTIATEDWIDTH2",
+        "wire": "CFGLINKSTATUSNEGOTIATEDWIDTH2",
+        "dir": "OUTPUT"
+      },
+      "CFGLINKSTATUSNEGOTIATEDWIDTH3": {
+        "primary": "CFGLINKSTATUSNEGOTIATEDWIDTH3",
+        "wire": "CFGLINKSTATUSNEGOTIATEDWIDTH3",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTBYTEENN0": {
+        "primary": "CFGMGMTBYTEENN0",
+        "wire": "CFGMGMTBYTEENN0",
+        "dir": "INPUT"
+      },
+      "CFGMGMTBYTEENN1": {
+        "primary": "CFGMGMTBYTEENN1",
+        "wire": "CFGMGMTBYTEENN1",
+        "dir": "INPUT"
+      },
+      "CFGMGMTBYTEENN2": {
+        "primary": "CFGMGMTBYTEENN2",
+        "wire": "CFGMGMTBYTEENN2",
+        "dir": "INPUT"
+      },
+      "CFGMGMTBYTEENN3": {
+        "primary": "CFGMGMTBYTEENN3",
+        "wire": "CFGMGMTBYTEENN3",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDI0": {
+        "primary": "CFGMGMTDI0",
+        "wire": "CFGMGMTDI0",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDI1": {
+        "primary": "CFGMGMTDI1",
+        "wire": "CFGMGMTDI1",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDI2": {
+        "primary": "CFGMGMTDI2",
+        "wire": "CFGMGMTDI2",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDI3": {
+        "primary": "CFGMGMTDI3",
+        "wire": "CFGMGMTDI3",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDI4": {
+        "primary": "CFGMGMTDI4",
+        "wire": "CFGMGMTDI4",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDI5": {
+        "primary": "CFGMGMTDI5",
+        "wire": "CFGMGMTDI5",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDI6": {
+        "primary": "CFGMGMTDI6",
+        "wire": "CFGMGMTDI6",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDI7": {
+        "primary": "CFGMGMTDI7",
+        "wire": "CFGMGMTDI7",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDI8": {
+        "primary": "CFGMGMTDI8",
+        "wire": "CFGMGMTDI8",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDI9": {
+        "primary": "CFGMGMTDI9",
+        "wire": "CFGMGMTDI9",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDI10": {
+        "primary": "CFGMGMTDI10",
+        "wire": "CFGMGMTDI10",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDI11": {
+        "primary": "CFGMGMTDI11",
+        "wire": "CFGMGMTDI11",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDI12": {
+        "primary": "CFGMGMTDI12",
+        "wire": "CFGMGMTDI12",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDI13": {
+        "primary": "CFGMGMTDI13",
+        "wire": "CFGMGMTDI13",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDI14": {
+        "primary": "CFGMGMTDI14",
+        "wire": "CFGMGMTDI14",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDI15": {
+        "primary": "CFGMGMTDI15",
+        "wire": "CFGMGMTDI15",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDI16": {
+        "primary": "CFGMGMTDI16",
+        "wire": "CFGMGMTDI16",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDI17": {
+        "primary": "CFGMGMTDI17",
+        "wire": "CFGMGMTDI17",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDI18": {
+        "primary": "CFGMGMTDI18",
+        "wire": "CFGMGMTDI18",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDI19": {
+        "primary": "CFGMGMTDI19",
+        "wire": "CFGMGMTDI19",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDI20": {
+        "primary": "CFGMGMTDI20",
+        "wire": "CFGMGMTDI20",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDI21": {
+        "primary": "CFGMGMTDI21",
+        "wire": "CFGMGMTDI21",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDI22": {
+        "primary": "CFGMGMTDI22",
+        "wire": "CFGMGMTDI22",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDI23": {
+        "primary": "CFGMGMTDI23",
+        "wire": "CFGMGMTDI23",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDI24": {
+        "primary": "CFGMGMTDI24",
+        "wire": "CFGMGMTDI24",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDI25": {
+        "primary": "CFGMGMTDI25",
+        "wire": "CFGMGMTDI25",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDI26": {
+        "primary": "CFGMGMTDI26",
+        "wire": "CFGMGMTDI26",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDI27": {
+        "primary": "CFGMGMTDI27",
+        "wire": "CFGMGMTDI27",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDI28": {
+        "primary": "CFGMGMTDI28",
+        "wire": "CFGMGMTDI28",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDI29": {
+        "primary": "CFGMGMTDI29",
+        "wire": "CFGMGMTDI29",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDI30": {
+        "primary": "CFGMGMTDI30",
+        "wire": "CFGMGMTDI30",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDI31": {
+        "primary": "CFGMGMTDI31",
+        "wire": "CFGMGMTDI31",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDO0": {
+        "primary": "CFGMGMTDO0",
+        "wire": "CFGMGMTDO0",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTDO1": {
+        "primary": "CFGMGMTDO1",
+        "wire": "CFGMGMTDO1",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTDO2": {
+        "primary": "CFGMGMTDO2",
+        "wire": "CFGMGMTDO2",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTDO3": {
+        "primary": "CFGMGMTDO3",
+        "wire": "CFGMGMTDO3",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTDO4": {
+        "primary": "CFGMGMTDO4",
+        "wire": "CFGMGMTDO4",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTDO5": {
+        "primary": "CFGMGMTDO5",
+        "wire": "CFGMGMTDO5",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTDO6": {
+        "primary": "CFGMGMTDO6",
+        "wire": "CFGMGMTDO6",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTDO7": {
+        "primary": "CFGMGMTDO7",
+        "wire": "CFGMGMTDO7",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTDO8": {
+        "primary": "CFGMGMTDO8",
+        "wire": "CFGMGMTDO8",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTDO9": {
+        "primary": "CFGMGMTDO9",
+        "wire": "CFGMGMTDO9",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTDO10": {
+        "primary": "CFGMGMTDO10",
+        "wire": "CFGMGMTDO10",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTDO11": {
+        "primary": "CFGMGMTDO11",
+        "wire": "CFGMGMTDO11",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTDO12": {
+        "primary": "CFGMGMTDO12",
+        "wire": "CFGMGMTDO12",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTDO13": {
+        "primary": "CFGMGMTDO13",
+        "wire": "CFGMGMTDO13",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTDO14": {
+        "primary": "CFGMGMTDO14",
+        "wire": "CFGMGMTDO14",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTDO15": {
+        "primary": "CFGMGMTDO15",
+        "wire": "CFGMGMTDO15",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTDO16": {
+        "primary": "CFGMGMTDO16",
+        "wire": "CFGMGMTDO16",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTDO17": {
+        "primary": "CFGMGMTDO17",
+        "wire": "CFGMGMTDO17",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTDO18": {
+        "primary": "CFGMGMTDO18",
+        "wire": "CFGMGMTDO18",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTDO19": {
+        "primary": "CFGMGMTDO19",
+        "wire": "CFGMGMTDO19",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTDO20": {
+        "primary": "CFGMGMTDO20",
+        "wire": "CFGMGMTDO20",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTDO21": {
+        "primary": "CFGMGMTDO21",
+        "wire": "CFGMGMTDO21",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTDO22": {
+        "primary": "CFGMGMTDO22",
+        "wire": "CFGMGMTDO22",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTDO23": {
+        "primary": "CFGMGMTDO23",
+        "wire": "CFGMGMTDO23",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTDO24": {
+        "primary": "CFGMGMTDO24",
+        "wire": "CFGMGMTDO24",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTDO25": {
+        "primary": "CFGMGMTDO25",
+        "wire": "CFGMGMTDO25",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTDO26": {
+        "primary": "CFGMGMTDO26",
+        "wire": "CFGMGMTDO26",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTDO27": {
+        "primary": "CFGMGMTDO27",
+        "wire": "CFGMGMTDO27",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTDO28": {
+        "primary": "CFGMGMTDO28",
+        "wire": "CFGMGMTDO28",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTDO29": {
+        "primary": "CFGMGMTDO29",
+        "wire": "CFGMGMTDO29",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTDO30": {
+        "primary": "CFGMGMTDO30",
+        "wire": "CFGMGMTDO30",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTDO31": {
+        "primary": "CFGMGMTDO31",
+        "wire": "CFGMGMTDO31",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTDWADDR0": {
+        "primary": "CFGMGMTDWADDR0",
+        "wire": "CFGMGMTDWADDR0",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDWADDR1": {
+        "primary": "CFGMGMTDWADDR1",
+        "wire": "CFGMGMTDWADDR1",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDWADDR2": {
+        "primary": "CFGMGMTDWADDR2",
+        "wire": "CFGMGMTDWADDR2",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDWADDR3": {
+        "primary": "CFGMGMTDWADDR3",
+        "wire": "CFGMGMTDWADDR3",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDWADDR4": {
+        "primary": "CFGMGMTDWADDR4",
+        "wire": "CFGMGMTDWADDR4",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDWADDR5": {
+        "primary": "CFGMGMTDWADDR5",
+        "wire": "CFGMGMTDWADDR5",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDWADDR6": {
+        "primary": "CFGMGMTDWADDR6",
+        "wire": "CFGMGMTDWADDR6",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDWADDR7": {
+        "primary": "CFGMGMTDWADDR7",
+        "wire": "CFGMGMTDWADDR7",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDWADDR8": {
+        "primary": "CFGMGMTDWADDR8",
+        "wire": "CFGMGMTDWADDR8",
+        "dir": "INPUT"
+      },
+      "CFGMGMTDWADDR9": {
+        "primary": "CFGMGMTDWADDR9",
+        "wire": "CFGMGMTDWADDR9",
+        "dir": "INPUT"
+      },
+      "CFGMGMTRDENN": {
+        "primary": "CFGMGMTRDENN",
+        "wire": "CFGMGMTRDENN",
+        "dir": "INPUT"
+      },
+      "CFGMGMTRDWRDONEN": {
+        "primary": "CFGMGMTRDWRDONEN",
+        "wire": "CFGMGMTRDWRDONEN",
+        "dir": "OUTPUT"
+      },
+      "CFGMGMTWRENN": {
+        "primary": "CFGMGMTWRENN",
+        "wire": "CFGMGMTWRENN",
+        "dir": "INPUT"
+      },
+      "CFGMGMTWRREADONLYN": {
+        "primary": "CFGMGMTWRREADONLYN",
+        "wire": "CFGMGMTWRREADONLYN",
+        "dir": "INPUT"
+      },
+      "CFGMGMTWRRW1CASRWN": {
+        "primary": "CFGMGMTWRRW1CASRWN",
+        "wire": "CFGMGMTWRRW1CASRWN",
+        "dir": "INPUT"
+      },
+      "CFGMSGDATA0": {
+        "primary": "CFGMSGDATA0",
+        "wire": "CFGMSGDATA0",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGDATA1": {
+        "primary": "CFGMSGDATA1",
+        "wire": "CFGMSGDATA1",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGDATA2": {
+        "primary": "CFGMSGDATA2",
+        "wire": "CFGMSGDATA2",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGDATA3": {
+        "primary": "CFGMSGDATA3",
+        "wire": "CFGMSGDATA3",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGDATA4": {
+        "primary": "CFGMSGDATA4",
+        "wire": "CFGMSGDATA4",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGDATA5": {
+        "primary": "CFGMSGDATA5",
+        "wire": "CFGMSGDATA5",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGDATA6": {
+        "primary": "CFGMSGDATA6",
+        "wire": "CFGMSGDATA6",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGDATA7": {
+        "primary": "CFGMSGDATA7",
+        "wire": "CFGMSGDATA7",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGDATA8": {
+        "primary": "CFGMSGDATA8",
+        "wire": "CFGMSGDATA8",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGDATA9": {
+        "primary": "CFGMSGDATA9",
+        "wire": "CFGMSGDATA9",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGDATA10": {
+        "primary": "CFGMSGDATA10",
+        "wire": "CFGMSGDATA10",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGDATA11": {
+        "primary": "CFGMSGDATA11",
+        "wire": "CFGMSGDATA11",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGDATA12": {
+        "primary": "CFGMSGDATA12",
+        "wire": "CFGMSGDATA12",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGDATA13": {
+        "primary": "CFGMSGDATA13",
+        "wire": "CFGMSGDATA13",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGDATA14": {
+        "primary": "CFGMSGDATA14",
+        "wire": "CFGMSGDATA14",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGDATA15": {
+        "primary": "CFGMSGDATA15",
+        "wire": "CFGMSGDATA15",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGRECEIVED": {
+        "primary": "CFGMSGRECEIVED",
+        "wire": "CFGMSGRECEIVED",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGRECEIVEDASSERTINTA": {
+        "primary": "CFGMSGRECEIVEDASSERTINTA",
+        "wire": "CFGMSGRECEIVEDASSERTINTA",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGRECEIVEDASSERTINTB": {
+        "primary": "CFGMSGRECEIVEDASSERTINTB",
+        "wire": "CFGMSGRECEIVEDASSERTINTB",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGRECEIVEDASSERTINTC": {
+        "primary": "CFGMSGRECEIVEDASSERTINTC",
+        "wire": "CFGMSGRECEIVEDASSERTINTC",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGRECEIVEDASSERTINTD": {
+        "primary": "CFGMSGRECEIVEDASSERTINTD",
+        "wire": "CFGMSGRECEIVEDASSERTINTD",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGRECEIVEDDEASSERTINTA": {
+        "primary": "CFGMSGRECEIVEDDEASSERTINTA",
+        "wire": "CFGMSGRECEIVEDDEASSERTINTA",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGRECEIVEDDEASSERTINTB": {
+        "primary": "CFGMSGRECEIVEDDEASSERTINTB",
+        "wire": "CFGMSGRECEIVEDDEASSERTINTB",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGRECEIVEDDEASSERTINTC": {
+        "primary": "CFGMSGRECEIVEDDEASSERTINTC",
+        "wire": "CFGMSGRECEIVEDDEASSERTINTC",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGRECEIVEDDEASSERTINTD": {
+        "primary": "CFGMSGRECEIVEDDEASSERTINTD",
+        "wire": "CFGMSGRECEIVEDDEASSERTINTD",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGRECEIVEDERRCOR": {
+        "primary": "CFGMSGRECEIVEDERRCOR",
+        "wire": "CFGMSGRECEIVEDERRCOR",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGRECEIVEDERRFATAL": {
+        "primary": "CFGMSGRECEIVEDERRFATAL",
+        "wire": "CFGMSGRECEIVEDERRFATAL",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGRECEIVEDERRNONFATAL": {
+        "primary": "CFGMSGRECEIVEDERRNONFATAL",
+        "wire": "CFGMSGRECEIVEDERRNONFATAL",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGRECEIVEDPMASNAK": {
+        "primary": "CFGMSGRECEIVEDPMASNAK",
+        "wire": "CFGMSGRECEIVEDPMASNAK",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGRECEIVEDPMETO": {
+        "primary": "CFGMSGRECEIVEDPMETO",
+        "wire": "CFGMSGRECEIVEDPMETO",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGRECEIVEDPMETOACK": {
+        "primary": "CFGMSGRECEIVEDPMETOACK",
+        "wire": "CFGMSGRECEIVEDPMETOACK",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGRECEIVEDPMPME": {
+        "primary": "CFGMSGRECEIVEDPMPME",
+        "wire": "CFGMSGRECEIVEDPMPME",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGRECEIVEDSETSLOTPOWERLIMIT": {
+        "primary": "CFGMSGRECEIVEDSETSLOTPOWERLIMIT",
+        "wire": "CFGMSGRECEIVEDSETSLOTPOWERLIMIT",
+        "dir": "OUTPUT"
+      },
+      "CFGMSGRECEIVEDUNLOCK": {
+        "primary": "CFGMSGRECEIVEDUNLOCK",
+        "wire": "CFGMSGRECEIVEDUNLOCK",
+        "dir": "OUTPUT"
+      },
+      "CFGPCIECAPINTERRUPTMSGNUM0": {
+        "primary": "CFGPCIECAPINTERRUPTMSGNUM0",
+        "wire": "CFGPCIECAPINTERRUPTMSGNUM0",
+        "dir": "INPUT"
+      },
+      "CFGPCIECAPINTERRUPTMSGNUM1": {
+        "primary": "CFGPCIECAPINTERRUPTMSGNUM1",
+        "wire": "CFGPCIECAPINTERRUPTMSGNUM1",
+        "dir": "INPUT"
+      },
+      "CFGPCIECAPINTERRUPTMSGNUM2": {
+        "primary": "CFGPCIECAPINTERRUPTMSGNUM2",
+        "wire": "CFGPCIECAPINTERRUPTMSGNUM2",
+        "dir": "INPUT"
+      },
+      "CFGPCIECAPINTERRUPTMSGNUM3": {
+        "primary": "CFGPCIECAPINTERRUPTMSGNUM3",
+        "wire": "CFGPCIECAPINTERRUPTMSGNUM3",
+        "dir": "INPUT"
+      },
+      "CFGPCIECAPINTERRUPTMSGNUM4": {
+        "primary": "CFGPCIECAPINTERRUPTMSGNUM4",
+        "wire": "CFGPCIECAPINTERRUPTMSGNUM4",
+        "dir": "INPUT"
+      },
+      "CFGPCIELINKSTATE0": {
+        "primary": "CFGPCIELINKSTATE0",
+        "wire": "CFGPCIELINKSTATE0",
+        "dir": "OUTPUT"
+      },
+      "CFGPCIELINKSTATE1": {
+        "primary": "CFGPCIELINKSTATE1",
+        "wire": "CFGPCIELINKSTATE1",
+        "dir": "OUTPUT"
+      },
+      "CFGPCIELINKSTATE2": {
+        "primary": "CFGPCIELINKSTATE2",
+        "wire": "CFGPCIELINKSTATE2",
+        "dir": "OUTPUT"
+      },
+      "CFGPMCSRPMEEN": {
+        "primary": "CFGPMCSRPMEEN",
+        "wire": "CFGPMCSRPMEEN",
+        "dir": "OUTPUT"
+      },
+      "CFGPMCSRPMESTATUS": {
+        "primary": "CFGPMCSRPMESTATUS",
+        "wire": "CFGPMCSRPMESTATUS",
+        "dir": "OUTPUT"
+      },
+      "CFGPMCSRPOWERSTATE0": {
+        "primary": "CFGPMCSRPOWERSTATE0",
+        "wire": "CFGPMCSRPOWERSTATE0",
+        "dir": "OUTPUT"
+      },
+      "CFGPMCSRPOWERSTATE1": {
+        "primary": "CFGPMCSRPOWERSTATE1",
+        "wire": "CFGPMCSRPOWERSTATE1",
+        "dir": "OUTPUT"
+      },
+      "CFGPMFORCESTATE0": {
+        "primary": "CFGPMFORCESTATE0",
+        "wire": "CFGPMFORCESTATE0",
+        "dir": "INPUT"
+      },
+      "CFGPMFORCESTATE1": {
+        "primary": "CFGPMFORCESTATE1",
+        "wire": "CFGPMFORCESTATE1",
+        "dir": "INPUT"
+      },
+      "CFGPMFORCESTATEENN": {
+        "primary": "CFGPMFORCESTATEENN",
+        "wire": "CFGPMFORCESTATEENN",
+        "dir": "INPUT"
+      },
+      "CFGPMHALTASPML0SN": {
+        "primary": "CFGPMHALTASPML0SN",
+        "wire": "CFGPMHALTASPML0SN",
+        "dir": "INPUT"
+      },
+      "CFGPMHALTASPML1N": {
+        "primary": "CFGPMHALTASPML1N",
+        "wire": "CFGPMHALTASPML1N",
+        "dir": "INPUT"
+      },
+      "CFGPMRCVASREQL1N": {
+        "primary": "CFGPMRCVASREQL1N",
+        "wire": "CFGPMRCVASREQL1N",
+        "dir": "OUTPUT"
+      },
+      "CFGPMRCVENTERL1N": {
+        "primary": "CFGPMRCVENTERL1N",
+        "wire": "CFGPMRCVENTERL1N",
+        "dir": "OUTPUT"
+      },
+      "CFGPMRCVENTERL23N": {
+        "primary": "CFGPMRCVENTERL23N",
+        "wire": "CFGPMRCVENTERL23N",
+        "dir": "OUTPUT"
+      },
+      "CFGPMRCVREQACKN": {
+        "primary": "CFGPMRCVREQACKN",
+        "wire": "CFGPMRCVREQACKN",
+        "dir": "OUTPUT"
+      },
+      "CFGPMSENDPMETON": {
+        "primary": "CFGPMSENDPMETON",
+        "wire": "CFGPMSENDPMETON",
+        "dir": "INPUT"
+      },
+      "CFGPMTURNOFFOKN": {
+        "primary": "CFGPMTURNOFFOKN",
+        "wire": "CFGPMTURNOFFOKN",
+        "dir": "INPUT"
+      },
+      "CFGPMWAKEN": {
+        "primary": "CFGPMWAKEN",
+        "wire": "CFGPMWAKEN",
+        "dir": "INPUT"
+      },
+      "CFGPORTNUMBER0": {
+        "primary": "CFGPORTNUMBER0",
+        "wire": "CFGPORTNUMBER0",
+        "dir": "INPUT"
+      },
+      "CFGPORTNUMBER1": {
+        "primary": "CFGPORTNUMBER1",
+        "wire": "CFGPORTNUMBER1",
+        "dir": "INPUT"
+      },
+      "CFGPORTNUMBER2": {
+        "primary": "CFGPORTNUMBER2",
+        "wire": "CFGPORTNUMBER2",
+        "dir": "INPUT"
+      },
+      "CFGPORTNUMBER3": {
+        "primary": "CFGPORTNUMBER3",
+        "wire": "CFGPORTNUMBER3",
+        "dir": "INPUT"
+      },
+      "CFGPORTNUMBER4": {
+        "primary": "CFGPORTNUMBER4",
+        "wire": "CFGPORTNUMBER4",
+        "dir": "INPUT"
+      },
+      "CFGPORTNUMBER5": {
+        "primary": "CFGPORTNUMBER5",
+        "wire": "CFGPORTNUMBER5",
+        "dir": "INPUT"
+      },
+      "CFGPORTNUMBER6": {
+        "primary": "CFGPORTNUMBER6",
+        "wire": "CFGPORTNUMBER6",
+        "dir": "INPUT"
+      },
+      "CFGPORTNUMBER7": {
+        "primary": "CFGPORTNUMBER7",
+        "wire": "CFGPORTNUMBER7",
+        "dir": "INPUT"
+      },
+      "CFGREVID0": {
+        "primary": "CFGREVID0",
+        "wire": "CFGREVID0",
+        "dir": "INPUT"
+      },
+      "CFGREVID1": {
+        "primary": "CFGREVID1",
+        "wire": "CFGREVID1",
+        "dir": "INPUT"
+      },
+      "CFGREVID2": {
+        "primary": "CFGREVID2",
+        "wire": "CFGREVID2",
+        "dir": "INPUT"
+      },
+      "CFGREVID3": {
+        "primary": "CFGREVID3",
+        "wire": "CFGREVID3",
+        "dir": "INPUT"
+      },
+      "CFGREVID4": {
+        "primary": "CFGREVID4",
+        "wire": "CFGREVID4",
+        "dir": "INPUT"
+      },
+      "CFGREVID5": {
+        "primary": "CFGREVID5",
+        "wire": "CFGREVID5",
+        "dir": "INPUT"
+      },
+      "CFGREVID6": {
+        "primary": "CFGREVID6",
+        "wire": "CFGREVID6",
+        "dir": "INPUT"
+      },
+      "CFGREVID7": {
+        "primary": "CFGREVID7",
+        "wire": "CFGREVID7",
+        "dir": "INPUT"
+      },
+      "CFGROOTCONTROLPMEINTEN": {
+        "primary": "CFGROOTCONTROLPMEINTEN",
+        "wire": "CFGROOTCONTROLPMEINTEN",
+        "dir": "OUTPUT"
+      },
+      "CFGROOTCONTROLSYSERRCORRERREN": {
+        "primary": "CFGROOTCONTROLSYSERRCORRERREN",
+        "wire": "CFGROOTCONTROLSYSERRCORRERREN",
+        "dir": "OUTPUT"
+      },
+      "CFGROOTCONTROLSYSERRFATALERREN": {
+        "primary": "CFGROOTCONTROLSYSERRFATALERREN",
+        "wire": "CFGROOTCONTROLSYSERRFATALERREN",
+        "dir": "OUTPUT"
+      },
+      "CFGROOTCONTROLSYSERRNONFATALERREN": {
+        "primary": "CFGROOTCONTROLSYSERRNONFATALERREN",
+        "wire": "CFGROOTCONTROLSYSERRNONFATALERREN",
+        "dir": "OUTPUT"
+      },
+      "CFGSLOTCONTROLELECTROMECHILCTLPULSE": {
+        "primary": "CFGSLOTCONTROLELECTROMECHILCTLPULSE",
+        "wire": "CFGSLOTCONTROLELECTROMECHILCTLPULSE",
+        "dir": "OUTPUT"
+      },
+      "CFGSUBSYSID0": {
+        "primary": "CFGSUBSYSID0",
+        "wire": "CFGSUBSYSID0",
+        "dir": "INPUT"
+      },
+      "CFGSUBSYSID1": {
+        "primary": "CFGSUBSYSID1",
+        "wire": "CFGSUBSYSID1",
+        "dir": "INPUT"
+      },
+      "CFGSUBSYSID2": {
+        "primary": "CFGSUBSYSID2",
+        "wire": "CFGSUBSYSID2",
+        "dir": "INPUT"
+      },
+      "CFGSUBSYSID3": {
+        "primary": "CFGSUBSYSID3",
+        "wire": "CFGSUBSYSID3",
+        "dir": "INPUT"
+      },
+      "CFGSUBSYSID4": {
+        "primary": "CFGSUBSYSID4",
+        "wire": "CFGSUBSYSID4",
+        "dir": "INPUT"
+      },
+      "CFGSUBSYSID5": {
+        "primary": "CFGSUBSYSID5",
+        "wire": "CFGSUBSYSID5",
+        "dir": "INPUT"
+      },
+      "CFGSUBSYSID6": {
+        "primary": "CFGSUBSYSID6",
+        "wire": "CFGSUBSYSID6",
+        "dir": "INPUT"
+      },
+      "CFGSUBSYSID7": {
+        "primary": "CFGSUBSYSID7",
+        "wire": "CFGSUBSYSID7",
+        "dir": "INPUT"
+      },
+      "CFGSUBSYSID8": {
+        "primary": "CFGSUBSYSID8",
+        "wire": "CFGSUBSYSID8",
+        "dir": "INPUT"
+      },
+      "CFGSUBSYSID9": {
+        "primary": "CFGSUBSYSID9",
+        "wire": "CFGSUBSYSID9",
+        "dir": "INPUT"
+      },
+      "CFGSUBSYSID10": {
+        "primary": "CFGSUBSYSID10",
+        "wire": "CFGSUBSYSID10",
+        "dir": "INPUT"
+      },
+      "CFGSUBSYSID11": {
+        "primary": "CFGSUBSYSID11",
+        "wire": "CFGSUBSYSID11",
+        "dir": "INPUT"
+      },
+      "CFGSUBSYSID12": {
+        "primary": "CFGSUBSYSID12",
+        "wire": "CFGSUBSYSID12",
+        "dir": "INPUT"
+      },
+      "CFGSUBSYSID13": {
+        "primary": "CFGSUBSYSID13",
+        "wire": "CFGSUBSYSID13",
+        "dir": "INPUT"
+      },
+      "CFGSUBSYSID14": {
+        "primary": "CFGSUBSYSID14",
+        "wire": "CFGSUBSYSID14",
+        "dir": "INPUT"
+      },
+      "CFGSUBSYSID15": {
+        "primary": "CFGSUBSYSID15",
+        "wire": "CFGSUBSYSID15",
+        "dir": "INPUT"
+      },
+      "CFGSUBSYSVENDID0": {
+        "primary": "CFGSUBSYSVENDID0",
+        "wire": "CFGSUBSYSVENDID0",
+        "dir": "INPUT"
+      },
+      "CFGSUBSYSVENDID1": {
+        "primary": "CFGSUBSYSVENDID1",
+        "wire": "CFGSUBSYSVENDID1",
+        "dir": "INPUT"
+      },
+      "CFGSUBSYSVENDID2": {
+        "primary": "CFGSUBSYSVENDID2",
+        "wire": "CFGSUBSYSVENDID2",
+        "dir": "INPUT"
+      },
+      "CFGSUBSYSVENDID3": {
+        "primary": "CFGSUBSYSVENDID3",
+        "wire": "CFGSUBSYSVENDID3",
+        "dir": "INPUT"
+      },
+      "CFGSUBSYSVENDID4": {
+        "primary": "CFGSUBSYSVENDID4",
+        "wire": "CFGSUBSYSVENDID4",
+        "dir": "INPUT"
+      },
+      "CFGSUBSYSVENDID5": {
+        "primary": "CFGSUBSYSVENDID5",
+        "wire": "CFGSUBSYSVENDID5",
+        "dir": "INPUT"
+      },
+      "CFGSUBSYSVENDID6": {
+        "primary": "CFGSUBSYSVENDID6",
+        "wire": "CFGSUBSYSVENDID6",
+        "dir": "INPUT"
+      },
+      "CFGSUBSYSVENDID7": {
+        "primary": "CFGSUBSYSVENDID7",
+        "wire": "CFGSUBSYSVENDID7",
+        "dir": "INPUT"
+      },
+      "CFGSUBSYSVENDID8": {
+        "primary": "CFGSUBSYSVENDID8",
+        "wire": "CFGSUBSYSVENDID8",
+        "dir": "INPUT"
+      },
+      "CFGSUBSYSVENDID9": {
+        "primary": "CFGSUBSYSVENDID9",
+        "wire": "CFGSUBSYSVENDID9",
+        "dir": "INPUT"
+      },
+      "CFGSUBSYSVENDID10": {
+        "primary": "CFGSUBSYSVENDID10",
+        "wire": "CFGSUBSYSVENDID10",
+        "dir": "INPUT"
+      },
+      "CFGSUBSYSVENDID11": {
+        "primary": "CFGSUBSYSVENDID11",
+        "wire": "CFGSUBSYSVENDID11",
+        "dir": "INPUT"
+      },
+      "CFGSUBSYSVENDID12": {
+        "primary": "CFGSUBSYSVENDID12",
+        "wire": "CFGSUBSYSVENDID12",
+        "dir": "INPUT"
+      },
+      "CFGSUBSYSVENDID13": {
+        "primary": "CFGSUBSYSVENDID13",
+        "wire": "CFGSUBSYSVENDID13",
+        "dir": "INPUT"
+      },
+      "CFGSUBSYSVENDID14": {
+        "primary": "CFGSUBSYSVENDID14",
+        "wire": "CFGSUBSYSVENDID14",
+        "dir": "INPUT"
+      },
+      "CFGSUBSYSVENDID15": {
+        "primary": "CFGSUBSYSVENDID15",
+        "wire": "CFGSUBSYSVENDID15",
+        "dir": "INPUT"
+      },
+      "CFGTRANSACTION": {
+        "primary": "CFGTRANSACTION",
+        "wire": "CFGTRANSACTION",
+        "dir": "OUTPUT"
+      },
+      "CFGTRANSACTIONADDR0": {
+        "primary": "CFGTRANSACTIONADDR0",
+        "wire": "CFGTRANSACTIONADDR0",
+        "dir": "OUTPUT"
+      },
+      "CFGTRANSACTIONADDR1": {
+        "primary": "CFGTRANSACTIONADDR1",
+        "wire": "CFGTRANSACTIONADDR1",
+        "dir": "OUTPUT"
+      },
+      "CFGTRANSACTIONADDR2": {
+        "primary": "CFGTRANSACTIONADDR2",
+        "wire": "CFGTRANSACTIONADDR2",
+        "dir": "OUTPUT"
+      },
+      "CFGTRANSACTIONADDR3": {
+        "primary": "CFGTRANSACTIONADDR3",
+        "wire": "CFGTRANSACTIONADDR3",
+        "dir": "OUTPUT"
+      },
+      "CFGTRANSACTIONADDR4": {
+        "primary": "CFGTRANSACTIONADDR4",
+        "wire": "CFGTRANSACTIONADDR4",
+        "dir": "OUTPUT"
+      },
+      "CFGTRANSACTIONADDR5": {
+        "primary": "CFGTRANSACTIONADDR5",
+        "wire": "CFGTRANSACTIONADDR5",
+        "dir": "OUTPUT"
+      },
+      "CFGTRANSACTIONADDR6": {
+        "primary": "CFGTRANSACTIONADDR6",
+        "wire": "CFGTRANSACTIONADDR6",
+        "dir": "OUTPUT"
+      },
+      "CFGTRANSACTIONTYPE": {
+        "primary": "CFGTRANSACTIONTYPE",
+        "wire": "CFGTRANSACTIONTYPE",
+        "dir": "OUTPUT"
+      },
+      "CFGTRNPENDINGN": {
+        "primary": "CFGTRNPENDINGN",
+        "wire": "CFGTRNPENDINGN",
+        "dir": "INPUT"
+      },
+      "CFGVCTCVCMAP0": {
+        "primary": "CFGVCTCVCMAP0",
+        "wire": "CFGVCTCVCMAP0",
+        "dir": "OUTPUT"
+      },
+      "CFGVCTCVCMAP1": {
+        "primary": "CFGVCTCVCMAP1",
+        "wire": "CFGVCTCVCMAP1",
+        "dir": "OUTPUT"
+      },
+      "CFGVCTCVCMAP2": {
+        "primary": "CFGVCTCVCMAP2",
+        "wire": "CFGVCTCVCMAP2",
+        "dir": "OUTPUT"
+      },
+      "CFGVCTCVCMAP3": {
+        "primary": "CFGVCTCVCMAP3",
+        "wire": "CFGVCTCVCMAP3",
+        "dir": "OUTPUT"
+      },
+      "CFGVCTCVCMAP4": {
+        "primary": "CFGVCTCVCMAP4",
+        "wire": "CFGVCTCVCMAP4",
+        "dir": "OUTPUT"
+      },
+      "CFGVCTCVCMAP5": {
+        "primary": "CFGVCTCVCMAP5",
+        "wire": "CFGVCTCVCMAP5",
+        "dir": "OUTPUT"
+      },
+      "CFGVCTCVCMAP6": {
+        "primary": "CFGVCTCVCMAP6",
+        "wire": "CFGVCTCVCMAP6",
+        "dir": "OUTPUT"
+      },
+      "CFGVENDID0": {
+        "primary": "CFGVENDID0",
+        "wire": "CFGVENDID0",
+        "dir": "INPUT"
+      },
+      "CFGVENDID1": {
+        "primary": "CFGVENDID1",
+        "wire": "CFGVENDID1",
+        "dir": "INPUT"
+      },
+      "CFGVENDID2": {
+        "primary": "CFGVENDID2",
+        "wire": "CFGVENDID2",
+        "dir": "INPUT"
+      },
+      "CFGVENDID3": {
+        "primary": "CFGVENDID3",
+        "wire": "CFGVENDID3",
+        "dir": "INPUT"
+      },
+      "CFGVENDID4": {
+        "primary": "CFGVENDID4",
+        "wire": "CFGVENDID4",
+        "dir": "INPUT"
+      },
+      "CFGVENDID5": {
+        "primary": "CFGVENDID5",
+        "wire": "CFGVENDID5",
+        "dir": "INPUT"
+      },
+      "CFGVENDID6": {
+        "primary": "CFGVENDID6",
+        "wire": "CFGVENDID6",
+        "dir": "INPUT"
+      },
+      "CFGVENDID7": {
+        "primary": "CFGVENDID7",
+        "wire": "CFGVENDID7",
+        "dir": "INPUT"
+      },
+      "CFGVENDID8": {
+        "primary": "CFGVENDID8",
+        "wire": "CFGVENDID8",
+        "dir": "INPUT"
+      },
+      "CFGVENDID9": {
+        "primary": "CFGVENDID9",
+        "wire": "CFGVENDID9",
+        "dir": "INPUT"
+      },
+      "CFGVENDID10": {
+        "primary": "CFGVENDID10",
+        "wire": "CFGVENDID10",
+        "dir": "INPUT"
+      },
+      "CFGVENDID11": {
+        "primary": "CFGVENDID11",
+        "wire": "CFGVENDID11",
+        "dir": "INPUT"
+      },
+      "CFGVENDID12": {
+        "primary": "CFGVENDID12",
+        "wire": "CFGVENDID12",
+        "dir": "INPUT"
+      },
+      "CFGVENDID13": {
+        "primary": "CFGVENDID13",
+        "wire": "CFGVENDID13",
+        "dir": "INPUT"
+      },
+      "CFGVENDID14": {
+        "primary": "CFGVENDID14",
+        "wire": "CFGVENDID14",
+        "dir": "INPUT"
+      },
+      "CFGVENDID15": {
+        "primary": "CFGVENDID15",
+        "wire": "CFGVENDID15",
+        "dir": "INPUT"
+      },
+      "CMRSTN": {
+        "primary": "CMRSTN",
+        "wire": "CMRSTN",
+        "dir": "INPUT"
+      },
+      "CMSTICKYRSTN": {
+        "primary": "CMSTICKYRSTN",
+        "wire": "CMSTICKYRSTN",
+        "dir": "INPUT"
+      },
+      "DBGMODE0": {
+        "primary": "DBGMODE0",
+        "wire": "DBGMODE0",
+        "dir": "INPUT"
+      },
+      "DBGMODE1": {
+        "primary": "DBGMODE1",
+        "wire": "DBGMODE1",
+        "dir": "INPUT"
+      },
+      "DBGSCLRA": {
+        "primary": "DBGSCLRA",
+        "wire": "DBGSCLRA",
+        "dir": "OUTPUT"
+      },
+      "DBGSCLRB": {
+        "primary": "DBGSCLRB",
+        "wire": "DBGSCLRB",
+        "dir": "OUTPUT"
+      },
+      "DBGSCLRC": {
+        "primary": "DBGSCLRC",
+        "wire": "DBGSCLRC",
+        "dir": "OUTPUT"
+      },
+      "DBGSCLRD": {
+        "primary": "DBGSCLRD",
+        "wire": "DBGSCLRD",
+        "dir": "OUTPUT"
+      },
+      "DBGSCLRE": {
+        "primary": "DBGSCLRE",
+        "wire": "DBGSCLRE",
+        "dir": "OUTPUT"
+      },
+      "DBGSCLRF": {
+        "primary": "DBGSCLRF",
+        "wire": "DBGSCLRF",
+        "dir": "OUTPUT"
+      },
+      "DBGSCLRG": {
+        "primary": "DBGSCLRG",
+        "wire": "DBGSCLRG",
+        "dir": "OUTPUT"
+      },
+      "DBGSCLRH": {
+        "primary": "DBGSCLRH",
+        "wire": "DBGSCLRH",
+        "dir": "OUTPUT"
+      },
+      "DBGSCLRI": {
+        "primary": "DBGSCLRI",
+        "wire": "DBGSCLRI",
+        "dir": "OUTPUT"
+      },
+      "DBGSCLRJ": {
+        "primary": "DBGSCLRJ",
+        "wire": "DBGSCLRJ",
+        "dir": "OUTPUT"
+      },
+      "DBGSCLRK": {
+        "primary": "DBGSCLRK",
+        "wire": "DBGSCLRK",
+        "dir": "OUTPUT"
+      },
+      "DBGSUBMODE": {
+        "primary": "DBGSUBMODE",
+        "wire": "DBGSUBMODE",
+        "dir": "INPUT"
+      },
+      "DBGVECA0": {
+        "primary": "DBGVECA0",
+        "wire": "DBGVECA0",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA1": {
+        "primary": "DBGVECA1",
+        "wire": "DBGVECA1",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA2": {
+        "primary": "DBGVECA2",
+        "wire": "DBGVECA2",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA3": {
+        "primary": "DBGVECA3",
+        "wire": "DBGVECA3",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA4": {
+        "primary": "DBGVECA4",
+        "wire": "DBGVECA4",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA5": {
+        "primary": "DBGVECA5",
+        "wire": "DBGVECA5",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA6": {
+        "primary": "DBGVECA6",
+        "wire": "DBGVECA6",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA7": {
+        "primary": "DBGVECA7",
+        "wire": "DBGVECA7",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA8": {
+        "primary": "DBGVECA8",
+        "wire": "DBGVECA8",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA9": {
+        "primary": "DBGVECA9",
+        "wire": "DBGVECA9",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA10": {
+        "primary": "DBGVECA10",
+        "wire": "DBGVECA10",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA11": {
+        "primary": "DBGVECA11",
+        "wire": "DBGVECA11",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA12": {
+        "primary": "DBGVECA12",
+        "wire": "DBGVECA12",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA13": {
+        "primary": "DBGVECA13",
+        "wire": "DBGVECA13",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA14": {
+        "primary": "DBGVECA14",
+        "wire": "DBGVECA14",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA15": {
+        "primary": "DBGVECA15",
+        "wire": "DBGVECA15",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA16": {
+        "primary": "DBGVECA16",
+        "wire": "DBGVECA16",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA17": {
+        "primary": "DBGVECA17",
+        "wire": "DBGVECA17",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA18": {
+        "primary": "DBGVECA18",
+        "wire": "DBGVECA18",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA19": {
+        "primary": "DBGVECA19",
+        "wire": "DBGVECA19",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA20": {
+        "primary": "DBGVECA20",
+        "wire": "DBGVECA20",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA21": {
+        "primary": "DBGVECA21",
+        "wire": "DBGVECA21",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA22": {
+        "primary": "DBGVECA22",
+        "wire": "DBGVECA22",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA23": {
+        "primary": "DBGVECA23",
+        "wire": "DBGVECA23",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA24": {
+        "primary": "DBGVECA24",
+        "wire": "DBGVECA24",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA25": {
+        "primary": "DBGVECA25",
+        "wire": "DBGVECA25",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA26": {
+        "primary": "DBGVECA26",
+        "wire": "DBGVECA26",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA27": {
+        "primary": "DBGVECA27",
+        "wire": "DBGVECA27",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA28": {
+        "primary": "DBGVECA28",
+        "wire": "DBGVECA28",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA29": {
+        "primary": "DBGVECA29",
+        "wire": "DBGVECA29",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA30": {
+        "primary": "DBGVECA30",
+        "wire": "DBGVECA30",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA31": {
+        "primary": "DBGVECA31",
+        "wire": "DBGVECA31",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA32": {
+        "primary": "DBGVECA32",
+        "wire": "DBGVECA32",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA33": {
+        "primary": "DBGVECA33",
+        "wire": "DBGVECA33",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA34": {
+        "primary": "DBGVECA34",
+        "wire": "DBGVECA34",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA35": {
+        "primary": "DBGVECA35",
+        "wire": "DBGVECA35",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA36": {
+        "primary": "DBGVECA36",
+        "wire": "DBGVECA36",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA37": {
+        "primary": "DBGVECA37",
+        "wire": "DBGVECA37",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA38": {
+        "primary": "DBGVECA38",
+        "wire": "DBGVECA38",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA39": {
+        "primary": "DBGVECA39",
+        "wire": "DBGVECA39",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA40": {
+        "primary": "DBGVECA40",
+        "wire": "DBGVECA40",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA41": {
+        "primary": "DBGVECA41",
+        "wire": "DBGVECA41",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA42": {
+        "primary": "DBGVECA42",
+        "wire": "DBGVECA42",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA43": {
+        "primary": "DBGVECA43",
+        "wire": "DBGVECA43",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA44": {
+        "primary": "DBGVECA44",
+        "wire": "DBGVECA44",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA45": {
+        "primary": "DBGVECA45",
+        "wire": "DBGVECA45",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA46": {
+        "primary": "DBGVECA46",
+        "wire": "DBGVECA46",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA47": {
+        "primary": "DBGVECA47",
+        "wire": "DBGVECA47",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA48": {
+        "primary": "DBGVECA48",
+        "wire": "DBGVECA48",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA49": {
+        "primary": "DBGVECA49",
+        "wire": "DBGVECA49",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA50": {
+        "primary": "DBGVECA50",
+        "wire": "DBGVECA50",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA51": {
+        "primary": "DBGVECA51",
+        "wire": "DBGVECA51",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA52": {
+        "primary": "DBGVECA52",
+        "wire": "DBGVECA52",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA53": {
+        "primary": "DBGVECA53",
+        "wire": "DBGVECA53",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA54": {
+        "primary": "DBGVECA54",
+        "wire": "DBGVECA54",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA55": {
+        "primary": "DBGVECA55",
+        "wire": "DBGVECA55",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA56": {
+        "primary": "DBGVECA56",
+        "wire": "DBGVECA56",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA57": {
+        "primary": "DBGVECA57",
+        "wire": "DBGVECA57",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA58": {
+        "primary": "DBGVECA58",
+        "wire": "DBGVECA58",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA59": {
+        "primary": "DBGVECA59",
+        "wire": "DBGVECA59",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA60": {
+        "primary": "DBGVECA60",
+        "wire": "DBGVECA60",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA61": {
+        "primary": "DBGVECA61",
+        "wire": "DBGVECA61",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA62": {
+        "primary": "DBGVECA62",
+        "wire": "DBGVECA62",
+        "dir": "OUTPUT"
+      },
+      "DBGVECA63": {
+        "primary": "DBGVECA63",
+        "wire": "DBGVECA63",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB0": {
+        "primary": "DBGVECB0",
+        "wire": "DBGVECB0",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB1": {
+        "primary": "DBGVECB1",
+        "wire": "DBGVECB1",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB2": {
+        "primary": "DBGVECB2",
+        "wire": "DBGVECB2",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB3": {
+        "primary": "DBGVECB3",
+        "wire": "DBGVECB3",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB4": {
+        "primary": "DBGVECB4",
+        "wire": "DBGVECB4",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB5": {
+        "primary": "DBGVECB5",
+        "wire": "DBGVECB5",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB6": {
+        "primary": "DBGVECB6",
+        "wire": "DBGVECB6",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB7": {
+        "primary": "DBGVECB7",
+        "wire": "DBGVECB7",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB8": {
+        "primary": "DBGVECB8",
+        "wire": "DBGVECB8",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB9": {
+        "primary": "DBGVECB9",
+        "wire": "DBGVECB9",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB10": {
+        "primary": "DBGVECB10",
+        "wire": "DBGVECB10",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB11": {
+        "primary": "DBGVECB11",
+        "wire": "DBGVECB11",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB12": {
+        "primary": "DBGVECB12",
+        "wire": "DBGVECB12",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB13": {
+        "primary": "DBGVECB13",
+        "wire": "DBGVECB13",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB14": {
+        "primary": "DBGVECB14",
+        "wire": "DBGVECB14",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB15": {
+        "primary": "DBGVECB15",
+        "wire": "DBGVECB15",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB16": {
+        "primary": "DBGVECB16",
+        "wire": "DBGVECB16",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB17": {
+        "primary": "DBGVECB17",
+        "wire": "DBGVECB17",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB18": {
+        "primary": "DBGVECB18",
+        "wire": "DBGVECB18",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB19": {
+        "primary": "DBGVECB19",
+        "wire": "DBGVECB19",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB20": {
+        "primary": "DBGVECB20",
+        "wire": "DBGVECB20",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB21": {
+        "primary": "DBGVECB21",
+        "wire": "DBGVECB21",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB22": {
+        "primary": "DBGVECB22",
+        "wire": "DBGVECB22",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB23": {
+        "primary": "DBGVECB23",
+        "wire": "DBGVECB23",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB24": {
+        "primary": "DBGVECB24",
+        "wire": "DBGVECB24",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB25": {
+        "primary": "DBGVECB25",
+        "wire": "DBGVECB25",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB26": {
+        "primary": "DBGVECB26",
+        "wire": "DBGVECB26",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB27": {
+        "primary": "DBGVECB27",
+        "wire": "DBGVECB27",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB28": {
+        "primary": "DBGVECB28",
+        "wire": "DBGVECB28",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB29": {
+        "primary": "DBGVECB29",
+        "wire": "DBGVECB29",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB30": {
+        "primary": "DBGVECB30",
+        "wire": "DBGVECB30",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB31": {
+        "primary": "DBGVECB31",
+        "wire": "DBGVECB31",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB32": {
+        "primary": "DBGVECB32",
+        "wire": "DBGVECB32",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB33": {
+        "primary": "DBGVECB33",
+        "wire": "DBGVECB33",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB34": {
+        "primary": "DBGVECB34",
+        "wire": "DBGVECB34",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB35": {
+        "primary": "DBGVECB35",
+        "wire": "DBGVECB35",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB36": {
+        "primary": "DBGVECB36",
+        "wire": "DBGVECB36",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB37": {
+        "primary": "DBGVECB37",
+        "wire": "DBGVECB37",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB38": {
+        "primary": "DBGVECB38",
+        "wire": "DBGVECB38",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB39": {
+        "primary": "DBGVECB39",
+        "wire": "DBGVECB39",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB40": {
+        "primary": "DBGVECB40",
+        "wire": "DBGVECB40",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB41": {
+        "primary": "DBGVECB41",
+        "wire": "DBGVECB41",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB42": {
+        "primary": "DBGVECB42",
+        "wire": "DBGVECB42",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB43": {
+        "primary": "DBGVECB43",
+        "wire": "DBGVECB43",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB44": {
+        "primary": "DBGVECB44",
+        "wire": "DBGVECB44",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB45": {
+        "primary": "DBGVECB45",
+        "wire": "DBGVECB45",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB46": {
+        "primary": "DBGVECB46",
+        "wire": "DBGVECB46",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB47": {
+        "primary": "DBGVECB47",
+        "wire": "DBGVECB47",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB48": {
+        "primary": "DBGVECB48",
+        "wire": "DBGVECB48",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB49": {
+        "primary": "DBGVECB49",
+        "wire": "DBGVECB49",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB50": {
+        "primary": "DBGVECB50",
+        "wire": "DBGVECB50",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB51": {
+        "primary": "DBGVECB51",
+        "wire": "DBGVECB51",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB52": {
+        "primary": "DBGVECB52",
+        "wire": "DBGVECB52",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB53": {
+        "primary": "DBGVECB53",
+        "wire": "DBGVECB53",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB54": {
+        "primary": "DBGVECB54",
+        "wire": "DBGVECB54",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB55": {
+        "primary": "DBGVECB55",
+        "wire": "DBGVECB55",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB56": {
+        "primary": "DBGVECB56",
+        "wire": "DBGVECB56",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB57": {
+        "primary": "DBGVECB57",
+        "wire": "DBGVECB57",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB58": {
+        "primary": "DBGVECB58",
+        "wire": "DBGVECB58",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB59": {
+        "primary": "DBGVECB59",
+        "wire": "DBGVECB59",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB60": {
+        "primary": "DBGVECB60",
+        "wire": "DBGVECB60",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB61": {
+        "primary": "DBGVECB61",
+        "wire": "DBGVECB61",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB62": {
+        "primary": "DBGVECB62",
+        "wire": "DBGVECB62",
+        "dir": "OUTPUT"
+      },
+      "DBGVECB63": {
+        "primary": "DBGVECB63",
+        "wire": "DBGVECB63",
+        "dir": "OUTPUT"
+      },
+      "DBGVECC0": {
+        "primary": "DBGVECC0",
+        "wire": "DBGVECC0",
+        "dir": "OUTPUT"
+      },
+      "DBGVECC1": {
+        "primary": "DBGVECC1",
+        "wire": "DBGVECC1",
+        "dir": "OUTPUT"
+      },
+      "DBGVECC2": {
+        "primary": "DBGVECC2",
+        "wire": "DBGVECC2",
+        "dir": "OUTPUT"
+      },
+      "DBGVECC3": {
+        "primary": "DBGVECC3",
+        "wire": "DBGVECC3",
+        "dir": "OUTPUT"
+      },
+      "DBGVECC4": {
+        "primary": "DBGVECC4",
+        "wire": "DBGVECC4",
+        "dir": "OUTPUT"
+      },
+      "DBGVECC5": {
+        "primary": "DBGVECC5",
+        "wire": "DBGVECC5",
+        "dir": "OUTPUT"
+      },
+      "DBGVECC6": {
+        "primary": "DBGVECC6",
+        "wire": "DBGVECC6",
+        "dir": "OUTPUT"
+      },
+      "DBGVECC7": {
+        "primary": "DBGVECC7",
+        "wire": "DBGVECC7",
+        "dir": "OUTPUT"
+      },
+      "DBGVECC8": {
+        "primary": "DBGVECC8",
+        "wire": "DBGVECC8",
+        "dir": "OUTPUT"
+      },
+      "DBGVECC9": {
+        "primary": "DBGVECC9",
+        "wire": "DBGVECC9",
+        "dir": "OUTPUT"
+      },
+      "DBGVECC10": {
+        "primary": "DBGVECC10",
+        "wire": "DBGVECC10",
+        "dir": "OUTPUT"
+      },
+      "DBGVECC11": {
+        "primary": "DBGVECC11",
+        "wire": "DBGVECC11",
+        "dir": "OUTPUT"
+      },
+      "DLRSTN": {
+        "primary": "DLRSTN",
+        "wire": "DLRSTN",
+        "dir": "INPUT"
+      },
+      "DRPADDR0": {
+        "primary": "DRPADDR0",
+        "wire": "DRPADDR0",
+        "dir": "INPUT"
+      },
+      "DRPADDR1": {
+        "primary": "DRPADDR1",
+        "wire": "DRPADDR1",
+        "dir": "INPUT"
+      },
+      "DRPADDR2": {
+        "primary": "DRPADDR2",
+        "wire": "DRPADDR2",
+        "dir": "INPUT"
+      },
+      "DRPADDR3": {
+        "primary": "DRPADDR3",
+        "wire": "DRPADDR3",
+        "dir": "INPUT"
+      },
+      "DRPADDR4": {
+        "primary": "DRPADDR4",
+        "wire": "DRPADDR4",
+        "dir": "INPUT"
+      },
+      "DRPADDR5": {
+        "primary": "DRPADDR5",
+        "wire": "DRPADDR5",
+        "dir": "INPUT"
+      },
+      "DRPADDR6": {
+        "primary": "DRPADDR6",
+        "wire": "DRPADDR6",
+        "dir": "INPUT"
+      },
+      "DRPADDR7": {
+        "primary": "DRPADDR7",
+        "wire": "DRPADDR7",
+        "dir": "INPUT"
+      },
+      "DRPADDR8": {
+        "primary": "DRPADDR8",
+        "wire": "DRPADDR8",
+        "dir": "INPUT"
+      },
+      "DRPCLK": {
+        "primary": "DRPCLK",
+        "wire": "DRPCLK",
+        "dir": "INPUT"
+      },
+      "DRPDI0": {
+        "primary": "DRPDI0",
+        "wire": "DRPDI0",
+        "dir": "INPUT"
+      },
+      "DRPDI1": {
+        "primary": "DRPDI1",
+        "wire": "DRPDI1",
+        "dir": "INPUT"
+      },
+      "DRPDI2": {
+        "primary": "DRPDI2",
+        "wire": "DRPDI2",
+        "dir": "INPUT"
+      },
+      "DRPDI3": {
+        "primary": "DRPDI3",
+        "wire": "DRPDI3",
+        "dir": "INPUT"
+      },
+      "DRPDI4": {
+        "primary": "DRPDI4",
+        "wire": "DRPDI4",
+        "dir": "INPUT"
+      },
+      "DRPDI5": {
+        "primary": "DRPDI5",
+        "wire": "DRPDI5",
+        "dir": "INPUT"
+      },
+      "DRPDI6": {
+        "primary": "DRPDI6",
+        "wire": "DRPDI6",
+        "dir": "INPUT"
+      },
+      "DRPDI7": {
+        "primary": "DRPDI7",
+        "wire": "DRPDI7",
+        "dir": "INPUT"
+      },
+      "DRPDI8": {
+        "primary": "DRPDI8",
+        "wire": "DRPDI8",
+        "dir": "INPUT"
+      },
+      "DRPDI9": {
+        "primary": "DRPDI9",
+        "wire": "DRPDI9",
+        "dir": "INPUT"
+      },
+      "DRPDI10": {
+        "primary": "DRPDI10",
+        "wire": "DRPDI10",
+        "dir": "INPUT"
+      },
+      "DRPDI11": {
+        "primary": "DRPDI11",
+        "wire": "DRPDI11",
+        "dir": "INPUT"
+      },
+      "DRPDI12": {
+        "primary": "DRPDI12",
+        "wire": "DRPDI12",
+        "dir": "INPUT"
+      },
+      "DRPDI13": {
+        "primary": "DRPDI13",
+        "wire": "DRPDI13",
+        "dir": "INPUT"
+      },
+      "DRPDI14": {
+        "primary": "DRPDI14",
+        "wire": "DRPDI14",
+        "dir": "INPUT"
+      },
+      "DRPDI15": {
+        "primary": "DRPDI15",
+        "wire": "DRPDI15",
+        "dir": "INPUT"
+      },
+      "DRPDO0": {
+        "primary": "DRPDO0",
+        "wire": "DRPDO0",
+        "dir": "OUTPUT"
+      },
+      "DRPDO1": {
+        "primary": "DRPDO1",
+        "wire": "DRPDO1",
+        "dir": "OUTPUT"
+      },
+      "DRPDO2": {
+        "primary": "DRPDO2",
+        "wire": "DRPDO2",
+        "dir": "OUTPUT"
+      },
+      "DRPDO3": {
+        "primary": "DRPDO3",
+        "wire": "DRPDO3",
+        "dir": "OUTPUT"
+      },
+      "DRPDO4": {
+        "primary": "DRPDO4",
+        "wire": "DRPDO4",
+        "dir": "OUTPUT"
+      },
+      "DRPDO5": {
+        "primary": "DRPDO5",
+        "wire": "DRPDO5",
+        "dir": "OUTPUT"
+      },
+      "DRPDO6": {
+        "primary": "DRPDO6",
+        "wire": "DRPDO6",
+        "dir": "OUTPUT"
+      },
+      "DRPDO7": {
+        "primary": "DRPDO7",
+        "wire": "DRPDO7",
+        "dir": "OUTPUT"
+      },
+      "DRPDO8": {
+        "primary": "DRPDO8",
+        "wire": "DRPDO8",
+        "dir": "OUTPUT"
+      },
+      "DRPDO9": {
+        "primary": "DRPDO9",
+        "wire": "DRPDO9",
+        "dir": "OUTPUT"
+      },
+      "DRPDO10": {
+        "primary": "DRPDO10",
+        "wire": "DRPDO10",
+        "dir": "OUTPUT"
+      },
+      "DRPDO11": {
+        "primary": "DRPDO11",
+        "wire": "DRPDO11",
+        "dir": "OUTPUT"
+      },
+      "DRPDO12": {
+        "primary": "DRPDO12",
+        "wire": "DRPDO12",
+        "dir": "OUTPUT"
+      },
+      "DRPDO13": {
+        "primary": "DRPDO13",
+        "wire": "DRPDO13",
+        "dir": "OUTPUT"
+      },
+      "DRPDO14": {
+        "primary": "DRPDO14",
+        "wire": "DRPDO14",
+        "dir": "OUTPUT"
+      },
+      "DRPDO15": {
+        "primary": "DRPDO15",
+        "wire": "DRPDO15",
+        "dir": "OUTPUT"
+      },
+      "DRPEN": {
+        "primary": "DRPEN",
+        "wire": "DRPEN",
+        "dir": "INPUT"
+      },
+      "DRPRDY": {
+        "primary": "DRPRDY",
+        "wire": "DRPRDY",
+        "dir": "OUTPUT"
+      },
+      "DRPWE": {
+        "primary": "DRPWE",
+        "wire": "DRPWE",
+        "dir": "INPUT"
+      },
+      "EDTBYPASS": {
+        "primary": "EDTBYPASS",
+        "wire": "EDTBYPASS",
+        "dir": "INPUT"
+      },
+      "EDTCHANNELSIN1": {
+        "primary": "EDTCHANNELSIN1",
+        "wire": "EDTCHANNELSIN1",
+        "dir": "INPUT"
+      },
+      "EDTCHANNELSIN2": {
+        "primary": "EDTCHANNELSIN2",
+        "wire": "EDTCHANNELSIN2",
+        "dir": "INPUT"
+      },
+      "EDTCHANNELSIN3": {
+        "primary": "EDTCHANNELSIN3",
+        "wire": "EDTCHANNELSIN3",
+        "dir": "INPUT"
+      },
+      "EDTCHANNELSIN4": {
+        "primary": "EDTCHANNELSIN4",
+        "wire": "EDTCHANNELSIN4",
+        "dir": "INPUT"
+      },
+      "EDTCHANNELSIN5": {
+        "primary": "EDTCHANNELSIN5",
+        "wire": "EDTCHANNELSIN5",
+        "dir": "INPUT"
+      },
+      "EDTCHANNELSIN6": {
+        "primary": "EDTCHANNELSIN6",
+        "wire": "EDTCHANNELSIN6",
+        "dir": "INPUT"
+      },
+      "EDTCHANNELSIN7": {
+        "primary": "EDTCHANNELSIN7",
+        "wire": "EDTCHANNELSIN7",
+        "dir": "INPUT"
+      },
+      "EDTCHANNELSIN8": {
+        "primary": "EDTCHANNELSIN8",
+        "wire": "EDTCHANNELSIN8",
+        "dir": "INPUT"
+      },
+      "EDTCHANNELSOUT1": {
+        "primary": "EDTCHANNELSOUT1",
+        "wire": "EDTCHANNELSOUT1",
+        "dir": "OUTPUT"
+      },
+      "EDTCHANNELSOUT2": {
+        "primary": "EDTCHANNELSOUT2",
+        "wire": "EDTCHANNELSOUT2",
+        "dir": "OUTPUT"
+      },
+      "EDTCHANNELSOUT3": {
+        "primary": "EDTCHANNELSOUT3",
+        "wire": "EDTCHANNELSOUT3",
+        "dir": "OUTPUT"
+      },
+      "EDTCHANNELSOUT4": {
+        "primary": "EDTCHANNELSOUT4",
+        "wire": "EDTCHANNELSOUT4",
+        "dir": "OUTPUT"
+      },
+      "EDTCHANNELSOUT5": {
+        "primary": "EDTCHANNELSOUT5",
+        "wire": "EDTCHANNELSOUT5",
+        "dir": "OUTPUT"
+      },
+      "EDTCHANNELSOUT6": {
+        "primary": "EDTCHANNELSOUT6",
+        "wire": "EDTCHANNELSOUT6",
+        "dir": "OUTPUT"
+      },
+      "EDTCHANNELSOUT7": {
+        "primary": "EDTCHANNELSOUT7",
+        "wire": "EDTCHANNELSOUT7",
+        "dir": "OUTPUT"
+      },
+      "EDTCHANNELSOUT8": {
+        "primary": "EDTCHANNELSOUT8",
+        "wire": "EDTCHANNELSOUT8",
+        "dir": "OUTPUT"
+      },
+      "EDTCLK": {
+        "primary": "EDTCLK",
+        "wire": "EDTCLK",
+        "dir": "INPUT"
+      },
+      "EDTCONFIGURATION": {
+        "primary": "EDTCONFIGURATION",
+        "wire": "EDTCONFIGURATION",
+        "dir": "INPUT"
+      },
+      "EDTSINGLEBYPASSCHAIN": {
+        "primary": "EDTSINGLEBYPASSCHAIN",
+        "wire": "EDTSINGLEBYPASSCHAIN",
+        "dir": "INPUT"
+      },
+      "EDTUPDATE": {
+        "primary": "EDTUPDATE",
+        "wire": "EDTUPDATE",
+        "dir": "INPUT"
+      },
+      "FUNCLVLRSTN": {
+        "primary": "FUNCLVLRSTN",
+        "wire": "FUNCLVLRSTN",
+        "dir": "INPUT"
+      },
+      "LL2BADDLLPERR": {
+        "primary": "LL2BADDLLPERR",
+        "wire": "LL2BADDLLPERR",
+        "dir": "OUTPUT"
+      },
+      "LL2BADTLPERR": {
+        "primary": "LL2BADTLPERR",
+        "wire": "LL2BADTLPERR",
+        "dir": "OUTPUT"
+      },
+      "LL2LINKSTATUS0": {
+        "primary": "LL2LINKSTATUS0",
+        "wire": "LL2LINKSTATUS0",
+        "dir": "OUTPUT"
+      },
+      "LL2LINKSTATUS1": {
+        "primary": "LL2LINKSTATUS1",
+        "wire": "LL2LINKSTATUS1",
+        "dir": "OUTPUT"
+      },
+      "LL2LINKSTATUS2": {
+        "primary": "LL2LINKSTATUS2",
+        "wire": "LL2LINKSTATUS2",
+        "dir": "OUTPUT"
+      },
+      "LL2LINKSTATUS3": {
+        "primary": "LL2LINKSTATUS3",
+        "wire": "LL2LINKSTATUS3",
+        "dir": "OUTPUT"
+      },
+      "LL2LINKSTATUS4": {
+        "primary": "LL2LINKSTATUS4",
+        "wire": "LL2LINKSTATUS4",
+        "dir": "OUTPUT"
+      },
+      "LL2PROTOCOLERR": {
+        "primary": "LL2PROTOCOLERR",
+        "wire": "LL2PROTOCOLERR",
+        "dir": "OUTPUT"
+      },
+      "LL2RECEIVERERR": {
+        "primary": "LL2RECEIVERERR",
+        "wire": "LL2RECEIVERERR",
+        "dir": "OUTPUT"
+      },
+      "LL2REPLAYROERR": {
+        "primary": "LL2REPLAYROERR",
+        "wire": "LL2REPLAYROERR",
+        "dir": "OUTPUT"
+      },
+      "LL2REPLAYTOERR": {
+        "primary": "LL2REPLAYTOERR",
+        "wire": "LL2REPLAYTOERR",
+        "dir": "OUTPUT"
+      },
+      "LL2SENDASREQL1": {
+        "primary": "LL2SENDASREQL1",
+        "wire": "LL2SENDASREQL1",
+        "dir": "INPUT"
+      },
+      "LL2SENDENTERL1": {
+        "primary": "LL2SENDENTERL1",
+        "wire": "LL2SENDENTERL1",
+        "dir": "INPUT"
+      },
+      "LL2SENDENTERL23": {
+        "primary": "LL2SENDENTERL23",
+        "wire": "LL2SENDENTERL23",
+        "dir": "INPUT"
+      },
+      "LL2SENDPMACK": {
+        "primary": "LL2SENDPMACK",
+        "wire": "LL2SENDPMACK",
+        "dir": "INPUT"
+      },
+      "LL2SUSPENDNOW": {
+        "primary": "LL2SUSPENDNOW",
+        "wire": "LL2SUSPENDNOW",
+        "dir": "INPUT"
+      },
+      "LL2SUSPENDOK": {
+        "primary": "LL2SUSPENDOK",
+        "wire": "LL2SUSPENDOK",
+        "dir": "OUTPUT"
+      },
+      "LL2TFCINIT1SEQ": {
+        "primary": "LL2TFCINIT1SEQ",
+        "wire": "LL2TFCINIT1SEQ",
+        "dir": "OUTPUT"
+      },
+      "LL2TFCINIT2SEQ": {
+        "primary": "LL2TFCINIT2SEQ",
+        "wire": "LL2TFCINIT2SEQ",
+        "dir": "OUTPUT"
+      },
+      "LL2TLPRCV": {
+        "primary": "LL2TLPRCV",
+        "wire": "LL2TLPRCV",
+        "dir": "INPUT"
+      },
+      "LL2TXIDLE": {
+        "primary": "LL2TXIDLE",
+        "wire": "LL2TXIDLE",
+        "dir": "OUTPUT"
+      },
+      "LNKCLKEN": {
+        "primary": "LNKCLKEN",
+        "wire": "LNKCLKEN",
+        "dir": "OUTPUT"
+      },
+      "MIMRXRADDR0": {
+        "primary": "MIMRXRADDR0",
+        "wire": "MIMRXRADDR0",
+        "dir": "OUTPUT"
+      },
+      "MIMRXRADDR1": {
+        "primary": "MIMRXRADDR1",
+        "wire": "MIMRXRADDR1",
+        "dir": "OUTPUT"
+      },
+      "MIMRXRADDR2": {
+        "primary": "MIMRXRADDR2",
+        "wire": "MIMRXRADDR2",
+        "dir": "OUTPUT"
+      },
+      "MIMRXRADDR3": {
+        "primary": "MIMRXRADDR3",
+        "wire": "MIMRXRADDR3",
+        "dir": "OUTPUT"
+      },
+      "MIMRXRADDR4": {
+        "primary": "MIMRXRADDR4",
+        "wire": "MIMRXRADDR4",
+        "dir": "OUTPUT"
+      },
+      "MIMRXRADDR5": {
+        "primary": "MIMRXRADDR5",
+        "wire": "MIMRXRADDR5",
+        "dir": "OUTPUT"
+      },
+      "MIMRXRADDR6": {
+        "primary": "MIMRXRADDR6",
+        "wire": "MIMRXRADDR6",
+        "dir": "OUTPUT"
+      },
+      "MIMRXRADDR7": {
+        "primary": "MIMRXRADDR7",
+        "wire": "MIMRXRADDR7",
+        "dir": "OUTPUT"
+      },
+      "MIMRXRADDR8": {
+        "primary": "MIMRXRADDR8",
+        "wire": "MIMRXRADDR8",
+        "dir": "OUTPUT"
+      },
+      "MIMRXRADDR9": {
+        "primary": "MIMRXRADDR9",
+        "wire": "MIMRXRADDR9",
+        "dir": "OUTPUT"
+      },
+      "MIMRXRADDR10": {
+        "primary": "MIMRXRADDR10",
+        "wire": "MIMRXRADDR10",
+        "dir": "OUTPUT"
+      },
+      "MIMRXRADDR11": {
+        "primary": "MIMRXRADDR11",
+        "wire": "MIMRXRADDR11",
+        "dir": "OUTPUT"
+      },
+      "MIMRXRADDR12": {
+        "primary": "MIMRXRADDR12",
+        "wire": "MIMRXRADDR12",
+        "dir": "OUTPUT"
+      },
+      "MIMRXRDATA0": {
+        "primary": "MIMRXRDATA0",
+        "wire": "MIMRXRDATA0",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA1": {
+        "primary": "MIMRXRDATA1",
+        "wire": "MIMRXRDATA1",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA2": {
+        "primary": "MIMRXRDATA2",
+        "wire": "MIMRXRDATA2",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA3": {
+        "primary": "MIMRXRDATA3",
+        "wire": "MIMRXRDATA3",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA4": {
+        "primary": "MIMRXRDATA4",
+        "wire": "MIMRXRDATA4",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA5": {
+        "primary": "MIMRXRDATA5",
+        "wire": "MIMRXRDATA5",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA6": {
+        "primary": "MIMRXRDATA6",
+        "wire": "MIMRXRDATA6",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA7": {
+        "primary": "MIMRXRDATA7",
+        "wire": "MIMRXRDATA7",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA8": {
+        "primary": "MIMRXRDATA8",
+        "wire": "MIMRXRDATA8",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA9": {
+        "primary": "MIMRXRDATA9",
+        "wire": "MIMRXRDATA9",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA10": {
+        "primary": "MIMRXRDATA10",
+        "wire": "MIMRXRDATA10",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA11": {
+        "primary": "MIMRXRDATA11",
+        "wire": "MIMRXRDATA11",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA12": {
+        "primary": "MIMRXRDATA12",
+        "wire": "MIMRXRDATA12",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA13": {
+        "primary": "MIMRXRDATA13",
+        "wire": "MIMRXRDATA13",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA14": {
+        "primary": "MIMRXRDATA14",
+        "wire": "MIMRXRDATA14",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA15": {
+        "primary": "MIMRXRDATA15",
+        "wire": "MIMRXRDATA15",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA16": {
+        "primary": "MIMRXRDATA16",
+        "wire": "MIMRXRDATA16",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA17": {
+        "primary": "MIMRXRDATA17",
+        "wire": "MIMRXRDATA17",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA18": {
+        "primary": "MIMRXRDATA18",
+        "wire": "MIMRXRDATA18",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA19": {
+        "primary": "MIMRXRDATA19",
+        "wire": "MIMRXRDATA19",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA20": {
+        "primary": "MIMRXRDATA20",
+        "wire": "MIMRXRDATA20",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA21": {
+        "primary": "MIMRXRDATA21",
+        "wire": "MIMRXRDATA21",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA22": {
+        "primary": "MIMRXRDATA22",
+        "wire": "MIMRXRDATA22",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA23": {
+        "primary": "MIMRXRDATA23",
+        "wire": "MIMRXRDATA23",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA24": {
+        "primary": "MIMRXRDATA24",
+        "wire": "MIMRXRDATA24",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA25": {
+        "primary": "MIMRXRDATA25",
+        "wire": "MIMRXRDATA25",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA26": {
+        "primary": "MIMRXRDATA26",
+        "wire": "MIMRXRDATA26",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA27": {
+        "primary": "MIMRXRDATA27",
+        "wire": "MIMRXRDATA27",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA28": {
+        "primary": "MIMRXRDATA28",
+        "wire": "MIMRXRDATA28",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA29": {
+        "primary": "MIMRXRDATA29",
+        "wire": "MIMRXRDATA29",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA30": {
+        "primary": "MIMRXRDATA30",
+        "wire": "MIMRXRDATA30",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA31": {
+        "primary": "MIMRXRDATA31",
+        "wire": "MIMRXRDATA31",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA32": {
+        "primary": "MIMRXRDATA32",
+        "wire": "MIMRXRDATA32",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA33": {
+        "primary": "MIMRXRDATA33",
+        "wire": "MIMRXRDATA33",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA34": {
+        "primary": "MIMRXRDATA34",
+        "wire": "MIMRXRDATA34",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA35": {
+        "primary": "MIMRXRDATA35",
+        "wire": "MIMRXRDATA35",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA36": {
+        "primary": "MIMRXRDATA36",
+        "wire": "MIMRXRDATA36",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA37": {
+        "primary": "MIMRXRDATA37",
+        "wire": "MIMRXRDATA37",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA38": {
+        "primary": "MIMRXRDATA38",
+        "wire": "MIMRXRDATA38",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA39": {
+        "primary": "MIMRXRDATA39",
+        "wire": "MIMRXRDATA39",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA40": {
+        "primary": "MIMRXRDATA40",
+        "wire": "MIMRXRDATA40",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA41": {
+        "primary": "MIMRXRDATA41",
+        "wire": "MIMRXRDATA41",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA42": {
+        "primary": "MIMRXRDATA42",
+        "wire": "MIMRXRDATA42",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA43": {
+        "primary": "MIMRXRDATA43",
+        "wire": "MIMRXRDATA43",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA44": {
+        "primary": "MIMRXRDATA44",
+        "wire": "MIMRXRDATA44",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA45": {
+        "primary": "MIMRXRDATA45",
+        "wire": "MIMRXRDATA45",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA46": {
+        "primary": "MIMRXRDATA46",
+        "wire": "MIMRXRDATA46",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA47": {
+        "primary": "MIMRXRDATA47",
+        "wire": "MIMRXRDATA47",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA48": {
+        "primary": "MIMRXRDATA48",
+        "wire": "MIMRXRDATA48",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA49": {
+        "primary": "MIMRXRDATA49",
+        "wire": "MIMRXRDATA49",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA50": {
+        "primary": "MIMRXRDATA50",
+        "wire": "MIMRXRDATA50",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA51": {
+        "primary": "MIMRXRDATA51",
+        "wire": "MIMRXRDATA51",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA52": {
+        "primary": "MIMRXRDATA52",
+        "wire": "MIMRXRDATA52",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA53": {
+        "primary": "MIMRXRDATA53",
+        "wire": "MIMRXRDATA53",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA54": {
+        "primary": "MIMRXRDATA54",
+        "wire": "MIMRXRDATA54",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA55": {
+        "primary": "MIMRXRDATA55",
+        "wire": "MIMRXRDATA55",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA56": {
+        "primary": "MIMRXRDATA56",
+        "wire": "MIMRXRDATA56",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA57": {
+        "primary": "MIMRXRDATA57",
+        "wire": "MIMRXRDATA57",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA58": {
+        "primary": "MIMRXRDATA58",
+        "wire": "MIMRXRDATA58",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA59": {
+        "primary": "MIMRXRDATA59",
+        "wire": "MIMRXRDATA59",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA60": {
+        "primary": "MIMRXRDATA60",
+        "wire": "MIMRXRDATA60",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA61": {
+        "primary": "MIMRXRDATA61",
+        "wire": "MIMRXRDATA61",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA62": {
+        "primary": "MIMRXRDATA62",
+        "wire": "MIMRXRDATA62",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA63": {
+        "primary": "MIMRXRDATA63",
+        "wire": "MIMRXRDATA63",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA64": {
+        "primary": "MIMRXRDATA64",
+        "wire": "MIMRXRDATA64",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA65": {
+        "primary": "MIMRXRDATA65",
+        "wire": "MIMRXRDATA65",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA66": {
+        "primary": "MIMRXRDATA66",
+        "wire": "MIMRXRDATA66",
+        "dir": "INPUT"
+      },
+      "MIMRXRDATA67": {
+        "primary": "MIMRXRDATA67",
+        "wire": "MIMRXRDATA67",
+        "dir": "INPUT"
+      },
+      "MIMRXREN": {
+        "primary": "MIMRXREN",
+        "wire": "MIMRXREN",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWADDR0": {
+        "primary": "MIMRXWADDR0",
+        "wire": "MIMRXWADDR0",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWADDR1": {
+        "primary": "MIMRXWADDR1",
+        "wire": "MIMRXWADDR1",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWADDR2": {
+        "primary": "MIMRXWADDR2",
+        "wire": "MIMRXWADDR2",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWADDR3": {
+        "primary": "MIMRXWADDR3",
+        "wire": "MIMRXWADDR3",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWADDR4": {
+        "primary": "MIMRXWADDR4",
+        "wire": "MIMRXWADDR4",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWADDR5": {
+        "primary": "MIMRXWADDR5",
+        "wire": "MIMRXWADDR5",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWADDR6": {
+        "primary": "MIMRXWADDR6",
+        "wire": "MIMRXWADDR6",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWADDR7": {
+        "primary": "MIMRXWADDR7",
+        "wire": "MIMRXWADDR7",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWADDR8": {
+        "primary": "MIMRXWADDR8",
+        "wire": "MIMRXWADDR8",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWADDR9": {
+        "primary": "MIMRXWADDR9",
+        "wire": "MIMRXWADDR9",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWADDR10": {
+        "primary": "MIMRXWADDR10",
+        "wire": "MIMRXWADDR10",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWADDR11": {
+        "primary": "MIMRXWADDR11",
+        "wire": "MIMRXWADDR11",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWADDR12": {
+        "primary": "MIMRXWADDR12",
+        "wire": "MIMRXWADDR12",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA0": {
+        "primary": "MIMRXWDATA0",
+        "wire": "MIMRXWDATA0",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA1": {
+        "primary": "MIMRXWDATA1",
+        "wire": "MIMRXWDATA1",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA2": {
+        "primary": "MIMRXWDATA2",
+        "wire": "MIMRXWDATA2",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA3": {
+        "primary": "MIMRXWDATA3",
+        "wire": "MIMRXWDATA3",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA4": {
+        "primary": "MIMRXWDATA4",
+        "wire": "MIMRXWDATA4",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA5": {
+        "primary": "MIMRXWDATA5",
+        "wire": "MIMRXWDATA5",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA6": {
+        "primary": "MIMRXWDATA6",
+        "wire": "MIMRXWDATA6",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA7": {
+        "primary": "MIMRXWDATA7",
+        "wire": "MIMRXWDATA7",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA8": {
+        "primary": "MIMRXWDATA8",
+        "wire": "MIMRXWDATA8",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA9": {
+        "primary": "MIMRXWDATA9",
+        "wire": "MIMRXWDATA9",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA10": {
+        "primary": "MIMRXWDATA10",
+        "wire": "MIMRXWDATA10",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA11": {
+        "primary": "MIMRXWDATA11",
+        "wire": "MIMRXWDATA11",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA12": {
+        "primary": "MIMRXWDATA12",
+        "wire": "MIMRXWDATA12",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA13": {
+        "primary": "MIMRXWDATA13",
+        "wire": "MIMRXWDATA13",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA14": {
+        "primary": "MIMRXWDATA14",
+        "wire": "MIMRXWDATA14",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA15": {
+        "primary": "MIMRXWDATA15",
+        "wire": "MIMRXWDATA15",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA16": {
+        "primary": "MIMRXWDATA16",
+        "wire": "MIMRXWDATA16",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA17": {
+        "primary": "MIMRXWDATA17",
+        "wire": "MIMRXWDATA17",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA18": {
+        "primary": "MIMRXWDATA18",
+        "wire": "MIMRXWDATA18",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA19": {
+        "primary": "MIMRXWDATA19",
+        "wire": "MIMRXWDATA19",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA20": {
+        "primary": "MIMRXWDATA20",
+        "wire": "MIMRXWDATA20",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA21": {
+        "primary": "MIMRXWDATA21",
+        "wire": "MIMRXWDATA21",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA22": {
+        "primary": "MIMRXWDATA22",
+        "wire": "MIMRXWDATA22",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA23": {
+        "primary": "MIMRXWDATA23",
+        "wire": "MIMRXWDATA23",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA24": {
+        "primary": "MIMRXWDATA24",
+        "wire": "MIMRXWDATA24",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA25": {
+        "primary": "MIMRXWDATA25",
+        "wire": "MIMRXWDATA25",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA26": {
+        "primary": "MIMRXWDATA26",
+        "wire": "MIMRXWDATA26",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA27": {
+        "primary": "MIMRXWDATA27",
+        "wire": "MIMRXWDATA27",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA28": {
+        "primary": "MIMRXWDATA28",
+        "wire": "MIMRXWDATA28",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA29": {
+        "primary": "MIMRXWDATA29",
+        "wire": "MIMRXWDATA29",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA30": {
+        "primary": "MIMRXWDATA30",
+        "wire": "MIMRXWDATA30",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA31": {
+        "primary": "MIMRXWDATA31",
+        "wire": "MIMRXWDATA31",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA32": {
+        "primary": "MIMRXWDATA32",
+        "wire": "MIMRXWDATA32",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA33": {
+        "primary": "MIMRXWDATA33",
+        "wire": "MIMRXWDATA33",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA34": {
+        "primary": "MIMRXWDATA34",
+        "wire": "MIMRXWDATA34",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA35": {
+        "primary": "MIMRXWDATA35",
+        "wire": "MIMRXWDATA35",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA36": {
+        "primary": "MIMRXWDATA36",
+        "wire": "MIMRXWDATA36",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA37": {
+        "primary": "MIMRXWDATA37",
+        "wire": "MIMRXWDATA37",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA38": {
+        "primary": "MIMRXWDATA38",
+        "wire": "MIMRXWDATA38",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA39": {
+        "primary": "MIMRXWDATA39",
+        "wire": "MIMRXWDATA39",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA40": {
+        "primary": "MIMRXWDATA40",
+        "wire": "MIMRXWDATA40",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA41": {
+        "primary": "MIMRXWDATA41",
+        "wire": "MIMRXWDATA41",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA42": {
+        "primary": "MIMRXWDATA42",
+        "wire": "MIMRXWDATA42",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA43": {
+        "primary": "MIMRXWDATA43",
+        "wire": "MIMRXWDATA43",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA44": {
+        "primary": "MIMRXWDATA44",
+        "wire": "MIMRXWDATA44",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA45": {
+        "primary": "MIMRXWDATA45",
+        "wire": "MIMRXWDATA45",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA46": {
+        "primary": "MIMRXWDATA46",
+        "wire": "MIMRXWDATA46",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA47": {
+        "primary": "MIMRXWDATA47",
+        "wire": "MIMRXWDATA47",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA48": {
+        "primary": "MIMRXWDATA48",
+        "wire": "MIMRXWDATA48",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA49": {
+        "primary": "MIMRXWDATA49",
+        "wire": "MIMRXWDATA49",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA50": {
+        "primary": "MIMRXWDATA50",
+        "wire": "MIMRXWDATA50",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA51": {
+        "primary": "MIMRXWDATA51",
+        "wire": "MIMRXWDATA51",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA52": {
+        "primary": "MIMRXWDATA52",
+        "wire": "MIMRXWDATA52",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA53": {
+        "primary": "MIMRXWDATA53",
+        "wire": "MIMRXWDATA53",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA54": {
+        "primary": "MIMRXWDATA54",
+        "wire": "MIMRXWDATA54",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA55": {
+        "primary": "MIMRXWDATA55",
+        "wire": "MIMRXWDATA55",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA56": {
+        "primary": "MIMRXWDATA56",
+        "wire": "MIMRXWDATA56",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA57": {
+        "primary": "MIMRXWDATA57",
+        "wire": "MIMRXWDATA57",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA58": {
+        "primary": "MIMRXWDATA58",
+        "wire": "MIMRXWDATA58",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA59": {
+        "primary": "MIMRXWDATA59",
+        "wire": "MIMRXWDATA59",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA60": {
+        "primary": "MIMRXWDATA60",
+        "wire": "MIMRXWDATA60",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA61": {
+        "primary": "MIMRXWDATA61",
+        "wire": "MIMRXWDATA61",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA62": {
+        "primary": "MIMRXWDATA62",
+        "wire": "MIMRXWDATA62",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA63": {
+        "primary": "MIMRXWDATA63",
+        "wire": "MIMRXWDATA63",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA64": {
+        "primary": "MIMRXWDATA64",
+        "wire": "MIMRXWDATA64",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA65": {
+        "primary": "MIMRXWDATA65",
+        "wire": "MIMRXWDATA65",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA66": {
+        "primary": "MIMRXWDATA66",
+        "wire": "MIMRXWDATA66",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWDATA67": {
+        "primary": "MIMRXWDATA67",
+        "wire": "MIMRXWDATA67",
+        "dir": "OUTPUT"
+      },
+      "MIMRXWEN": {
+        "primary": "MIMRXWEN",
+        "wire": "MIMRXWEN",
+        "dir": "OUTPUT"
+      },
+      "MIMTXRADDR0": {
+        "primary": "MIMTXRADDR0",
+        "wire": "MIMTXRADDR0",
+        "dir": "OUTPUT"
+      },
+      "MIMTXRADDR1": {
+        "primary": "MIMTXRADDR1",
+        "wire": "MIMTXRADDR1",
+        "dir": "OUTPUT"
+      },
+      "MIMTXRADDR2": {
+        "primary": "MIMTXRADDR2",
+        "wire": "MIMTXRADDR2",
+        "dir": "OUTPUT"
+      },
+      "MIMTXRADDR3": {
+        "primary": "MIMTXRADDR3",
+        "wire": "MIMTXRADDR3",
+        "dir": "OUTPUT"
+      },
+      "MIMTXRADDR4": {
+        "primary": "MIMTXRADDR4",
+        "wire": "MIMTXRADDR4",
+        "dir": "OUTPUT"
+      },
+      "MIMTXRADDR5": {
+        "primary": "MIMTXRADDR5",
+        "wire": "MIMTXRADDR5",
+        "dir": "OUTPUT"
+      },
+      "MIMTXRADDR6": {
+        "primary": "MIMTXRADDR6",
+        "wire": "MIMTXRADDR6",
+        "dir": "OUTPUT"
+      },
+      "MIMTXRADDR7": {
+        "primary": "MIMTXRADDR7",
+        "wire": "MIMTXRADDR7",
+        "dir": "OUTPUT"
+      },
+      "MIMTXRADDR8": {
+        "primary": "MIMTXRADDR8",
+        "wire": "MIMTXRADDR8",
+        "dir": "OUTPUT"
+      },
+      "MIMTXRADDR9": {
+        "primary": "MIMTXRADDR9",
+        "wire": "MIMTXRADDR9",
+        "dir": "OUTPUT"
+      },
+      "MIMTXRADDR10": {
+        "primary": "MIMTXRADDR10",
+        "wire": "MIMTXRADDR10",
+        "dir": "OUTPUT"
+      },
+      "MIMTXRADDR11": {
+        "primary": "MIMTXRADDR11",
+        "wire": "MIMTXRADDR11",
+        "dir": "OUTPUT"
+      },
+      "MIMTXRADDR12": {
+        "primary": "MIMTXRADDR12",
+        "wire": "MIMTXRADDR12",
+        "dir": "OUTPUT"
+      },
+      "MIMTXRDATA0": {
+        "primary": "MIMTXRDATA0",
+        "wire": "MIMTXRDATA0",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA1": {
+        "primary": "MIMTXRDATA1",
+        "wire": "MIMTXRDATA1",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA2": {
+        "primary": "MIMTXRDATA2",
+        "wire": "MIMTXRDATA2",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA3": {
+        "primary": "MIMTXRDATA3",
+        "wire": "MIMTXRDATA3",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA4": {
+        "primary": "MIMTXRDATA4",
+        "wire": "MIMTXRDATA4",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA5": {
+        "primary": "MIMTXRDATA5",
+        "wire": "MIMTXRDATA5",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA6": {
+        "primary": "MIMTXRDATA6",
+        "wire": "MIMTXRDATA6",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA7": {
+        "primary": "MIMTXRDATA7",
+        "wire": "MIMTXRDATA7",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA8": {
+        "primary": "MIMTXRDATA8",
+        "wire": "MIMTXRDATA8",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA9": {
+        "primary": "MIMTXRDATA9",
+        "wire": "MIMTXRDATA9",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA10": {
+        "primary": "MIMTXRDATA10",
+        "wire": "MIMTXRDATA10",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA11": {
+        "primary": "MIMTXRDATA11",
+        "wire": "MIMTXRDATA11",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA12": {
+        "primary": "MIMTXRDATA12",
+        "wire": "MIMTXRDATA12",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA13": {
+        "primary": "MIMTXRDATA13",
+        "wire": "MIMTXRDATA13",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA14": {
+        "primary": "MIMTXRDATA14",
+        "wire": "MIMTXRDATA14",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA15": {
+        "primary": "MIMTXRDATA15",
+        "wire": "MIMTXRDATA15",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA16": {
+        "primary": "MIMTXRDATA16",
+        "wire": "MIMTXRDATA16",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA17": {
+        "primary": "MIMTXRDATA17",
+        "wire": "MIMTXRDATA17",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA18": {
+        "primary": "MIMTXRDATA18",
+        "wire": "MIMTXRDATA18",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA19": {
+        "primary": "MIMTXRDATA19",
+        "wire": "MIMTXRDATA19",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA20": {
+        "primary": "MIMTXRDATA20",
+        "wire": "MIMTXRDATA20",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA21": {
+        "primary": "MIMTXRDATA21",
+        "wire": "MIMTXRDATA21",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA22": {
+        "primary": "MIMTXRDATA22",
+        "wire": "MIMTXRDATA22",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA23": {
+        "primary": "MIMTXRDATA23",
+        "wire": "MIMTXRDATA23",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA24": {
+        "primary": "MIMTXRDATA24",
+        "wire": "MIMTXRDATA24",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA25": {
+        "primary": "MIMTXRDATA25",
+        "wire": "MIMTXRDATA25",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA26": {
+        "primary": "MIMTXRDATA26",
+        "wire": "MIMTXRDATA26",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA27": {
+        "primary": "MIMTXRDATA27",
+        "wire": "MIMTXRDATA27",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA28": {
+        "primary": "MIMTXRDATA28",
+        "wire": "MIMTXRDATA28",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA29": {
+        "primary": "MIMTXRDATA29",
+        "wire": "MIMTXRDATA29",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA30": {
+        "primary": "MIMTXRDATA30",
+        "wire": "MIMTXRDATA30",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA31": {
+        "primary": "MIMTXRDATA31",
+        "wire": "MIMTXRDATA31",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA32": {
+        "primary": "MIMTXRDATA32",
+        "wire": "MIMTXRDATA32",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA33": {
+        "primary": "MIMTXRDATA33",
+        "wire": "MIMTXRDATA33",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA34": {
+        "primary": "MIMTXRDATA34",
+        "wire": "MIMTXRDATA34",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA35": {
+        "primary": "MIMTXRDATA35",
+        "wire": "MIMTXRDATA35",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA36": {
+        "primary": "MIMTXRDATA36",
+        "wire": "MIMTXRDATA36",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA37": {
+        "primary": "MIMTXRDATA37",
+        "wire": "MIMTXRDATA37",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA38": {
+        "primary": "MIMTXRDATA38",
+        "wire": "MIMTXRDATA38",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA39": {
+        "primary": "MIMTXRDATA39",
+        "wire": "MIMTXRDATA39",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA40": {
+        "primary": "MIMTXRDATA40",
+        "wire": "MIMTXRDATA40",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA41": {
+        "primary": "MIMTXRDATA41",
+        "wire": "MIMTXRDATA41",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA42": {
+        "primary": "MIMTXRDATA42",
+        "wire": "MIMTXRDATA42",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA43": {
+        "primary": "MIMTXRDATA43",
+        "wire": "MIMTXRDATA43",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA44": {
+        "primary": "MIMTXRDATA44",
+        "wire": "MIMTXRDATA44",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA45": {
+        "primary": "MIMTXRDATA45",
+        "wire": "MIMTXRDATA45",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA46": {
+        "primary": "MIMTXRDATA46",
+        "wire": "MIMTXRDATA46",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA47": {
+        "primary": "MIMTXRDATA47",
+        "wire": "MIMTXRDATA47",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA48": {
+        "primary": "MIMTXRDATA48",
+        "wire": "MIMTXRDATA48",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA49": {
+        "primary": "MIMTXRDATA49",
+        "wire": "MIMTXRDATA49",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA50": {
+        "primary": "MIMTXRDATA50",
+        "wire": "MIMTXRDATA50",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA51": {
+        "primary": "MIMTXRDATA51",
+        "wire": "MIMTXRDATA51",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA52": {
+        "primary": "MIMTXRDATA52",
+        "wire": "MIMTXRDATA52",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA53": {
+        "primary": "MIMTXRDATA53",
+        "wire": "MIMTXRDATA53",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA54": {
+        "primary": "MIMTXRDATA54",
+        "wire": "MIMTXRDATA54",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA55": {
+        "primary": "MIMTXRDATA55",
+        "wire": "MIMTXRDATA55",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA56": {
+        "primary": "MIMTXRDATA56",
+        "wire": "MIMTXRDATA56",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA57": {
+        "primary": "MIMTXRDATA57",
+        "wire": "MIMTXRDATA57",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA58": {
+        "primary": "MIMTXRDATA58",
+        "wire": "MIMTXRDATA58",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA59": {
+        "primary": "MIMTXRDATA59",
+        "wire": "MIMTXRDATA59",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA60": {
+        "primary": "MIMTXRDATA60",
+        "wire": "MIMTXRDATA60",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA61": {
+        "primary": "MIMTXRDATA61",
+        "wire": "MIMTXRDATA61",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA62": {
+        "primary": "MIMTXRDATA62",
+        "wire": "MIMTXRDATA62",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA63": {
+        "primary": "MIMTXRDATA63",
+        "wire": "MIMTXRDATA63",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA64": {
+        "primary": "MIMTXRDATA64",
+        "wire": "MIMTXRDATA64",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA65": {
+        "primary": "MIMTXRDATA65",
+        "wire": "MIMTXRDATA65",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA66": {
+        "primary": "MIMTXRDATA66",
+        "wire": "MIMTXRDATA66",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA67": {
+        "primary": "MIMTXRDATA67",
+        "wire": "MIMTXRDATA67",
+        "dir": "INPUT"
+      },
+      "MIMTXRDATA68": {
+        "primary": "MIMTXRDATA68",
+        "wire": "MIMTXRDATA68",
+        "dir": "INPUT"
+      },
+      "MIMTXREN": {
+        "primary": "MIMTXREN",
+        "wire": "MIMTXREN",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWADDR0": {
+        "primary": "MIMTXWADDR0",
+        "wire": "MIMTXWADDR0",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWADDR1": {
+        "primary": "MIMTXWADDR1",
+        "wire": "MIMTXWADDR1",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWADDR2": {
+        "primary": "MIMTXWADDR2",
+        "wire": "MIMTXWADDR2",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWADDR3": {
+        "primary": "MIMTXWADDR3",
+        "wire": "MIMTXWADDR3",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWADDR4": {
+        "primary": "MIMTXWADDR4",
+        "wire": "MIMTXWADDR4",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWADDR5": {
+        "primary": "MIMTXWADDR5",
+        "wire": "MIMTXWADDR5",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWADDR6": {
+        "primary": "MIMTXWADDR6",
+        "wire": "MIMTXWADDR6",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWADDR7": {
+        "primary": "MIMTXWADDR7",
+        "wire": "MIMTXWADDR7",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWADDR8": {
+        "primary": "MIMTXWADDR8",
+        "wire": "MIMTXWADDR8",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWADDR9": {
+        "primary": "MIMTXWADDR9",
+        "wire": "MIMTXWADDR9",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWADDR10": {
+        "primary": "MIMTXWADDR10",
+        "wire": "MIMTXWADDR10",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWADDR11": {
+        "primary": "MIMTXWADDR11",
+        "wire": "MIMTXWADDR11",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWADDR12": {
+        "primary": "MIMTXWADDR12",
+        "wire": "MIMTXWADDR12",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA0": {
+        "primary": "MIMTXWDATA0",
+        "wire": "MIMTXWDATA0",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA1": {
+        "primary": "MIMTXWDATA1",
+        "wire": "MIMTXWDATA1",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA2": {
+        "primary": "MIMTXWDATA2",
+        "wire": "MIMTXWDATA2",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA3": {
+        "primary": "MIMTXWDATA3",
+        "wire": "MIMTXWDATA3",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA4": {
+        "primary": "MIMTXWDATA4",
+        "wire": "MIMTXWDATA4",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA5": {
+        "primary": "MIMTXWDATA5",
+        "wire": "MIMTXWDATA5",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA6": {
+        "primary": "MIMTXWDATA6",
+        "wire": "MIMTXWDATA6",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA7": {
+        "primary": "MIMTXWDATA7",
+        "wire": "MIMTXWDATA7",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA8": {
+        "primary": "MIMTXWDATA8",
+        "wire": "MIMTXWDATA8",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA9": {
+        "primary": "MIMTXWDATA9",
+        "wire": "MIMTXWDATA9",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA10": {
+        "primary": "MIMTXWDATA10",
+        "wire": "MIMTXWDATA10",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA11": {
+        "primary": "MIMTXWDATA11",
+        "wire": "MIMTXWDATA11",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA12": {
+        "primary": "MIMTXWDATA12",
+        "wire": "MIMTXWDATA12",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA13": {
+        "primary": "MIMTXWDATA13",
+        "wire": "MIMTXWDATA13",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA14": {
+        "primary": "MIMTXWDATA14",
+        "wire": "MIMTXWDATA14",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA15": {
+        "primary": "MIMTXWDATA15",
+        "wire": "MIMTXWDATA15",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA16": {
+        "primary": "MIMTXWDATA16",
+        "wire": "MIMTXWDATA16",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA17": {
+        "primary": "MIMTXWDATA17",
+        "wire": "MIMTXWDATA17",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA18": {
+        "primary": "MIMTXWDATA18",
+        "wire": "MIMTXWDATA18",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA19": {
+        "primary": "MIMTXWDATA19",
+        "wire": "MIMTXWDATA19",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA20": {
+        "primary": "MIMTXWDATA20",
+        "wire": "MIMTXWDATA20",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA21": {
+        "primary": "MIMTXWDATA21",
+        "wire": "MIMTXWDATA21",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA22": {
+        "primary": "MIMTXWDATA22",
+        "wire": "MIMTXWDATA22",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA23": {
+        "primary": "MIMTXWDATA23",
+        "wire": "MIMTXWDATA23",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA24": {
+        "primary": "MIMTXWDATA24",
+        "wire": "MIMTXWDATA24",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA25": {
+        "primary": "MIMTXWDATA25",
+        "wire": "MIMTXWDATA25",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA26": {
+        "primary": "MIMTXWDATA26",
+        "wire": "MIMTXWDATA26",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA27": {
+        "primary": "MIMTXWDATA27",
+        "wire": "MIMTXWDATA27",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA28": {
+        "primary": "MIMTXWDATA28",
+        "wire": "MIMTXWDATA28",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA29": {
+        "primary": "MIMTXWDATA29",
+        "wire": "MIMTXWDATA29",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA30": {
+        "primary": "MIMTXWDATA30",
+        "wire": "MIMTXWDATA30",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA31": {
+        "primary": "MIMTXWDATA31",
+        "wire": "MIMTXWDATA31",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA32": {
+        "primary": "MIMTXWDATA32",
+        "wire": "MIMTXWDATA32",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA33": {
+        "primary": "MIMTXWDATA33",
+        "wire": "MIMTXWDATA33",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA34": {
+        "primary": "MIMTXWDATA34",
+        "wire": "MIMTXWDATA34",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA35": {
+        "primary": "MIMTXWDATA35",
+        "wire": "MIMTXWDATA35",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA36": {
+        "primary": "MIMTXWDATA36",
+        "wire": "MIMTXWDATA36",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA37": {
+        "primary": "MIMTXWDATA37",
+        "wire": "MIMTXWDATA37",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA38": {
+        "primary": "MIMTXWDATA38",
+        "wire": "MIMTXWDATA38",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA39": {
+        "primary": "MIMTXWDATA39",
+        "wire": "MIMTXWDATA39",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA40": {
+        "primary": "MIMTXWDATA40",
+        "wire": "MIMTXWDATA40",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA41": {
+        "primary": "MIMTXWDATA41",
+        "wire": "MIMTXWDATA41",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA42": {
+        "primary": "MIMTXWDATA42",
+        "wire": "MIMTXWDATA42",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA43": {
+        "primary": "MIMTXWDATA43",
+        "wire": "MIMTXWDATA43",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA44": {
+        "primary": "MIMTXWDATA44",
+        "wire": "MIMTXWDATA44",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA45": {
+        "primary": "MIMTXWDATA45",
+        "wire": "MIMTXWDATA45",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA46": {
+        "primary": "MIMTXWDATA46",
+        "wire": "MIMTXWDATA46",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA47": {
+        "primary": "MIMTXWDATA47",
+        "wire": "MIMTXWDATA47",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA48": {
+        "primary": "MIMTXWDATA48",
+        "wire": "MIMTXWDATA48",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA49": {
+        "primary": "MIMTXWDATA49",
+        "wire": "MIMTXWDATA49",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA50": {
+        "primary": "MIMTXWDATA50",
+        "wire": "MIMTXWDATA50",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA51": {
+        "primary": "MIMTXWDATA51",
+        "wire": "MIMTXWDATA51",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA52": {
+        "primary": "MIMTXWDATA52",
+        "wire": "MIMTXWDATA52",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA53": {
+        "primary": "MIMTXWDATA53",
+        "wire": "MIMTXWDATA53",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA54": {
+        "primary": "MIMTXWDATA54",
+        "wire": "MIMTXWDATA54",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA55": {
+        "primary": "MIMTXWDATA55",
+        "wire": "MIMTXWDATA55",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA56": {
+        "primary": "MIMTXWDATA56",
+        "wire": "MIMTXWDATA56",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA57": {
+        "primary": "MIMTXWDATA57",
+        "wire": "MIMTXWDATA57",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA58": {
+        "primary": "MIMTXWDATA58",
+        "wire": "MIMTXWDATA58",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA59": {
+        "primary": "MIMTXWDATA59",
+        "wire": "MIMTXWDATA59",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA60": {
+        "primary": "MIMTXWDATA60",
+        "wire": "MIMTXWDATA60",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA61": {
+        "primary": "MIMTXWDATA61",
+        "wire": "MIMTXWDATA61",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA62": {
+        "primary": "MIMTXWDATA62",
+        "wire": "MIMTXWDATA62",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA63": {
+        "primary": "MIMTXWDATA63",
+        "wire": "MIMTXWDATA63",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA64": {
+        "primary": "MIMTXWDATA64",
+        "wire": "MIMTXWDATA64",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA65": {
+        "primary": "MIMTXWDATA65",
+        "wire": "MIMTXWDATA65",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA66": {
+        "primary": "MIMTXWDATA66",
+        "wire": "MIMTXWDATA66",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA67": {
+        "primary": "MIMTXWDATA67",
+        "wire": "MIMTXWDATA67",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWDATA68": {
+        "primary": "MIMTXWDATA68",
+        "wire": "MIMTXWDATA68",
+        "dir": "OUTPUT"
+      },
+      "MIMTXWEN": {
+        "primary": "MIMTXWEN",
+        "wire": "MIMTXWEN",
+        "dir": "OUTPUT"
+      },
+      "PIPECLK": {
+        "primary": "PIPECLK",
+        "wire": "PIPECLK",
+        "dir": "INPUT"
+      },
+      "PIPERX0CHANISALIGNED": {
+        "primary": "PIPERX0CHANISALIGNED",
+        "wire": "PIPERX0CHANISALIGNED",
+        "dir": "INPUT"
+      },
+      "PIPERX0CHARISK0": {
+        "primary": "PIPERX0CHARISK0",
+        "wire": "PIPERX0CHARISK0",
+        "dir": "INPUT"
+      },
+      "PIPERX0CHARISK1": {
+        "primary": "PIPERX0CHARISK1",
+        "wire": "PIPERX0CHARISK1",
+        "dir": "INPUT"
+      },
+      "PIPERX0DATA0": {
+        "primary": "PIPERX0DATA0",
+        "wire": "PIPERX0DATA0",
+        "dir": "INPUT"
+      },
+      "PIPERX0DATA1": {
+        "primary": "PIPERX0DATA1",
+        "wire": "PIPERX0DATA1",
+        "dir": "INPUT"
+      },
+      "PIPERX0DATA2": {
+        "primary": "PIPERX0DATA2",
+        "wire": "PIPERX0DATA2",
+        "dir": "INPUT"
+      },
+      "PIPERX0DATA3": {
+        "primary": "PIPERX0DATA3",
+        "wire": "PIPERX0DATA3",
+        "dir": "INPUT"
+      },
+      "PIPERX0DATA4": {
+        "primary": "PIPERX0DATA4",
+        "wire": "PIPERX0DATA4",
+        "dir": "INPUT"
+      },
+      "PIPERX0DATA5": {
+        "primary": "PIPERX0DATA5",
+        "wire": "PIPERX0DATA5",
+        "dir": "INPUT"
+      },
+      "PIPERX0DATA6": {
+        "primary": "PIPERX0DATA6",
+        "wire": "PIPERX0DATA6",
+        "dir": "INPUT"
+      },
+      "PIPERX0DATA7": {
+        "primary": "PIPERX0DATA7",
+        "wire": "PIPERX0DATA7",
+        "dir": "INPUT"
+      },
+      "PIPERX0DATA8": {
+        "primary": "PIPERX0DATA8",
+        "wire": "PIPERX0DATA8",
+        "dir": "INPUT"
+      },
+      "PIPERX0DATA9": {
+        "primary": "PIPERX0DATA9",
+        "wire": "PIPERX0DATA9",
+        "dir": "INPUT"
+      },
+      "PIPERX0DATA10": {
+        "primary": "PIPERX0DATA10",
+        "wire": "PIPERX0DATA10",
+        "dir": "INPUT"
+      },
+      "PIPERX0DATA11": {
+        "primary": "PIPERX0DATA11",
+        "wire": "PIPERX0DATA11",
+        "dir": "INPUT"
+      },
+      "PIPERX0DATA12": {
+        "primary": "PIPERX0DATA12",
+        "wire": "PIPERX0DATA12",
+        "dir": "INPUT"
+      },
+      "PIPERX0DATA13": {
+        "primary": "PIPERX0DATA13",
+        "wire": "PIPERX0DATA13",
+        "dir": "INPUT"
+      },
+      "PIPERX0DATA14": {
+        "primary": "PIPERX0DATA14",
+        "wire": "PIPERX0DATA14",
+        "dir": "INPUT"
+      },
+      "PIPERX0DATA15": {
+        "primary": "PIPERX0DATA15",
+        "wire": "PIPERX0DATA15",
+        "dir": "INPUT"
+      },
+      "PIPERX0ELECIDLE": {
+        "primary": "PIPERX0ELECIDLE",
+        "wire": "PIPERX0ELECIDLE",
+        "dir": "INPUT"
+      },
+      "PIPERX0PHYSTATUS": {
+        "primary": "PIPERX0PHYSTATUS",
+        "wire": "PIPERX0PHYSTATUS",
+        "dir": "INPUT"
+      },
+      "PIPERX0POLARITY": {
+        "primary": "PIPERX0POLARITY",
+        "wire": "PIPERX0POLARITY",
+        "dir": "OUTPUT"
+      },
+      "PIPERX0STATUS0": {
+        "primary": "PIPERX0STATUS0",
+        "wire": "PIPERX0STATUS0",
+        "dir": "INPUT"
+      },
+      "PIPERX0STATUS1": {
+        "primary": "PIPERX0STATUS1",
+        "wire": "PIPERX0STATUS1",
+        "dir": "INPUT"
+      },
+      "PIPERX0STATUS2": {
+        "primary": "PIPERX0STATUS2",
+        "wire": "PIPERX0STATUS2",
+        "dir": "INPUT"
+      },
+      "PIPERX0VALID": {
+        "primary": "PIPERX0VALID",
+        "wire": "PIPERX0VALID",
+        "dir": "INPUT"
+      },
+      "PIPERX1CHANISALIGNED": {
+        "primary": "PIPERX1CHANISALIGNED",
+        "wire": "PIPERX1CHANISALIGNED",
+        "dir": "INPUT"
+      },
+      "PIPERX1CHARISK0": {
+        "primary": "PIPERX1CHARISK0",
+        "wire": "PIPERX1CHARISK0",
+        "dir": "INPUT"
+      },
+      "PIPERX1CHARISK1": {
+        "primary": "PIPERX1CHARISK1",
+        "wire": "PIPERX1CHARISK1",
+        "dir": "INPUT"
+      },
+      "PIPERX1DATA0": {
+        "primary": "PIPERX1DATA0",
+        "wire": "PIPERX1DATA0",
+        "dir": "INPUT"
+      },
+      "PIPERX1DATA1": {
+        "primary": "PIPERX1DATA1",
+        "wire": "PIPERX1DATA1",
+        "dir": "INPUT"
+      },
+      "PIPERX1DATA2": {
+        "primary": "PIPERX1DATA2",
+        "wire": "PIPERX1DATA2",
+        "dir": "INPUT"
+      },
+      "PIPERX1DATA3": {
+        "primary": "PIPERX1DATA3",
+        "wire": "PIPERX1DATA3",
+        "dir": "INPUT"
+      },
+      "PIPERX1DATA4": {
+        "primary": "PIPERX1DATA4",
+        "wire": "PIPERX1DATA4",
+        "dir": "INPUT"
+      },
+      "PIPERX1DATA5": {
+        "primary": "PIPERX1DATA5",
+        "wire": "PIPERX1DATA5",
+        "dir": "INPUT"
+      },
+      "PIPERX1DATA6": {
+        "primary": "PIPERX1DATA6",
+        "wire": "PIPERX1DATA6",
+        "dir": "INPUT"
+      },
+      "PIPERX1DATA7": {
+        "primary": "PIPERX1DATA7",
+        "wire": "PIPERX1DATA7",
+        "dir": "INPUT"
+      },
+      "PIPERX1DATA8": {
+        "primary": "PIPERX1DATA8",
+        "wire": "PIPERX1DATA8",
+        "dir": "INPUT"
+      },
+      "PIPERX1DATA9": {
+        "primary": "PIPERX1DATA9",
+        "wire": "PIPERX1DATA9",
+        "dir": "INPUT"
+      },
+      "PIPERX1DATA10": {
+        "primary": "PIPERX1DATA10",
+        "wire": "PIPERX1DATA10",
+        "dir": "INPUT"
+      },
+      "PIPERX1DATA11": {
+        "primary": "PIPERX1DATA11",
+        "wire": "PIPERX1DATA11",
+        "dir": "INPUT"
+      },
+      "PIPERX1DATA12": {
+        "primary": "PIPERX1DATA12",
+        "wire": "PIPERX1DATA12",
+        "dir": "INPUT"
+      },
+      "PIPERX1DATA13": {
+        "primary": "PIPERX1DATA13",
+        "wire": "PIPERX1DATA13",
+        "dir": "INPUT"
+      },
+      "PIPERX1DATA14": {
+        "primary": "PIPERX1DATA14",
+        "wire": "PIPERX1DATA14",
+        "dir": "INPUT"
+      },
+      "PIPERX1DATA15": {
+        "primary": "PIPERX1DATA15",
+        "wire": "PIPERX1DATA15",
+        "dir": "INPUT"
+      },
+      "PIPERX1ELECIDLE": {
+        "primary": "PIPERX1ELECIDLE",
+        "wire": "PIPERX1ELECIDLE",
+        "dir": "INPUT"
+      },
+      "PIPERX1PHYSTATUS": {
+        "primary": "PIPERX1PHYSTATUS",
+        "wire": "PIPERX1PHYSTATUS",
+        "dir": "INPUT"
+      },
+      "PIPERX1POLARITY": {
+        "primary": "PIPERX1POLARITY",
+        "wire": "PIPERX1POLARITY",
+        "dir": "OUTPUT"
+      },
+      "PIPERX1STATUS0": {
+        "primary": "PIPERX1STATUS0",
+        "wire": "PIPERX1STATUS0",
+        "dir": "INPUT"
+      },
+      "PIPERX1STATUS1": {
+        "primary": "PIPERX1STATUS1",
+        "wire": "PIPERX1STATUS1",
+        "dir": "INPUT"
+      },
+      "PIPERX1STATUS2": {
+        "primary": "PIPERX1STATUS2",
+        "wire": "PIPERX1STATUS2",
+        "dir": "INPUT"
+      },
+      "PIPERX1VALID": {
+        "primary": "PIPERX1VALID",
+        "wire": "PIPERX1VALID",
+        "dir": "INPUT"
+      },
+      "PIPERX2CHANISALIGNED": {
+        "primary": "PIPERX2CHANISALIGNED",
+        "wire": "PIPERX2CHANISALIGNED",
+        "dir": "INPUT"
+      },
+      "PIPERX2CHARISK0": {
+        "primary": "PIPERX2CHARISK0",
+        "wire": "PIPERX2CHARISK0",
+        "dir": "INPUT"
+      },
+      "PIPERX2CHARISK1": {
+        "primary": "PIPERX2CHARISK1",
+        "wire": "PIPERX2CHARISK1",
+        "dir": "INPUT"
+      },
+      "PIPERX2DATA0": {
+        "primary": "PIPERX2DATA0",
+        "wire": "PIPERX2DATA0",
+        "dir": "INPUT"
+      },
+      "PIPERX2DATA1": {
+        "primary": "PIPERX2DATA1",
+        "wire": "PIPERX2DATA1",
+        "dir": "INPUT"
+      },
+      "PIPERX2DATA2": {
+        "primary": "PIPERX2DATA2",
+        "wire": "PIPERX2DATA2",
+        "dir": "INPUT"
+      },
+      "PIPERX2DATA3": {
+        "primary": "PIPERX2DATA3",
+        "wire": "PIPERX2DATA3",
+        "dir": "INPUT"
+      },
+      "PIPERX2DATA4": {
+        "primary": "PIPERX2DATA4",
+        "wire": "PIPERX2DATA4",
+        "dir": "INPUT"
+      },
+      "PIPERX2DATA5": {
+        "primary": "PIPERX2DATA5",
+        "wire": "PIPERX2DATA5",
+        "dir": "INPUT"
+      },
+      "PIPERX2DATA6": {
+        "primary": "PIPERX2DATA6",
+        "wire": "PIPERX2DATA6",
+        "dir": "INPUT"
+      },
+      "PIPERX2DATA7": {
+        "primary": "PIPERX2DATA7",
+        "wire": "PIPERX2DATA7",
+        "dir": "INPUT"
+      },
+      "PIPERX2DATA8": {
+        "primary": "PIPERX2DATA8",
+        "wire": "PIPERX2DATA8",
+        "dir": "INPUT"
+      },
+      "PIPERX2DATA9": {
+        "primary": "PIPERX2DATA9",
+        "wire": "PIPERX2DATA9",
+        "dir": "INPUT"
+      },
+      "PIPERX2DATA10": {
+        "primary": "PIPERX2DATA10",
+        "wire": "PIPERX2DATA10",
+        "dir": "INPUT"
+      },
+      "PIPERX2DATA11": {
+        "primary": "PIPERX2DATA11",
+        "wire": "PIPERX2DATA11",
+        "dir": "INPUT"
+      },
+      "PIPERX2DATA12": {
+        "primary": "PIPERX2DATA12",
+        "wire": "PIPERX2DATA12",
+        "dir": "INPUT"
+      },
+      "PIPERX2DATA13": {
+        "primary": "PIPERX2DATA13",
+        "wire": "PIPERX2DATA13",
+        "dir": "INPUT"
+      },
+      "PIPERX2DATA14": {
+        "primary": "PIPERX2DATA14",
+        "wire": "PIPERX2DATA14",
+        "dir": "INPUT"
+      },
+      "PIPERX2DATA15": {
+        "primary": "PIPERX2DATA15",
+        "wire": "PIPERX2DATA15",
+        "dir": "INPUT"
+      },
+      "PIPERX2ELECIDLE": {
+        "primary": "PIPERX2ELECIDLE",
+        "wire": "PIPERX2ELECIDLE",
+        "dir": "INPUT"
+      },
+      "PIPERX2PHYSTATUS": {
+        "primary": "PIPERX2PHYSTATUS",
+        "wire": "PIPERX2PHYSTATUS",
+        "dir": "INPUT"
+      },
+      "PIPERX2POLARITY": {
+        "primary": "PIPERX2POLARITY",
+        "wire": "PIPERX2POLARITY",
+        "dir": "OUTPUT"
+      },
+      "PIPERX2STATUS0": {
+        "primary": "PIPERX2STATUS0",
+        "wire": "PIPERX2STATUS0",
+        "dir": "INPUT"
+      },
+      "PIPERX2STATUS1": {
+        "primary": "PIPERX2STATUS1",
+        "wire": "PIPERX2STATUS1",
+        "dir": "INPUT"
+      },
+      "PIPERX2STATUS2": {
+        "primary": "PIPERX2STATUS2",
+        "wire": "PIPERX2STATUS2",
+        "dir": "INPUT"
+      },
+      "PIPERX2VALID": {
+        "primary": "PIPERX2VALID",
+        "wire": "PIPERX2VALID",
+        "dir": "INPUT"
+      },
+      "PIPERX3CHANISALIGNED": {
+        "primary": "PIPERX3CHANISALIGNED",
+        "wire": "PIPERX3CHANISALIGNED",
+        "dir": "INPUT"
+      },
+      "PIPERX3CHARISK0": {
+        "primary": "PIPERX3CHARISK0",
+        "wire": "PIPERX3CHARISK0",
+        "dir": "INPUT"
+      },
+      "PIPERX3CHARISK1": {
+        "primary": "PIPERX3CHARISK1",
+        "wire": "PIPERX3CHARISK1",
+        "dir": "INPUT"
+      },
+      "PIPERX3DATA0": {
+        "primary": "PIPERX3DATA0",
+        "wire": "PIPERX3DATA0",
+        "dir": "INPUT"
+      },
+      "PIPERX3DATA1": {
+        "primary": "PIPERX3DATA1",
+        "wire": "PIPERX3DATA1",
+        "dir": "INPUT"
+      },
+      "PIPERX3DATA2": {
+        "primary": "PIPERX3DATA2",
+        "wire": "PIPERX3DATA2",
+        "dir": "INPUT"
+      },
+      "PIPERX3DATA3": {
+        "primary": "PIPERX3DATA3",
+        "wire": "PIPERX3DATA3",
+        "dir": "INPUT"
+      },
+      "PIPERX3DATA4": {
+        "primary": "PIPERX3DATA4",
+        "wire": "PIPERX3DATA4",
+        "dir": "INPUT"
+      },
+      "PIPERX3DATA5": {
+        "primary": "PIPERX3DATA5",
+        "wire": "PIPERX3DATA5",
+        "dir": "INPUT"
+      },
+      "PIPERX3DATA6": {
+        "primary": "PIPERX3DATA6",
+        "wire": "PIPERX3DATA6",
+        "dir": "INPUT"
+      },
+      "PIPERX3DATA7": {
+        "primary": "PIPERX3DATA7",
+        "wire": "PIPERX3DATA7",
+        "dir": "INPUT"
+      },
+      "PIPERX3DATA8": {
+        "primary": "PIPERX3DATA8",
+        "wire": "PIPERX3DATA8",
+        "dir": "INPUT"
+      },
+      "PIPERX3DATA9": {
+        "primary": "PIPERX3DATA9",
+        "wire": "PIPERX3DATA9",
+        "dir": "INPUT"
+      },
+      "PIPERX3DATA10": {
+        "primary": "PIPERX3DATA10",
+        "wire": "PIPERX3DATA10",
+        "dir": "INPUT"
+      },
+      "PIPERX3DATA11": {
+        "primary": "PIPERX3DATA11",
+        "wire": "PIPERX3DATA11",
+        "dir": "INPUT"
+      },
+      "PIPERX3DATA12": {
+        "primary": "PIPERX3DATA12",
+        "wire": "PIPERX3DATA12",
+        "dir": "INPUT"
+      },
+      "PIPERX3DATA13": {
+        "primary": "PIPERX3DATA13",
+        "wire": "PIPERX3DATA13",
+        "dir": "INPUT"
+      },
+      "PIPERX3DATA14": {
+        "primary": "PIPERX3DATA14",
+        "wire": "PIPERX3DATA14",
+        "dir": "INPUT"
+      },
+      "PIPERX3DATA15": {
+        "primary": "PIPERX3DATA15",
+        "wire": "PIPERX3DATA15",
+        "dir": "INPUT"
+      },
+      "PIPERX3ELECIDLE": {
+        "primary": "PIPERX3ELECIDLE",
+        "wire": "PIPERX3ELECIDLE",
+        "dir": "INPUT"
+      },
+      "PIPERX3PHYSTATUS": {
+        "primary": "PIPERX3PHYSTATUS",
+        "wire": "PIPERX3PHYSTATUS",
+        "dir": "INPUT"
+      },
+      "PIPERX3POLARITY": {
+        "primary": "PIPERX3POLARITY",
+        "wire": "PIPERX3POLARITY",
+        "dir": "OUTPUT"
+      },
+      "PIPERX3STATUS0": {
+        "primary": "PIPERX3STATUS0",
+        "wire": "PIPERX3STATUS0",
+        "dir": "INPUT"
+      },
+      "PIPERX3STATUS1": {
+        "primary": "PIPERX3STATUS1",
+        "wire": "PIPERX3STATUS1",
+        "dir": "INPUT"
+      },
+      "PIPERX3STATUS2": {
+        "primary": "PIPERX3STATUS2",
+        "wire": "PIPERX3STATUS2",
+        "dir": "INPUT"
+      },
+      "PIPERX3VALID": {
+        "primary": "PIPERX3VALID",
+        "wire": "PIPERX3VALID",
+        "dir": "INPUT"
+      },
+      "PIPERX4CHANISALIGNED": {
+        "primary": "PIPERX4CHANISALIGNED",
+        "wire": "PIPERX4CHANISALIGNED",
+        "dir": "INPUT"
+      },
+      "PIPERX4CHARISK0": {
+        "primary": "PIPERX4CHARISK0",
+        "wire": "PIPERX4CHARISK0",
+        "dir": "INPUT"
+      },
+      "PIPERX4CHARISK1": {
+        "primary": "PIPERX4CHARISK1",
+        "wire": "PIPERX4CHARISK1",
+        "dir": "INPUT"
+      },
+      "PIPERX4DATA0": {
+        "primary": "PIPERX4DATA0",
+        "wire": "PIPERX4DATA0",
+        "dir": "INPUT"
+      },
+      "PIPERX4DATA1": {
+        "primary": "PIPERX4DATA1",
+        "wire": "PIPERX4DATA1",
+        "dir": "INPUT"
+      },
+      "PIPERX4DATA2": {
+        "primary": "PIPERX4DATA2",
+        "wire": "PIPERX4DATA2",
+        "dir": "INPUT"
+      },
+      "PIPERX4DATA3": {
+        "primary": "PIPERX4DATA3",
+        "wire": "PIPERX4DATA3",
+        "dir": "INPUT"
+      },
+      "PIPERX4DATA4": {
+        "primary": "PIPERX4DATA4",
+        "wire": "PIPERX4DATA4",
+        "dir": "INPUT"
+      },
+      "PIPERX4DATA5": {
+        "primary": "PIPERX4DATA5",
+        "wire": "PIPERX4DATA5",
+        "dir": "INPUT"
+      },
+      "PIPERX4DATA6": {
+        "primary": "PIPERX4DATA6",
+        "wire": "PIPERX4DATA6",
+        "dir": "INPUT"
+      },
+      "PIPERX4DATA7": {
+        "primary": "PIPERX4DATA7",
+        "wire": "PIPERX4DATA7",
+        "dir": "INPUT"
+      },
+      "PIPERX4DATA8": {
+        "primary": "PIPERX4DATA8",
+        "wire": "PIPERX4DATA8",
+        "dir": "INPUT"
+      },
+      "PIPERX4DATA9": {
+        "primary": "PIPERX4DATA9",
+        "wire": "PIPERX4DATA9",
+        "dir": "INPUT"
+      },
+      "PIPERX4DATA10": {
+        "primary": "PIPERX4DATA10",
+        "wire": "PIPERX4DATA10",
+        "dir": "INPUT"
+      },
+      "PIPERX4DATA11": {
+        "primary": "PIPERX4DATA11",
+        "wire": "PIPERX4DATA11",
+        "dir": "INPUT"
+      },
+      "PIPERX4DATA12": {
+        "primary": "PIPERX4DATA12",
+        "wire": "PIPERX4DATA12",
+        "dir": "INPUT"
+      },
+      "PIPERX4DATA13": {
+        "primary": "PIPERX4DATA13",
+        "wire": "PIPERX4DATA13",
+        "dir": "INPUT"
+      },
+      "PIPERX4DATA14": {
+        "primary": "PIPERX4DATA14",
+        "wire": "PIPERX4DATA14",
+        "dir": "INPUT"
+      },
+      "PIPERX4DATA15": {
+        "primary": "PIPERX4DATA15",
+        "wire": "PIPERX4DATA15",
+        "dir": "INPUT"
+      },
+      "PIPERX4ELECIDLE": {
+        "primary": "PIPERX4ELECIDLE",
+        "wire": "PIPERX4ELECIDLE",
+        "dir": "INPUT"
+      },
+      "PIPERX4PHYSTATUS": {
+        "primary": "PIPERX4PHYSTATUS",
+        "wire": "PIPERX4PHYSTATUS",
+        "dir": "INPUT"
+      },
+      "PIPERX4POLARITY": {
+        "primary": "PIPERX4POLARITY",
+        "wire": "PIPERX4POLARITY",
+        "dir": "OUTPUT"
+      },
+      "PIPERX4STATUS0": {
+        "primary": "PIPERX4STATUS0",
+        "wire": "PIPERX4STATUS0",
+        "dir": "INPUT"
+      },
+      "PIPERX4STATUS1": {
+        "primary": "PIPERX4STATUS1",
+        "wire": "PIPERX4STATUS1",
+        "dir": "INPUT"
+      },
+      "PIPERX4STATUS2": {
+        "primary": "PIPERX4STATUS2",
+        "wire": "PIPERX4STATUS2",
+        "dir": "INPUT"
+      },
+      "PIPERX4VALID": {
+        "primary": "PIPERX4VALID",
+        "wire": "PIPERX4VALID",
+        "dir": "INPUT"
+      },
+      "PIPERX5CHANISALIGNED": {
+        "primary": "PIPERX5CHANISALIGNED",
+        "wire": "PIPERX5CHANISALIGNED",
+        "dir": "INPUT"
+      },
+      "PIPERX5CHARISK0": {
+        "primary": "PIPERX5CHARISK0",
+        "wire": "PIPERX5CHARISK0",
+        "dir": "INPUT"
+      },
+      "PIPERX5CHARISK1": {
+        "primary": "PIPERX5CHARISK1",
+        "wire": "PIPERX5CHARISK1",
+        "dir": "INPUT"
+      },
+      "PIPERX5DATA0": {
+        "primary": "PIPERX5DATA0",
+        "wire": "PIPERX5DATA0",
+        "dir": "INPUT"
+      },
+      "PIPERX5DATA1": {
+        "primary": "PIPERX5DATA1",
+        "wire": "PIPERX5DATA1",
+        "dir": "INPUT"
+      },
+      "PIPERX5DATA2": {
+        "primary": "PIPERX5DATA2",
+        "wire": "PIPERX5DATA2",
+        "dir": "INPUT"
+      },
+      "PIPERX5DATA3": {
+        "primary": "PIPERX5DATA3",
+        "wire": "PIPERX5DATA3",
+        "dir": "INPUT"
+      },
+      "PIPERX5DATA4": {
+        "primary": "PIPERX5DATA4",
+        "wire": "PIPERX5DATA4",
+        "dir": "INPUT"
+      },
+      "PIPERX5DATA5": {
+        "primary": "PIPERX5DATA5",
+        "wire": "PIPERX5DATA5",
+        "dir": "INPUT"
+      },
+      "PIPERX5DATA6": {
+        "primary": "PIPERX5DATA6",
+        "wire": "PIPERX5DATA6",
+        "dir": "INPUT"
+      },
+      "PIPERX5DATA7": {
+        "primary": "PIPERX5DATA7",
+        "wire": "PIPERX5DATA7",
+        "dir": "INPUT"
+      },
+      "PIPERX5DATA8": {
+        "primary": "PIPERX5DATA8",
+        "wire": "PIPERX5DATA8",
+        "dir": "INPUT"
+      },
+      "PIPERX5DATA9": {
+        "primary": "PIPERX5DATA9",
+        "wire": "PIPERX5DATA9",
+        "dir": "INPUT"
+      },
+      "PIPERX5DATA10": {
+        "primary": "PIPERX5DATA10",
+        "wire": "PIPERX5DATA10",
+        "dir": "INPUT"
+      },
+      "PIPERX5DATA11": {
+        "primary": "PIPERX5DATA11",
+        "wire": "PIPERX5DATA11",
+        "dir": "INPUT"
+      },
+      "PIPERX5DATA12": {
+        "primary": "PIPERX5DATA12",
+        "wire": "PIPERX5DATA12",
+        "dir": "INPUT"
+      },
+      "PIPERX5DATA13": {
+        "primary": "PIPERX5DATA13",
+        "wire": "PIPERX5DATA13",
+        "dir": "INPUT"
+      },
+      "PIPERX5DATA14": {
+        "primary": "PIPERX5DATA14",
+        "wire": "PIPERX5DATA14",
+        "dir": "INPUT"
+      },
+      "PIPERX5DATA15": {
+        "primary": "PIPERX5DATA15",
+        "wire": "PIPERX5DATA15",
+        "dir": "INPUT"
+      },
+      "PIPERX5ELECIDLE": {
+        "primary": "PIPERX5ELECIDLE",
+        "wire": "PIPERX5ELECIDLE",
+        "dir": "INPUT"
+      },
+      "PIPERX5PHYSTATUS": {
+        "primary": "PIPERX5PHYSTATUS",
+        "wire": "PIPERX5PHYSTATUS",
+        "dir": "INPUT"
+      },
+      "PIPERX5POLARITY": {
+        "primary": "PIPERX5POLARITY",
+        "wire": "PIPERX5POLARITY",
+        "dir": "OUTPUT"
+      },
+      "PIPERX5STATUS0": {
+        "primary": "PIPERX5STATUS0",
+        "wire": "PIPERX5STATUS0",
+        "dir": "INPUT"
+      },
+      "PIPERX5STATUS1": {
+        "primary": "PIPERX5STATUS1",
+        "wire": "PIPERX5STATUS1",
+        "dir": "INPUT"
+      },
+      "PIPERX5STATUS2": {
+        "primary": "PIPERX5STATUS2",
+        "wire": "PIPERX5STATUS2",
+        "dir": "INPUT"
+      },
+      "PIPERX5VALID": {
+        "primary": "PIPERX5VALID",
+        "wire": "PIPERX5VALID",
+        "dir": "INPUT"
+      },
+      "PIPERX6CHANISALIGNED": {
+        "primary": "PIPERX6CHANISALIGNED",
+        "wire": "PIPERX6CHANISALIGNED",
+        "dir": "INPUT"
+      },
+      "PIPERX6CHARISK0": {
+        "primary": "PIPERX6CHARISK0",
+        "wire": "PIPERX6CHARISK0",
+        "dir": "INPUT"
+      },
+      "PIPERX6CHARISK1": {
+        "primary": "PIPERX6CHARISK1",
+        "wire": "PIPERX6CHARISK1",
+        "dir": "INPUT"
+      },
+      "PIPERX6DATA0": {
+        "primary": "PIPERX6DATA0",
+        "wire": "PIPERX6DATA0",
+        "dir": "INPUT"
+      },
+      "PIPERX6DATA1": {
+        "primary": "PIPERX6DATA1",
+        "wire": "PIPERX6DATA1",
+        "dir": "INPUT"
+      },
+      "PIPERX6DATA2": {
+        "primary": "PIPERX6DATA2",
+        "wire": "PIPERX6DATA2",
+        "dir": "INPUT"
+      },
+      "PIPERX6DATA3": {
+        "primary": "PIPERX6DATA3",
+        "wire": "PIPERX6DATA3",
+        "dir": "INPUT"
+      },
+      "PIPERX6DATA4": {
+        "primary": "PIPERX6DATA4",
+        "wire": "PIPERX6DATA4",
+        "dir": "INPUT"
+      },
+      "PIPERX6DATA5": {
+        "primary": "PIPERX6DATA5",
+        "wire": "PIPERX6DATA5",
+        "dir": "INPUT"
+      },
+      "PIPERX6DATA6": {
+        "primary": "PIPERX6DATA6",
+        "wire": "PIPERX6DATA6",
+        "dir": "INPUT"
+      },
+      "PIPERX6DATA7": {
+        "primary": "PIPERX6DATA7",
+        "wire": "PIPERX6DATA7",
+        "dir": "INPUT"
+      },
+      "PIPERX6DATA8": {
+        "primary": "PIPERX6DATA8",
+        "wire": "PIPERX6DATA8",
+        "dir": "INPUT"
+      },
+      "PIPERX6DATA9": {
+        "primary": "PIPERX6DATA9",
+        "wire": "PIPERX6DATA9",
+        "dir": "INPUT"
+      },
+      "PIPERX6DATA10": {
+        "primary": "PIPERX6DATA10",
+        "wire": "PIPERX6DATA10",
+        "dir": "INPUT"
+      },
+      "PIPERX6DATA11": {
+        "primary": "PIPERX6DATA11",
+        "wire": "PIPERX6DATA11",
+        "dir": "INPUT"
+      },
+      "PIPERX6DATA12": {
+        "primary": "PIPERX6DATA12",
+        "wire": "PIPERX6DATA12",
+        "dir": "INPUT"
+      },
+      "PIPERX6DATA13": {
+        "primary": "PIPERX6DATA13",
+        "wire": "PIPERX6DATA13",
+        "dir": "INPUT"
+      },
+      "PIPERX6DATA14": {
+        "primary": "PIPERX6DATA14",
+        "wire": "PIPERX6DATA14",
+        "dir": "INPUT"
+      },
+      "PIPERX6DATA15": {
+        "primary": "PIPERX6DATA15",
+        "wire": "PIPERX6DATA15",
+        "dir": "INPUT"
+      },
+      "PIPERX6ELECIDLE": {
+        "primary": "PIPERX6ELECIDLE",
+        "wire": "PIPERX6ELECIDLE",
+        "dir": "INPUT"
+      },
+      "PIPERX6PHYSTATUS": {
+        "primary": "PIPERX6PHYSTATUS",
+        "wire": "PIPERX6PHYSTATUS",
+        "dir": "INPUT"
+      },
+      "PIPERX6POLARITY": {
+        "primary": "PIPERX6POLARITY",
+        "wire": "PIPERX6POLARITY",
+        "dir": "OUTPUT"
+      },
+      "PIPERX6STATUS0": {
+        "primary": "PIPERX6STATUS0",
+        "wire": "PIPERX6STATUS0",
+        "dir": "INPUT"
+      },
+      "PIPERX6STATUS1": {
+        "primary": "PIPERX6STATUS1",
+        "wire": "PIPERX6STATUS1",
+        "dir": "INPUT"
+      },
+      "PIPERX6STATUS2": {
+        "primary": "PIPERX6STATUS2",
+        "wire": "PIPERX6STATUS2",
+        "dir": "INPUT"
+      },
+      "PIPERX6VALID": {
+        "primary": "PIPERX6VALID",
+        "wire": "PIPERX6VALID",
+        "dir": "INPUT"
+      },
+      "PIPERX7CHANISALIGNED": {
+        "primary": "PIPERX7CHANISALIGNED",
+        "wire": "PIPERX7CHANISALIGNED",
+        "dir": "INPUT"
+      },
+      "PIPERX7CHARISK0": {
+        "primary": "PIPERX7CHARISK0",
+        "wire": "PIPERX7CHARISK0",
+        "dir": "INPUT"
+      },
+      "PIPERX7CHARISK1": {
+        "primary": "PIPERX7CHARISK1",
+        "wire": "PIPERX7CHARISK1",
+        "dir": "INPUT"
+      },
+      "PIPERX7DATA0": {
+        "primary": "PIPERX7DATA0",
+        "wire": "PIPERX7DATA0",
+        "dir": "INPUT"
+      },
+      "PIPERX7DATA1": {
+        "primary": "PIPERX7DATA1",
+        "wire": "PIPERX7DATA1",
+        "dir": "INPUT"
+      },
+      "PIPERX7DATA2": {
+        "primary": "PIPERX7DATA2",
+        "wire": "PIPERX7DATA2",
+        "dir": "INPUT"
+      },
+      "PIPERX7DATA3": {
+        "primary": "PIPERX7DATA3",
+        "wire": "PIPERX7DATA3",
+        "dir": "INPUT"
+      },
+      "PIPERX7DATA4": {
+        "primary": "PIPERX7DATA4",
+        "wire": "PIPERX7DATA4",
+        "dir": "INPUT"
+      },
+      "PIPERX7DATA5": {
+        "primary": "PIPERX7DATA5",
+        "wire": "PIPERX7DATA5",
+        "dir": "INPUT"
+      },
+      "PIPERX7DATA6": {
+        "primary": "PIPERX7DATA6",
+        "wire": "PIPERX7DATA6",
+        "dir": "INPUT"
+      },
+      "PIPERX7DATA7": {
+        "primary": "PIPERX7DATA7",
+        "wire": "PIPERX7DATA7",
+        "dir": "INPUT"
+      },
+      "PIPERX7DATA8": {
+        "primary": "PIPERX7DATA8",
+        "wire": "PIPERX7DATA8",
+        "dir": "INPUT"
+      },
+      "PIPERX7DATA9": {
+        "primary": "PIPERX7DATA9",
+        "wire": "PIPERX7DATA9",
+        "dir": "INPUT"
+      },
+      "PIPERX7DATA10": {
+        "primary": "PIPERX7DATA10",
+        "wire": "PIPERX7DATA10",
+        "dir": "INPUT"
+      },
+      "PIPERX7DATA11": {
+        "primary": "PIPERX7DATA11",
+        "wire": "PIPERX7DATA11",
+        "dir": "INPUT"
+      },
+      "PIPERX7DATA12": {
+        "primary": "PIPERX7DATA12",
+        "wire": "PIPERX7DATA12",
+        "dir": "INPUT"
+      },
+      "PIPERX7DATA13": {
+        "primary": "PIPERX7DATA13",
+        "wire": "PIPERX7DATA13",
+        "dir": "INPUT"
+      },
+      "PIPERX7DATA14": {
+        "primary": "PIPERX7DATA14",
+        "wire": "PIPERX7DATA14",
+        "dir": "INPUT"
+      },
+      "PIPERX7DATA15": {
+        "primary": "PIPERX7DATA15",
+        "wire": "PIPERX7DATA15",
+        "dir": "INPUT"
+      },
+      "PIPERX7ELECIDLE": {
+        "primary": "PIPERX7ELECIDLE",
+        "wire": "PIPERX7ELECIDLE",
+        "dir": "INPUT"
+      },
+      "PIPERX7PHYSTATUS": {
+        "primary": "PIPERX7PHYSTATUS",
+        "wire": "PIPERX7PHYSTATUS",
+        "dir": "INPUT"
+      },
+      "PIPERX7POLARITY": {
+        "primary": "PIPERX7POLARITY",
+        "wire": "PIPERX7POLARITY",
+        "dir": "OUTPUT"
+      },
+      "PIPERX7STATUS0": {
+        "primary": "PIPERX7STATUS0",
+        "wire": "PIPERX7STATUS0",
+        "dir": "INPUT"
+      },
+      "PIPERX7STATUS1": {
+        "primary": "PIPERX7STATUS1",
+        "wire": "PIPERX7STATUS1",
+        "dir": "INPUT"
+      },
+      "PIPERX7STATUS2": {
+        "primary": "PIPERX7STATUS2",
+        "wire": "PIPERX7STATUS2",
+        "dir": "INPUT"
+      },
+      "PIPERX7VALID": {
+        "primary": "PIPERX7VALID",
+        "wire": "PIPERX7VALID",
+        "dir": "INPUT"
+      },
+      "PIPETX0CHARISK0": {
+        "primary": "PIPETX0CHARISK0",
+        "wire": "PIPETX0CHARISK0",
+        "dir": "OUTPUT"
+      },
+      "PIPETX0CHARISK1": {
+        "primary": "PIPETX0CHARISK1",
+        "wire": "PIPETX0CHARISK1",
+        "dir": "OUTPUT"
+      },
+      "PIPETX0COMPLIANCE": {
+        "primary": "PIPETX0COMPLIANCE",
+        "wire": "PIPETX0COMPLIANCE",
+        "dir": "OUTPUT"
+      },
+      "PIPETX0DATA0": {
+        "primary": "PIPETX0DATA0",
+        "wire": "PIPETX0DATA0",
+        "dir": "OUTPUT"
+      },
+      "PIPETX0DATA1": {
+        "primary": "PIPETX0DATA1",
+        "wire": "PIPETX0DATA1",
+        "dir": "OUTPUT"
+      },
+      "PIPETX0DATA2": {
+        "primary": "PIPETX0DATA2",
+        "wire": "PIPETX0DATA2",
+        "dir": "OUTPUT"
+      },
+      "PIPETX0DATA3": {
+        "primary": "PIPETX0DATA3",
+        "wire": "PIPETX0DATA3",
+        "dir": "OUTPUT"
+      },
+      "PIPETX0DATA4": {
+        "primary": "PIPETX0DATA4",
+        "wire": "PIPETX0DATA4",
+        "dir": "OUTPUT"
+      },
+      "PIPETX0DATA5": {
+        "primary": "PIPETX0DATA5",
+        "wire": "PIPETX0DATA5",
+        "dir": "OUTPUT"
+      },
+      "PIPETX0DATA6": {
+        "primary": "PIPETX0DATA6",
+        "wire": "PIPETX0DATA6",
+        "dir": "OUTPUT"
+      },
+      "PIPETX0DATA7": {
+        "primary": "PIPETX0DATA7",
+        "wire": "PIPETX0DATA7",
+        "dir": "OUTPUT"
+      },
+      "PIPETX0DATA8": {
+        "primary": "PIPETX0DATA8",
+        "wire": "PIPETX0DATA8",
+        "dir": "OUTPUT"
+      },
+      "PIPETX0DATA9": {
+        "primary": "PIPETX0DATA9",
+        "wire": "PIPETX0DATA9",
+        "dir": "OUTPUT"
+      },
+      "PIPETX0DATA10": {
+        "primary": "PIPETX0DATA10",
+        "wire": "PIPETX0DATA10",
+        "dir": "OUTPUT"
+      },
+      "PIPETX0DATA11": {
+        "primary": "PIPETX0DATA11",
+        "wire": "PIPETX0DATA11",
+        "dir": "OUTPUT"
+      },
+      "PIPETX0DATA12": {
+        "primary": "PIPETX0DATA12",
+        "wire": "PIPETX0DATA12",
+        "dir": "OUTPUT"
+      },
+      "PIPETX0DATA13": {
+        "primary": "PIPETX0DATA13",
+        "wire": "PIPETX0DATA13",
+        "dir": "OUTPUT"
+      },
+      "PIPETX0DATA14": {
+        "primary": "PIPETX0DATA14",
+        "wire": "PIPETX0DATA14",
+        "dir": "OUTPUT"
+      },
+      "PIPETX0DATA15": {
+        "primary": "PIPETX0DATA15",
+        "wire": "PIPETX0DATA15",
+        "dir": "OUTPUT"
+      },
+      "PIPETX0ELECIDLE": {
+        "primary": "PIPETX0ELECIDLE",
+        "wire": "PIPETX0ELECIDLE",
+        "dir": "OUTPUT"
+      },
+      "PIPETX0POWERDOWN0": {
+        "primary": "PIPETX0POWERDOWN0",
+        "wire": "PIPETX0POWERDOWN0",
+        "dir": "OUTPUT"
+      },
+      "PIPETX0POWERDOWN1": {
+        "primary": "PIPETX0POWERDOWN1",
+        "wire": "PIPETX0POWERDOWN1",
+        "dir": "OUTPUT"
+      },
+      "PIPETX1CHARISK0": {
+        "primary": "PIPETX1CHARISK0",
+        "wire": "PIPETX1CHARISK0",
+        "dir": "OUTPUT"
+      },
+      "PIPETX1CHARISK1": {
+        "primary": "PIPETX1CHARISK1",
+        "wire": "PIPETX1CHARISK1",
+        "dir": "OUTPUT"
+      },
+      "PIPETX1COMPLIANCE": {
+        "primary": "PIPETX1COMPLIANCE",
+        "wire": "PIPETX1COMPLIANCE",
+        "dir": "OUTPUT"
+      },
+      "PIPETX1DATA0": {
+        "primary": "PIPETX1DATA0",
+        "wire": "PIPETX1DATA0",
+        "dir": "OUTPUT"
+      },
+      "PIPETX1DATA1": {
+        "primary": "PIPETX1DATA1",
+        "wire": "PIPETX1DATA1",
+        "dir": "OUTPUT"
+      },
+      "PIPETX1DATA2": {
+        "primary": "PIPETX1DATA2",
+        "wire": "PIPETX1DATA2",
+        "dir": "OUTPUT"
+      },
+      "PIPETX1DATA3": {
+        "primary": "PIPETX1DATA3",
+        "wire": "PIPETX1DATA3",
+        "dir": "OUTPUT"
+      },
+      "PIPETX1DATA4": {
+        "primary": "PIPETX1DATA4",
+        "wire": "PIPETX1DATA4",
+        "dir": "OUTPUT"
+      },
+      "PIPETX1DATA5": {
+        "primary": "PIPETX1DATA5",
+        "wire": "PIPETX1DATA5",
+        "dir": "OUTPUT"
+      },
+      "PIPETX1DATA6": {
+        "primary": "PIPETX1DATA6",
+        "wire": "PIPETX1DATA6",
+        "dir": "OUTPUT"
+      },
+      "PIPETX1DATA7": {
+        "primary": "PIPETX1DATA7",
+        "wire": "PIPETX1DATA7",
+        "dir": "OUTPUT"
+      },
+      "PIPETX1DATA8": {
+        "primary": "PIPETX1DATA8",
+        "wire": "PIPETX1DATA8",
+        "dir": "OUTPUT"
+      },
+      "PIPETX1DATA9": {
+        "primary": "PIPETX1DATA9",
+        "wire": "PIPETX1DATA9",
+        "dir": "OUTPUT"
+      },
+      "PIPETX1DATA10": {
+        "primary": "PIPETX1DATA10",
+        "wire": "PIPETX1DATA10",
+        "dir": "OUTPUT"
+      },
+      "PIPETX1DATA11": {
+        "primary": "PIPETX1DATA11",
+        "wire": "PIPETX1DATA11",
+        "dir": "OUTPUT"
+      },
+      "PIPETX1DATA12": {
+        "primary": "PIPETX1DATA12",
+        "wire": "PIPETX1DATA12",
+        "dir": "OUTPUT"
+      },
+      "PIPETX1DATA13": {
+        "primary": "PIPETX1DATA13",
+        "wire": "PIPETX1DATA13",
+        "dir": "OUTPUT"
+      },
+      "PIPETX1DATA14": {
+        "primary": "PIPETX1DATA14",
+        "wire": "PIPETX1DATA14",
+        "dir": "OUTPUT"
+      },
+      "PIPETX1DATA15": {
+        "primary": "PIPETX1DATA15",
+        "wire": "PIPETX1DATA15",
+        "dir": "OUTPUT"
+      },
+      "PIPETX1ELECIDLE": {
+        "primary": "PIPETX1ELECIDLE",
+        "wire": "PIPETX1ELECIDLE",
+        "dir": "OUTPUT"
+      },
+      "PIPETX1POWERDOWN0": {
+        "primary": "PIPETX1POWERDOWN0",
+        "wire": "PIPETX1POWERDOWN0",
+        "dir": "OUTPUT"
+      },
+      "PIPETX1POWERDOWN1": {
+        "primary": "PIPETX1POWERDOWN1",
+        "wire": "PIPETX1POWERDOWN1",
+        "dir": "OUTPUT"
+      },
+      "PIPETX2CHARISK0": {
+        "primary": "PIPETX2CHARISK0",
+        "wire": "PIPETX2CHARISK0",
+        "dir": "OUTPUT"
+      },
+      "PIPETX2CHARISK1": {
+        "primary": "PIPETX2CHARISK1",
+        "wire": "PIPETX2CHARISK1",
+        "dir": "OUTPUT"
+      },
+      "PIPETX2COMPLIANCE": {
+        "primary": "PIPETX2COMPLIANCE",
+        "wire": "PIPETX2COMPLIANCE",
+        "dir": "OUTPUT"
+      },
+      "PIPETX2DATA0": {
+        "primary": "PIPETX2DATA0",
+        "wire": "PIPETX2DATA0",
+        "dir": "OUTPUT"
+      },
+      "PIPETX2DATA1": {
+        "primary": "PIPETX2DATA1",
+        "wire": "PIPETX2DATA1",
+        "dir": "OUTPUT"
+      },
+      "PIPETX2DATA2": {
+        "primary": "PIPETX2DATA2",
+        "wire": "PIPETX2DATA2",
+        "dir": "OUTPUT"
+      },
+      "PIPETX2DATA3": {
+        "primary": "PIPETX2DATA3",
+        "wire": "PIPETX2DATA3",
+        "dir": "OUTPUT"
+      },
+      "PIPETX2DATA4": {
+        "primary": "PIPETX2DATA4",
+        "wire": "PIPETX2DATA4",
+        "dir": "OUTPUT"
+      },
+      "PIPETX2DATA5": {
+        "primary": "PIPETX2DATA5",
+        "wire": "PIPETX2DATA5",
+        "dir": "OUTPUT"
+      },
+      "PIPETX2DATA6": {
+        "primary": "PIPETX2DATA6",
+        "wire": "PIPETX2DATA6",
+        "dir": "OUTPUT"
+      },
+      "PIPETX2DATA7": {
+        "primary": "PIPETX2DATA7",
+        "wire": "PIPETX2DATA7",
+        "dir": "OUTPUT"
+      },
+      "PIPETX2DATA8": {
+        "primary": "PIPETX2DATA8",
+        "wire": "PIPETX2DATA8",
+        "dir": "OUTPUT"
+      },
+      "PIPETX2DATA9": {
+        "primary": "PIPETX2DATA9",
+        "wire": "PIPETX2DATA9",
+        "dir": "OUTPUT"
+      },
+      "PIPETX2DATA10": {
+        "primary": "PIPETX2DATA10",
+        "wire": "PIPETX2DATA10",
+        "dir": "OUTPUT"
+      },
+      "PIPETX2DATA11": {
+        "primary": "PIPETX2DATA11",
+        "wire": "PIPETX2DATA11",
+        "dir": "OUTPUT"
+      },
+      "PIPETX2DATA12": {
+        "primary": "PIPETX2DATA12",
+        "wire": "PIPETX2DATA12",
+        "dir": "OUTPUT"
+      },
+      "PIPETX2DATA13": {
+        "primary": "PIPETX2DATA13",
+        "wire": "PIPETX2DATA13",
+        "dir": "OUTPUT"
+      },
+      "PIPETX2DATA14": {
+        "primary": "PIPETX2DATA14",
+        "wire": "PIPETX2DATA14",
+        "dir": "OUTPUT"
+      },
+      "PIPETX2DATA15": {
+        "primary": "PIPETX2DATA15",
+        "wire": "PIPETX2DATA15",
+        "dir": "OUTPUT"
+      },
+      "PIPETX2ELECIDLE": {
+        "primary": "PIPETX2ELECIDLE",
+        "wire": "PIPETX2ELECIDLE",
+        "dir": "OUTPUT"
+      },
+      "PIPETX2POWERDOWN0": {
+        "primary": "PIPETX2POWERDOWN0",
+        "wire": "PIPETX2POWERDOWN0",
+        "dir": "OUTPUT"
+      },
+      "PIPETX2POWERDOWN1": {
+        "primary": "PIPETX2POWERDOWN1",
+        "wire": "PIPETX2POWERDOWN1",
+        "dir": "OUTPUT"
+      },
+      "PIPETX3CHARISK0": {
+        "primary": "PIPETX3CHARISK0",
+        "wire": "PIPETX3CHARISK0",
+        "dir": "OUTPUT"
+      },
+      "PIPETX3CHARISK1": {
+        "primary": "PIPETX3CHARISK1",
+        "wire": "PIPETX3CHARISK1",
+        "dir": "OUTPUT"
+      },
+      "PIPETX3COMPLIANCE": {
+        "primary": "PIPETX3COMPLIANCE",
+        "wire": "PIPETX3COMPLIANCE",
+        "dir": "OUTPUT"
+      },
+      "PIPETX3DATA0": {
+        "primary": "PIPETX3DATA0",
+        "wire": "PIPETX3DATA0",
+        "dir": "OUTPUT"
+      },
+      "PIPETX3DATA1": {
+        "primary": "PIPETX3DATA1",
+        "wire": "PIPETX3DATA1",
+        "dir": "OUTPUT"
+      },
+      "PIPETX3DATA2": {
+        "primary": "PIPETX3DATA2",
+        "wire": "PIPETX3DATA2",
+        "dir": "OUTPUT"
+      },
+      "PIPETX3DATA3": {
+        "primary": "PIPETX3DATA3",
+        "wire": "PIPETX3DATA3",
+        "dir": "OUTPUT"
+      },
+      "PIPETX3DATA4": {
+        "primary": "PIPETX3DATA4",
+        "wire": "PIPETX3DATA4",
+        "dir": "OUTPUT"
+      },
+      "PIPETX3DATA5": {
+        "primary": "PIPETX3DATA5",
+        "wire": "PIPETX3DATA5",
+        "dir": "OUTPUT"
+      },
+      "PIPETX3DATA6": {
+        "primary": "PIPETX3DATA6",
+        "wire": "PIPETX3DATA6",
+        "dir": "OUTPUT"
+      },
+      "PIPETX3DATA7": {
+        "primary": "PIPETX3DATA7",
+        "wire": "PIPETX3DATA7",
+        "dir": "OUTPUT"
+      },
+      "PIPETX3DATA8": {
+        "primary": "PIPETX3DATA8",
+        "wire": "PIPETX3DATA8",
+        "dir": "OUTPUT"
+      },
+      "PIPETX3DATA9": {
+        "primary": "PIPETX3DATA9",
+        "wire": "PIPETX3DATA9",
+        "dir": "OUTPUT"
+      },
+      "PIPETX3DATA10": {
+        "primary": "PIPETX3DATA10",
+        "wire": "PIPETX3DATA10",
+        "dir": "OUTPUT"
+      },
+      "PIPETX3DATA11": {
+        "primary": "PIPETX3DATA11",
+        "wire": "PIPETX3DATA11",
+        "dir": "OUTPUT"
+      },
+      "PIPETX3DATA12": {
+        "primary": "PIPETX3DATA12",
+        "wire": "PIPETX3DATA12",
+        "dir": "OUTPUT"
+      },
+      "PIPETX3DATA13": {
+        "primary": "PIPETX3DATA13",
+        "wire": "PIPETX3DATA13",
+        "dir": "OUTPUT"
+      },
+      "PIPETX3DATA14": {
+        "primary": "PIPETX3DATA14",
+        "wire": "PIPETX3DATA14",
+        "dir": "OUTPUT"
+      },
+      "PIPETX3DATA15": {
+        "primary": "PIPETX3DATA15",
+        "wire": "PIPETX3DATA15",
+        "dir": "OUTPUT"
+      },
+      "PIPETX3ELECIDLE": {
+        "primary": "PIPETX3ELECIDLE",
+        "wire": "PIPETX3ELECIDLE",
+        "dir": "OUTPUT"
+      },
+      "PIPETX3POWERDOWN0": {
+        "primary": "PIPETX3POWERDOWN0",
+        "wire": "PIPETX3POWERDOWN0",
+        "dir": "OUTPUT"
+      },
+      "PIPETX3POWERDOWN1": {
+        "primary": "PIPETX3POWERDOWN1",
+        "wire": "PIPETX3POWERDOWN1",
+        "dir": "OUTPUT"
+      },
+      "PIPETX4CHARISK0": {
+        "primary": "PIPETX4CHARISK0",
+        "wire": "PIPETX4CHARISK0",
+        "dir": "OUTPUT"
+      },
+      "PIPETX4CHARISK1": {
+        "primary": "PIPETX4CHARISK1",
+        "wire": "PIPETX4CHARISK1",
+        "dir": "OUTPUT"
+      },
+      "PIPETX4COMPLIANCE": {
+        "primary": "PIPETX4COMPLIANCE",
+        "wire": "PIPETX4COMPLIANCE",
+        "dir": "OUTPUT"
+      },
+      "PIPETX4DATA0": {
+        "primary": "PIPETX4DATA0",
+        "wire": "PIPETX4DATA0",
+        "dir": "OUTPUT"
+      },
+      "PIPETX4DATA1": {
+        "primary": "PIPETX4DATA1",
+        "wire": "PIPETX4DATA1",
+        "dir": "OUTPUT"
+      },
+      "PIPETX4DATA2": {
+        "primary": "PIPETX4DATA2",
+        "wire": "PIPETX4DATA2",
+        "dir": "OUTPUT"
+      },
+      "PIPETX4DATA3": {
+        "primary": "PIPETX4DATA3",
+        "wire": "PIPETX4DATA3",
+        "dir": "OUTPUT"
+      },
+      "PIPETX4DATA4": {
+        "primary": "PIPETX4DATA4",
+        "wire": "PIPETX4DATA4",
+        "dir": "OUTPUT"
+      },
+      "PIPETX4DATA5": {
+        "primary": "PIPETX4DATA5",
+        "wire": "PIPETX4DATA5",
+        "dir": "OUTPUT"
+      },
+      "PIPETX4DATA6": {
+        "primary": "PIPETX4DATA6",
+        "wire": "PIPETX4DATA6",
+        "dir": "OUTPUT"
+      },
+      "PIPETX4DATA7": {
+        "primary": "PIPETX4DATA7",
+        "wire": "PIPETX4DATA7",
+        "dir": "OUTPUT"
+      },
+      "PIPETX4DATA8": {
+        "primary": "PIPETX4DATA8",
+        "wire": "PIPETX4DATA8",
+        "dir": "OUTPUT"
+      },
+      "PIPETX4DATA9": {
+        "primary": "PIPETX4DATA9",
+        "wire": "PIPETX4DATA9",
+        "dir": "OUTPUT"
+      },
+      "PIPETX4DATA10": {
+        "primary": "PIPETX4DATA10",
+        "wire": "PIPETX4DATA10",
+        "dir": "OUTPUT"
+      },
+      "PIPETX4DATA11": {
+        "primary": "PIPETX4DATA11",
+        "wire": "PIPETX4DATA11",
+        "dir": "OUTPUT"
+      },
+      "PIPETX4DATA12": {
+        "primary": "PIPETX4DATA12",
+        "wire": "PIPETX4DATA12",
+        "dir": "OUTPUT"
+      },
+      "PIPETX4DATA13": {
+        "primary": "PIPETX4DATA13",
+        "wire": "PIPETX4DATA13",
+        "dir": "OUTPUT"
+      },
+      "PIPETX4DATA14": {
+        "primary": "PIPETX4DATA14",
+        "wire": "PIPETX4DATA14",
+        "dir": "OUTPUT"
+      },
+      "PIPETX4DATA15": {
+        "primary": "PIPETX4DATA15",
+        "wire": "PIPETX4DATA15",
+        "dir": "OUTPUT"
+      },
+      "PIPETX4ELECIDLE": {
+        "primary": "PIPETX4ELECIDLE",
+        "wire": "PIPETX4ELECIDLE",
+        "dir": "OUTPUT"
+      },
+      "PIPETX4POWERDOWN0": {
+        "primary": "PIPETX4POWERDOWN0",
+        "wire": "PIPETX4POWERDOWN0",
+        "dir": "OUTPUT"
+      },
+      "PIPETX4POWERDOWN1": {
+        "primary": "PIPETX4POWERDOWN1",
+        "wire": "PIPETX4POWERDOWN1",
+        "dir": "OUTPUT"
+      },
+      "PIPETX5CHARISK0": {
+        "primary": "PIPETX5CHARISK0",
+        "wire": "PIPETX5CHARISK0",
+        "dir": "OUTPUT"
+      },
+      "PIPETX5CHARISK1": {
+        "primary": "PIPETX5CHARISK1",
+        "wire": "PIPETX5CHARISK1",
+        "dir": "OUTPUT"
+      },
+      "PIPETX5COMPLIANCE": {
+        "primary": "PIPETX5COMPLIANCE",
+        "wire": "PIPETX5COMPLIANCE",
+        "dir": "OUTPUT"
+      },
+      "PIPETX5DATA0": {
+        "primary": "PIPETX5DATA0",
+        "wire": "PIPETX5DATA0",
+        "dir": "OUTPUT"
+      },
+      "PIPETX5DATA1": {
+        "primary": "PIPETX5DATA1",
+        "wire": "PIPETX5DATA1",
+        "dir": "OUTPUT"
+      },
+      "PIPETX5DATA2": {
+        "primary": "PIPETX5DATA2",
+        "wire": "PIPETX5DATA2",
+        "dir": "OUTPUT"
+      },
+      "PIPETX5DATA3": {
+        "primary": "PIPETX5DATA3",
+        "wire": "PIPETX5DATA3",
+        "dir": "OUTPUT"
+      },
+      "PIPETX5DATA4": {
+        "primary": "PIPETX5DATA4",
+        "wire": "PIPETX5DATA4",
+        "dir": "OUTPUT"
+      },
+      "PIPETX5DATA5": {
+        "primary": "PIPETX5DATA5",
+        "wire": "PIPETX5DATA5",
+        "dir": "OUTPUT"
+      },
+      "PIPETX5DATA6": {
+        "primary": "PIPETX5DATA6",
+        "wire": "PIPETX5DATA6",
+        "dir": "OUTPUT"
+      },
+      "PIPETX5DATA7": {
+        "primary": "PIPETX5DATA7",
+        "wire": "PIPETX5DATA7",
+        "dir": "OUTPUT"
+      },
+      "PIPETX5DATA8": {
+        "primary": "PIPETX5DATA8",
+        "wire": "PIPETX5DATA8",
+        "dir": "OUTPUT"
+      },
+      "PIPETX5DATA9": {
+        "primary": "PIPETX5DATA9",
+        "wire": "PIPETX5DATA9",
+        "dir": "OUTPUT"
+      },
+      "PIPETX5DATA10": {
+        "primary": "PIPETX5DATA10",
+        "wire": "PIPETX5DATA10",
+        "dir": "OUTPUT"
+      },
+      "PIPETX5DATA11": {
+        "primary": "PIPETX5DATA11",
+        "wire": "PIPETX5DATA11",
+        "dir": "OUTPUT"
+      },
+      "PIPETX5DATA12": {
+        "primary": "PIPETX5DATA12",
+        "wire": "PIPETX5DATA12",
+        "dir": "OUTPUT"
+      },
+      "PIPETX5DATA13": {
+        "primary": "PIPETX5DATA13",
+        "wire": "PIPETX5DATA13",
+        "dir": "OUTPUT"
+      },
+      "PIPETX5DATA14": {
+        "primary": "PIPETX5DATA14",
+        "wire": "PIPETX5DATA14",
+        "dir": "OUTPUT"
+      },
+      "PIPETX5DATA15": {
+        "primary": "PIPETX5DATA15",
+        "wire": "PIPETX5DATA15",
+        "dir": "OUTPUT"
+      },
+      "PIPETX5ELECIDLE": {
+        "primary": "PIPETX5ELECIDLE",
+        "wire": "PIPETX5ELECIDLE",
+        "dir": "OUTPUT"
+      },
+      "PIPETX5POWERDOWN0": {
+        "primary": "PIPETX5POWERDOWN0",
+        "wire": "PIPETX5POWERDOWN0",
+        "dir": "OUTPUT"
+      },
+      "PIPETX5POWERDOWN1": {
+        "primary": "PIPETX5POWERDOWN1",
+        "wire": "PIPETX5POWERDOWN1",
+        "dir": "OUTPUT"
+      },
+      "PIPETX6CHARISK0": {
+        "primary": "PIPETX6CHARISK0",
+        "wire": "PIPETX6CHARISK0",
+        "dir": "OUTPUT"
+      },
+      "PIPETX6CHARISK1": {
+        "primary": "PIPETX6CHARISK1",
+        "wire": "PIPETX6CHARISK1",
+        "dir": "OUTPUT"
+      },
+      "PIPETX6COMPLIANCE": {
+        "primary": "PIPETX6COMPLIANCE",
+        "wire": "PIPETX6COMPLIANCE",
+        "dir": "OUTPUT"
+      },
+      "PIPETX6DATA0": {
+        "primary": "PIPETX6DATA0",
+        "wire": "PIPETX6DATA0",
+        "dir": "OUTPUT"
+      },
+      "PIPETX6DATA1": {
+        "primary": "PIPETX6DATA1",
+        "wire": "PIPETX6DATA1",
+        "dir": "OUTPUT"
+      },
+      "PIPETX6DATA2": {
+        "primary": "PIPETX6DATA2",
+        "wire": "PIPETX6DATA2",
+        "dir": "OUTPUT"
+      },
+      "PIPETX6DATA3": {
+        "primary": "PIPETX6DATA3",
+        "wire": "PIPETX6DATA3",
+        "dir": "OUTPUT"
+      },
+      "PIPETX6DATA4": {
+        "primary": "PIPETX6DATA4",
+        "wire": "PIPETX6DATA4",
+        "dir": "OUTPUT"
+      },
+      "PIPETX6DATA5": {
+        "primary": "PIPETX6DATA5",
+        "wire": "PIPETX6DATA5",
+        "dir": "OUTPUT"
+      },
+      "PIPETX6DATA6": {
+        "primary": "PIPETX6DATA6",
+        "wire": "PIPETX6DATA6",
+        "dir": "OUTPUT"
+      },
+      "PIPETX6DATA7": {
+        "primary": "PIPETX6DATA7",
+        "wire": "PIPETX6DATA7",
+        "dir": "OUTPUT"
+      },
+      "PIPETX6DATA8": {
+        "primary": "PIPETX6DATA8",
+        "wire": "PIPETX6DATA8",
+        "dir": "OUTPUT"
+      },
+      "PIPETX6DATA9": {
+        "primary": "PIPETX6DATA9",
+        "wire": "PIPETX6DATA9",
+        "dir": "OUTPUT"
+      },
+      "PIPETX6DATA10": {
+        "primary": "PIPETX6DATA10",
+        "wire": "PIPETX6DATA10",
+        "dir": "OUTPUT"
+      },
+      "PIPETX6DATA11": {
+        "primary": "PIPETX6DATA11",
+        "wire": "PIPETX6DATA11",
+        "dir": "OUTPUT"
+      },
+      "PIPETX6DATA12": {
+        "primary": "PIPETX6DATA12",
+        "wire": "PIPETX6DATA12",
+        "dir": "OUTPUT"
+      },
+      "PIPETX6DATA13": {
+        "primary": "PIPETX6DATA13",
+        "wire": "PIPETX6DATA13",
+        "dir": "OUTPUT"
+      },
+      "PIPETX6DATA14": {
+        "primary": "PIPETX6DATA14",
+        "wire": "PIPETX6DATA14",
+        "dir": "OUTPUT"
+      },
+      "PIPETX6DATA15": {
+        "primary": "PIPETX6DATA15",
+        "wire": "PIPETX6DATA15",
+        "dir": "OUTPUT"
+      },
+      "PIPETX6ELECIDLE": {
+        "primary": "PIPETX6ELECIDLE",
+        "wire": "PIPETX6ELECIDLE",
+        "dir": "OUTPUT"
+      },
+      "PIPETX6POWERDOWN0": {
+        "primary": "PIPETX6POWERDOWN0",
+        "wire": "PIPETX6POWERDOWN0",
+        "dir": "OUTPUT"
+      },
+      "PIPETX6POWERDOWN1": {
+        "primary": "PIPETX6POWERDOWN1",
+        "wire": "PIPETX6POWERDOWN1",
+        "dir": "OUTPUT"
+      },
+      "PIPETX7CHARISK0": {
+        "primary": "PIPETX7CHARISK0",
+        "wire": "PIPETX7CHARISK0",
+        "dir": "OUTPUT"
+      },
+      "PIPETX7CHARISK1": {
+        "primary": "PIPETX7CHARISK1",
+        "wire": "PIPETX7CHARISK1",
+        "dir": "OUTPUT"
+      },
+      "PIPETX7COMPLIANCE": {
+        "primary": "PIPETX7COMPLIANCE",
+        "wire": "PIPETX7COMPLIANCE",
+        "dir": "OUTPUT"
+      },
+      "PIPETX7DATA0": {
+        "primary": "PIPETX7DATA0",
+        "wire": "PIPETX7DATA0",
+        "dir": "OUTPUT"
+      },
+      "PIPETX7DATA1": {
+        "primary": "PIPETX7DATA1",
+        "wire": "PIPETX7DATA1",
+        "dir": "OUTPUT"
+      },
+      "PIPETX7DATA2": {
+        "primary": "PIPETX7DATA2",
+        "wire": "PIPETX7DATA2",
+        "dir": "OUTPUT"
+      },
+      "PIPETX7DATA3": {
+        "primary": "PIPETX7DATA3",
+        "wire": "PIPETX7DATA3",
+        "dir": "OUTPUT"
+      },
+      "PIPETX7DATA4": {
+        "primary": "PIPETX7DATA4",
+        "wire": "PIPETX7DATA4",
+        "dir": "OUTPUT"
+      },
+      "PIPETX7DATA5": {
+        "primary": "PIPETX7DATA5",
+        "wire": "PIPETX7DATA5",
+        "dir": "OUTPUT"
+      },
+      "PIPETX7DATA6": {
+        "primary": "PIPETX7DATA6",
+        "wire": "PIPETX7DATA6",
+        "dir": "OUTPUT"
+      },
+      "PIPETX7DATA7": {
+        "primary": "PIPETX7DATA7",
+        "wire": "PIPETX7DATA7",
+        "dir": "OUTPUT"
+      },
+      "PIPETX7DATA8": {
+        "primary": "PIPETX7DATA8",
+        "wire": "PIPETX7DATA8",
+        "dir": "OUTPUT"
+      },
+      "PIPETX7DATA9": {
+        "primary": "PIPETX7DATA9",
+        "wire": "PIPETX7DATA9",
+        "dir": "OUTPUT"
+      },
+      "PIPETX7DATA10": {
+        "primary": "PIPETX7DATA10",
+        "wire": "PIPETX7DATA10",
+        "dir": "OUTPUT"
+      },
+      "PIPETX7DATA11": {
+        "primary": "PIPETX7DATA11",
+        "wire": "PIPETX7DATA11",
+        "dir": "OUTPUT"
+      },
+      "PIPETX7DATA12": {
+        "primary": "PIPETX7DATA12",
+        "wire": "PIPETX7DATA12",
+        "dir": "OUTPUT"
+      },
+      "PIPETX7DATA13": {
+        "primary": "PIPETX7DATA13",
+        "wire": "PIPETX7DATA13",
+        "dir": "OUTPUT"
+      },
+      "PIPETX7DATA14": {
+        "primary": "PIPETX7DATA14",
+        "wire": "PIPETX7DATA14",
+        "dir": "OUTPUT"
+      },
+      "PIPETX7DATA15": {
+        "primary": "PIPETX7DATA15",
+        "wire": "PIPETX7DATA15",
+        "dir": "OUTPUT"
+      },
+      "PIPETX7ELECIDLE": {
+        "primary": "PIPETX7ELECIDLE",
+        "wire": "PIPETX7ELECIDLE",
+        "dir": "OUTPUT"
+      },
+      "PIPETX7POWERDOWN0": {
+        "primary": "PIPETX7POWERDOWN0",
+        "wire": "PIPETX7POWERDOWN0",
+        "dir": "OUTPUT"
+      },
+      "PIPETX7POWERDOWN1": {
+        "primary": "PIPETX7POWERDOWN1",
+        "wire": "PIPETX7POWERDOWN1",
+        "dir": "OUTPUT"
+      },
+      "PIPETXDEEMPH": {
+        "primary": "PIPETXDEEMPH",
+        "wire": "PIPETXDEEMPH",
+        "dir": "OUTPUT"
+      },
+      "PIPETXMARGIN0": {
+        "primary": "PIPETXMARGIN0",
+        "wire": "PIPETXMARGIN0",
+        "dir": "OUTPUT"
+      },
+      "PIPETXMARGIN1": {
+        "primary": "PIPETXMARGIN1",
+        "wire": "PIPETXMARGIN1",
+        "dir": "OUTPUT"
+      },
+      "PIPETXMARGIN2": {
+        "primary": "PIPETXMARGIN2",
+        "wire": "PIPETXMARGIN2",
+        "dir": "OUTPUT"
+      },
+      "PIPETXRATE": {
+        "primary": "PIPETXRATE",
+        "wire": "PIPETXRATE",
+        "dir": "OUTPUT"
+      },
+      "PIPETXRCVRDET": {
+        "primary": "PIPETXRCVRDET",
+        "wire": "PIPETXRCVRDET",
+        "dir": "OUTPUT"
+      },
+      "PIPETXRESET": {
+        "primary": "PIPETXRESET",
+        "wire": "PIPETXRESET",
+        "dir": "OUTPUT"
+      },
+      "PL2DIRECTEDLSTATE0": {
+        "primary": "PL2DIRECTEDLSTATE0",
+        "wire": "PL2DIRECTEDLSTATE0",
+        "dir": "INPUT"
+      },
+      "PL2DIRECTEDLSTATE1": {
+        "primary": "PL2DIRECTEDLSTATE1",
+        "wire": "PL2DIRECTEDLSTATE1",
+        "dir": "INPUT"
+      },
+      "PL2DIRECTEDLSTATE2": {
+        "primary": "PL2DIRECTEDLSTATE2",
+        "wire": "PL2DIRECTEDLSTATE2",
+        "dir": "INPUT"
+      },
+      "PL2DIRECTEDLSTATE3": {
+        "primary": "PL2DIRECTEDLSTATE3",
+        "wire": "PL2DIRECTEDLSTATE3",
+        "dir": "INPUT"
+      },
+      "PL2DIRECTEDLSTATE4": {
+        "primary": "PL2DIRECTEDLSTATE4",
+        "wire": "PL2DIRECTEDLSTATE4",
+        "dir": "INPUT"
+      },
+      "PL2L0REQ": {
+        "primary": "PL2L0REQ",
+        "wire": "PL2L0REQ",
+        "dir": "OUTPUT"
+      },
+      "PL2LINKUP": {
+        "primary": "PL2LINKUP",
+        "wire": "PL2LINKUP",
+        "dir": "OUTPUT"
+      },
+      "PL2RECEIVERERR": {
+        "primary": "PL2RECEIVERERR",
+        "wire": "PL2RECEIVERERR",
+        "dir": "OUTPUT"
+      },
+      "PL2RECOVERY": {
+        "primary": "PL2RECOVERY",
+        "wire": "PL2RECOVERY",
+        "dir": "OUTPUT"
+      },
+      "PL2RXELECIDLE": {
+        "primary": "PL2RXELECIDLE",
+        "wire": "PL2RXELECIDLE",
+        "dir": "OUTPUT"
+      },
+      "PL2RXPMSTATE0": {
+        "primary": "PL2RXPMSTATE0",
+        "wire": "PL2RXPMSTATE0",
+        "dir": "OUTPUT"
+      },
+      "PL2RXPMSTATE1": {
+        "primary": "PL2RXPMSTATE1",
+        "wire": "PL2RXPMSTATE1",
+        "dir": "OUTPUT"
+      },
+      "PL2SUSPENDOK": {
+        "primary": "PL2SUSPENDOK",
+        "wire": "PL2SUSPENDOK",
+        "dir": "OUTPUT"
+      },
+      "PLDBGMODE0": {
+        "primary": "PLDBGMODE0",
+        "wire": "PLDBGMODE0",
+        "dir": "INPUT"
+      },
+      "PLDBGMODE1": {
+        "primary": "PLDBGMODE1",
+        "wire": "PLDBGMODE1",
+        "dir": "INPUT"
+      },
+      "PLDBGMODE2": {
+        "primary": "PLDBGMODE2",
+        "wire": "PLDBGMODE2",
+        "dir": "INPUT"
+      },
+      "PLDBGVEC0": {
+        "primary": "PLDBGVEC0",
+        "wire": "PLDBGVEC0",
+        "dir": "OUTPUT"
+      },
+      "PLDBGVEC1": {
+        "primary": "PLDBGVEC1",
+        "wire": "PLDBGVEC1",
+        "dir": "OUTPUT"
+      },
+      "PLDBGVEC2": {
+        "primary": "PLDBGVEC2",
+        "wire": "PLDBGVEC2",
+        "dir": "OUTPUT"
+      },
+      "PLDBGVEC3": {
+        "primary": "PLDBGVEC3",
+        "wire": "PLDBGVEC3",
+        "dir": "OUTPUT"
+      },
+      "PLDBGVEC4": {
+        "primary": "PLDBGVEC4",
+        "wire": "PLDBGVEC4",
+        "dir": "OUTPUT"
+      },
+      "PLDBGVEC5": {
+        "primary": "PLDBGVEC5",
+        "wire": "PLDBGVEC5",
+        "dir": "OUTPUT"
+      },
+      "PLDBGVEC6": {
+        "primary": "PLDBGVEC6",
+        "wire": "PLDBGVEC6",
+        "dir": "OUTPUT"
+      },
+      "PLDBGVEC7": {
+        "primary": "PLDBGVEC7",
+        "wire": "PLDBGVEC7",
+        "dir": "OUTPUT"
+      },
+      "PLDBGVEC8": {
+        "primary": "PLDBGVEC8",
+        "wire": "PLDBGVEC8",
+        "dir": "OUTPUT"
+      },
+      "PLDBGVEC9": {
+        "primary": "PLDBGVEC9",
+        "wire": "PLDBGVEC9",
+        "dir": "OUTPUT"
+      },
+      "PLDBGVEC10": {
+        "primary": "PLDBGVEC10",
+        "wire": "PLDBGVEC10",
+        "dir": "OUTPUT"
+      },
+      "PLDBGVEC11": {
+        "primary": "PLDBGVEC11",
+        "wire": "PLDBGVEC11",
+        "dir": "OUTPUT"
+      },
+      "PLDIRECTEDCHANGEDONE": {
+        "primary": "PLDIRECTEDCHANGEDONE",
+        "wire": "PLDIRECTEDCHANGEDONE",
+        "dir": "OUTPUT"
+      },
+      "PLDIRECTEDLINKAUTON": {
+        "primary": "PLDIRECTEDLINKAUTON",
+        "wire": "PLDIRECTEDLINKAUTON",
+        "dir": "INPUT"
+      },
+      "PLDIRECTEDLINKCHANGE0": {
+        "primary": "PLDIRECTEDLINKCHANGE0",
+        "wire": "PLDIRECTEDLINKCHANGE0",
+        "dir": "INPUT"
+      },
+      "PLDIRECTEDLINKCHANGE1": {
+        "primary": "PLDIRECTEDLINKCHANGE1",
+        "wire": "PLDIRECTEDLINKCHANGE1",
+        "dir": "INPUT"
+      },
+      "PLDIRECTEDLINKSPEED": {
+        "primary": "PLDIRECTEDLINKSPEED",
+        "wire": "PLDIRECTEDLINKSPEED",
+        "dir": "INPUT"
+      },
+      "PLDIRECTEDLINKWIDTH0": {
+        "primary": "PLDIRECTEDLINKWIDTH0",
+        "wire": "PLDIRECTEDLINKWIDTH0",
+        "dir": "INPUT"
+      },
+      "PLDIRECTEDLINKWIDTH1": {
+        "primary": "PLDIRECTEDLINKWIDTH1",
+        "wire": "PLDIRECTEDLINKWIDTH1",
+        "dir": "INPUT"
+      },
+      "PLDIRECTEDLTSSMNEW0": {
+        "primary": "PLDIRECTEDLTSSMNEW0",
+        "wire": "PLDIRECTEDLTSSMNEW0",
+        "dir": "INPUT"
+      },
+      "PLDIRECTEDLTSSMNEW1": {
+        "primary": "PLDIRECTEDLTSSMNEW1",
+        "wire": "PLDIRECTEDLTSSMNEW1",
+        "dir": "INPUT"
+      },
+      "PLDIRECTEDLTSSMNEW2": {
+        "primary": "PLDIRECTEDLTSSMNEW2",
+        "wire": "PLDIRECTEDLTSSMNEW2",
+        "dir": "INPUT"
+      },
+      "PLDIRECTEDLTSSMNEW3": {
+        "primary": "PLDIRECTEDLTSSMNEW3",
+        "wire": "PLDIRECTEDLTSSMNEW3",
+        "dir": "INPUT"
+      },
+      "PLDIRECTEDLTSSMNEW4": {
+        "primary": "PLDIRECTEDLTSSMNEW4",
+        "wire": "PLDIRECTEDLTSSMNEW4",
+        "dir": "INPUT"
+      },
+      "PLDIRECTEDLTSSMNEW5": {
+        "primary": "PLDIRECTEDLTSSMNEW5",
+        "wire": "PLDIRECTEDLTSSMNEW5",
+        "dir": "INPUT"
+      },
+      "PLDIRECTEDLTSSMNEWVLD": {
+        "primary": "PLDIRECTEDLTSSMNEWVLD",
+        "wire": "PLDIRECTEDLTSSMNEWVLD",
+        "dir": "INPUT"
+      },
+      "PLDIRECTEDLTSSMSTALL": {
+        "primary": "PLDIRECTEDLTSSMSTALL",
+        "wire": "PLDIRECTEDLTSSMSTALL",
+        "dir": "INPUT"
+      },
+      "PLDOWNSTREAMDEEMPHSOURCE": {
+        "primary": "PLDOWNSTREAMDEEMPHSOURCE",
+        "wire": "PLDOWNSTREAMDEEMPHSOURCE",
+        "dir": "INPUT"
+      },
+      "PLINITIALLINKWIDTH0": {
+        "primary": "PLINITIALLINKWIDTH0",
+        "wire": "PLINITIALLINKWIDTH0",
+        "dir": "OUTPUT"
+      },
+      "PLINITIALLINKWIDTH1": {
+        "primary": "PLINITIALLINKWIDTH1",
+        "wire": "PLINITIALLINKWIDTH1",
+        "dir": "OUTPUT"
+      },
+      "PLINITIALLINKWIDTH2": {
+        "primary": "PLINITIALLINKWIDTH2",
+        "wire": "PLINITIALLINKWIDTH2",
+        "dir": "OUTPUT"
+      },
+      "PLLANEREVERSALMODE0": {
+        "primary": "PLLANEREVERSALMODE0",
+        "wire": "PLLANEREVERSALMODE0",
+        "dir": "OUTPUT"
+      },
+      "PLLANEREVERSALMODE1": {
+        "primary": "PLLANEREVERSALMODE1",
+        "wire": "PLLANEREVERSALMODE1",
+        "dir": "OUTPUT"
+      },
+      "PLLINKGEN2CAP": {
+        "primary": "PLLINKGEN2CAP",
+        "wire": "PLLINKGEN2CAP",
+        "dir": "OUTPUT"
+      },
+      "PLLINKPARTNERGEN2SUPPORTED": {
+        "primary": "PLLINKPARTNERGEN2SUPPORTED",
+        "wire": "PLLINKPARTNERGEN2SUPPORTED",
+        "dir": "OUTPUT"
+      },
+      "PLLINKUPCFGCAP": {
+        "primary": "PLLINKUPCFGCAP",
+        "wire": "PLLINKUPCFGCAP",
+        "dir": "OUTPUT"
+      },
+      "PLLTSSMSTATE0": {
+        "primary": "PLLTSSMSTATE0",
+        "wire": "PLLTSSMSTATE0",
+        "dir": "OUTPUT"
+      },
+      "PLLTSSMSTATE1": {
+        "primary": "PLLTSSMSTATE1",
+        "wire": "PLLTSSMSTATE1",
+        "dir": "OUTPUT"
+      },
+      "PLLTSSMSTATE2": {
+        "primary": "PLLTSSMSTATE2",
+        "wire": "PLLTSSMSTATE2",
+        "dir": "OUTPUT"
+      },
+      "PLLTSSMSTATE3": {
+        "primary": "PLLTSSMSTATE3",
+        "wire": "PLLTSSMSTATE3",
+        "dir": "OUTPUT"
+      },
+      "PLLTSSMSTATE4": {
+        "primary": "PLLTSSMSTATE4",
+        "wire": "PLLTSSMSTATE4",
+        "dir": "OUTPUT"
+      },
+      "PLLTSSMSTATE5": {
+        "primary": "PLLTSSMSTATE5",
+        "wire": "PLLTSSMSTATE5",
+        "dir": "OUTPUT"
+      },
+      "PLPHYLNKUPN": {
+        "primary": "PLPHYLNKUPN",
+        "wire": "PLPHYLNKUPN",
+        "dir": "OUTPUT"
+      },
+      "PLRECEIVEDHOTRST": {
+        "primary": "PLRECEIVEDHOTRST",
+        "wire": "PLRECEIVEDHOTRST",
+        "dir": "OUTPUT"
+      },
+      "PLRSTN": {
+        "primary": "PLRSTN",
+        "wire": "PLRSTN",
+        "dir": "INPUT"
+      },
+      "PLRXPMSTATE0": {
+        "primary": "PLRXPMSTATE0",
+        "wire": "PLRXPMSTATE0",
+        "dir": "OUTPUT"
+      },
+      "PLRXPMSTATE1": {
+        "primary": "PLRXPMSTATE1",
+        "wire": "PLRXPMSTATE1",
+        "dir": "OUTPUT"
+      },
+      "PLSELLNKRATE": {
+        "primary": "PLSELLNKRATE",
+        "wire": "PLSELLNKRATE",
+        "dir": "OUTPUT"
+      },
+      "PLSELLNKWIDTH0": {
+        "primary": "PLSELLNKWIDTH0",
+        "wire": "PLSELLNKWIDTH0",
+        "dir": "OUTPUT"
+      },
+      "PLSELLNKWIDTH1": {
+        "primary": "PLSELLNKWIDTH1",
+        "wire": "PLSELLNKWIDTH1",
+        "dir": "OUTPUT"
+      },
+      "PLTRANSMITHOTRST": {
+        "primary": "PLTRANSMITHOTRST",
+        "wire": "PLTRANSMITHOTRST",
+        "dir": "INPUT"
+      },
+      "PLTXPMSTATE0": {
+        "primary": "PLTXPMSTATE0",
+        "wire": "PLTXPMSTATE0",
+        "dir": "OUTPUT"
+      },
+      "PLTXPMSTATE1": {
+        "primary": "PLTXPMSTATE1",
+        "wire": "PLTXPMSTATE1",
+        "dir": "OUTPUT"
+      },
+      "PLTXPMSTATE2": {
+        "primary": "PLTXPMSTATE2",
+        "wire": "PLTXPMSTATE2",
+        "dir": "OUTPUT"
+      },
+      "PLUPSTREAMPREFERDEEMPH": {
+        "primary": "PLUPSTREAMPREFERDEEMPH",
+        "wire": "PLUPSTREAMPREFERDEEMPH",
+        "dir": "INPUT"
+      },
+      "PMVDIVIDE0": {
+        "primary": "PMVDIVIDE0",
+        "wire": "PMVDIVIDE0",
+        "dir": "INPUT"
+      },
+      "PMVDIVIDE1": {
+        "primary": "PMVDIVIDE1",
+        "wire": "PMVDIVIDE1",
+        "dir": "INPUT"
+      },
+      "PMVENABLEN": {
+        "primary": "PMVENABLEN",
+        "wire": "PMVENABLEN",
+        "dir": "INPUT"
+      },
+      "PMVOUT": {
+        "primary": "PMVOUT",
+        "wire": "PMVOUT",
+        "dir": "OUTPUT"
+      },
+      "PMVSELECT0": {
+        "primary": "PMVSELECT0",
+        "wire": "PMVSELECT0",
+        "dir": "INPUT"
+      },
+      "PMVSELECT1": {
+        "primary": "PMVSELECT1",
+        "wire": "PMVSELECT1",
+        "dir": "INPUT"
+      },
+      "PMVSELECT2": {
+        "primary": "PMVSELECT2",
+        "wire": "PMVSELECT2",
+        "dir": "INPUT"
+      },
+      "RECEIVEDFUNCLVLRSTN": {
+        "primary": "RECEIVEDFUNCLVLRSTN",
+        "wire": "RECEIVEDFUNCLVLRSTN",
+        "dir": "OUTPUT"
+      },
+      "SCANENABLEN": {
+        "primary": "SCANENABLEN",
+        "wire": "SCANENABLEN",
+        "dir": "INPUT"
+      },
+      "SCANMODEN": {
+        "primary": "SCANMODEN",
+        "wire": "SCANMODEN",
+        "dir": "INPUT"
+      },
+      "SYSRSTN": {
+        "primary": "SYSRSTN",
+        "wire": "SYSRSTN",
+        "dir": "INPUT"
+      },
+      "TL2ASPMSUSPENDCREDITCHECK": {
+        "primary": "TL2ASPMSUSPENDCREDITCHECK",
+        "wire": "TL2ASPMSUSPENDCREDITCHECK",
+        "dir": "INPUT"
+      },
+      "TL2ASPMSUSPENDCREDITCHECKOK": {
+        "primary": "TL2ASPMSUSPENDCREDITCHECKOK",
+        "wire": "TL2ASPMSUSPENDCREDITCHECKOK",
+        "dir": "OUTPUT"
+      },
+      "TL2ASPMSUSPENDREQ": {
+        "primary": "TL2ASPMSUSPENDREQ",
+        "wire": "TL2ASPMSUSPENDREQ",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRFCPE": {
+        "primary": "TL2ERRFCPE",
+        "wire": "TL2ERRFCPE",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR0": {
+        "primary": "TL2ERRHDR0",
+        "wire": "TL2ERRHDR0",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR1": {
+        "primary": "TL2ERRHDR1",
+        "wire": "TL2ERRHDR1",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR2": {
+        "primary": "TL2ERRHDR2",
+        "wire": "TL2ERRHDR2",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR3": {
+        "primary": "TL2ERRHDR3",
+        "wire": "TL2ERRHDR3",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR4": {
+        "primary": "TL2ERRHDR4",
+        "wire": "TL2ERRHDR4",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR5": {
+        "primary": "TL2ERRHDR5",
+        "wire": "TL2ERRHDR5",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR6": {
+        "primary": "TL2ERRHDR6",
+        "wire": "TL2ERRHDR6",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR7": {
+        "primary": "TL2ERRHDR7",
+        "wire": "TL2ERRHDR7",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR8": {
+        "primary": "TL2ERRHDR8",
+        "wire": "TL2ERRHDR8",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR9": {
+        "primary": "TL2ERRHDR9",
+        "wire": "TL2ERRHDR9",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR10": {
+        "primary": "TL2ERRHDR10",
+        "wire": "TL2ERRHDR10",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR11": {
+        "primary": "TL2ERRHDR11",
+        "wire": "TL2ERRHDR11",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR12": {
+        "primary": "TL2ERRHDR12",
+        "wire": "TL2ERRHDR12",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR13": {
+        "primary": "TL2ERRHDR13",
+        "wire": "TL2ERRHDR13",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR14": {
+        "primary": "TL2ERRHDR14",
+        "wire": "TL2ERRHDR14",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR15": {
+        "primary": "TL2ERRHDR15",
+        "wire": "TL2ERRHDR15",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR16": {
+        "primary": "TL2ERRHDR16",
+        "wire": "TL2ERRHDR16",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR17": {
+        "primary": "TL2ERRHDR17",
+        "wire": "TL2ERRHDR17",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR18": {
+        "primary": "TL2ERRHDR18",
+        "wire": "TL2ERRHDR18",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR19": {
+        "primary": "TL2ERRHDR19",
+        "wire": "TL2ERRHDR19",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR20": {
+        "primary": "TL2ERRHDR20",
+        "wire": "TL2ERRHDR20",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR21": {
+        "primary": "TL2ERRHDR21",
+        "wire": "TL2ERRHDR21",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR22": {
+        "primary": "TL2ERRHDR22",
+        "wire": "TL2ERRHDR22",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR23": {
+        "primary": "TL2ERRHDR23",
+        "wire": "TL2ERRHDR23",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR24": {
+        "primary": "TL2ERRHDR24",
+        "wire": "TL2ERRHDR24",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR25": {
+        "primary": "TL2ERRHDR25",
+        "wire": "TL2ERRHDR25",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR26": {
+        "primary": "TL2ERRHDR26",
+        "wire": "TL2ERRHDR26",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR27": {
+        "primary": "TL2ERRHDR27",
+        "wire": "TL2ERRHDR27",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR28": {
+        "primary": "TL2ERRHDR28",
+        "wire": "TL2ERRHDR28",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR29": {
+        "primary": "TL2ERRHDR29",
+        "wire": "TL2ERRHDR29",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR30": {
+        "primary": "TL2ERRHDR30",
+        "wire": "TL2ERRHDR30",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR31": {
+        "primary": "TL2ERRHDR31",
+        "wire": "TL2ERRHDR31",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR32": {
+        "primary": "TL2ERRHDR32",
+        "wire": "TL2ERRHDR32",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR33": {
+        "primary": "TL2ERRHDR33",
+        "wire": "TL2ERRHDR33",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR34": {
+        "primary": "TL2ERRHDR34",
+        "wire": "TL2ERRHDR34",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR35": {
+        "primary": "TL2ERRHDR35",
+        "wire": "TL2ERRHDR35",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR36": {
+        "primary": "TL2ERRHDR36",
+        "wire": "TL2ERRHDR36",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR37": {
+        "primary": "TL2ERRHDR37",
+        "wire": "TL2ERRHDR37",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR38": {
+        "primary": "TL2ERRHDR38",
+        "wire": "TL2ERRHDR38",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR39": {
+        "primary": "TL2ERRHDR39",
+        "wire": "TL2ERRHDR39",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR40": {
+        "primary": "TL2ERRHDR40",
+        "wire": "TL2ERRHDR40",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR41": {
+        "primary": "TL2ERRHDR41",
+        "wire": "TL2ERRHDR41",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR42": {
+        "primary": "TL2ERRHDR42",
+        "wire": "TL2ERRHDR42",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR43": {
+        "primary": "TL2ERRHDR43",
+        "wire": "TL2ERRHDR43",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR44": {
+        "primary": "TL2ERRHDR44",
+        "wire": "TL2ERRHDR44",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR45": {
+        "primary": "TL2ERRHDR45",
+        "wire": "TL2ERRHDR45",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR46": {
+        "primary": "TL2ERRHDR46",
+        "wire": "TL2ERRHDR46",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR47": {
+        "primary": "TL2ERRHDR47",
+        "wire": "TL2ERRHDR47",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR48": {
+        "primary": "TL2ERRHDR48",
+        "wire": "TL2ERRHDR48",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR49": {
+        "primary": "TL2ERRHDR49",
+        "wire": "TL2ERRHDR49",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR50": {
+        "primary": "TL2ERRHDR50",
+        "wire": "TL2ERRHDR50",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR51": {
+        "primary": "TL2ERRHDR51",
+        "wire": "TL2ERRHDR51",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR52": {
+        "primary": "TL2ERRHDR52",
+        "wire": "TL2ERRHDR52",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR53": {
+        "primary": "TL2ERRHDR53",
+        "wire": "TL2ERRHDR53",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR54": {
+        "primary": "TL2ERRHDR54",
+        "wire": "TL2ERRHDR54",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR55": {
+        "primary": "TL2ERRHDR55",
+        "wire": "TL2ERRHDR55",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR56": {
+        "primary": "TL2ERRHDR56",
+        "wire": "TL2ERRHDR56",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR57": {
+        "primary": "TL2ERRHDR57",
+        "wire": "TL2ERRHDR57",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR58": {
+        "primary": "TL2ERRHDR58",
+        "wire": "TL2ERRHDR58",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR59": {
+        "primary": "TL2ERRHDR59",
+        "wire": "TL2ERRHDR59",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR60": {
+        "primary": "TL2ERRHDR60",
+        "wire": "TL2ERRHDR60",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR61": {
+        "primary": "TL2ERRHDR61",
+        "wire": "TL2ERRHDR61",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR62": {
+        "primary": "TL2ERRHDR62",
+        "wire": "TL2ERRHDR62",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRHDR63": {
+        "primary": "TL2ERRHDR63",
+        "wire": "TL2ERRHDR63",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRMALFORMED": {
+        "primary": "TL2ERRMALFORMED",
+        "wire": "TL2ERRMALFORMED",
+        "dir": "OUTPUT"
+      },
+      "TL2ERRRXOVERFLOW": {
+        "primary": "TL2ERRRXOVERFLOW",
+        "wire": "TL2ERRRXOVERFLOW",
+        "dir": "OUTPUT"
+      },
+      "TL2PPMSUSPENDOK": {
+        "primary": "TL2PPMSUSPENDOK",
+        "wire": "TL2PPMSUSPENDOK",
+        "dir": "OUTPUT"
+      },
+      "TL2PPMSUSPENDREQ": {
+        "primary": "TL2PPMSUSPENDREQ",
+        "wire": "TL2PPMSUSPENDREQ",
+        "dir": "INPUT"
+      },
+      "TLRSTN": {
+        "primary": "TLRSTN",
+        "wire": "TLRSTN",
+        "dir": "INPUT"
+      },
+      "TRNFCCPLD0": {
+        "primary": "TRNFCCPLD0",
+        "wire": "TRNFCCPLD0",
+        "dir": "OUTPUT"
+      },
+      "TRNFCCPLD1": {
+        "primary": "TRNFCCPLD1",
+        "wire": "TRNFCCPLD1",
+        "dir": "OUTPUT"
+      },
+      "TRNFCCPLD2": {
+        "primary": "TRNFCCPLD2",
+        "wire": "TRNFCCPLD2",
+        "dir": "OUTPUT"
+      },
+      "TRNFCCPLD3": {
+        "primary": "TRNFCCPLD3",
+        "wire": "TRNFCCPLD3",
+        "dir": "OUTPUT"
+      },
+      "TRNFCCPLD4": {
+        "primary": "TRNFCCPLD4",
+        "wire": "TRNFCCPLD4",
+        "dir": "OUTPUT"
+      },
+      "TRNFCCPLD5": {
+        "primary": "TRNFCCPLD5",
+        "wire": "TRNFCCPLD5",
+        "dir": "OUTPUT"
+      },
+      "TRNFCCPLD6": {
+        "primary": "TRNFCCPLD6",
+        "wire": "TRNFCCPLD6",
+        "dir": "OUTPUT"
+      },
+      "TRNFCCPLD7": {
+        "primary": "TRNFCCPLD7",
+        "wire": "TRNFCCPLD7",
+        "dir": "OUTPUT"
+      },
+      "TRNFCCPLD8": {
+        "primary": "TRNFCCPLD8",
+        "wire": "TRNFCCPLD8",
+        "dir": "OUTPUT"
+      },
+      "TRNFCCPLD9": {
+        "primary": "TRNFCCPLD9",
+        "wire": "TRNFCCPLD9",
+        "dir": "OUTPUT"
+      },
+      "TRNFCCPLD10": {
+        "primary": "TRNFCCPLD10",
+        "wire": "TRNFCCPLD10",
+        "dir": "OUTPUT"
+      },
+      "TRNFCCPLD11": {
+        "primary": "TRNFCCPLD11",
+        "wire": "TRNFCCPLD11",
+        "dir": "OUTPUT"
+      },
+      "TRNFCCPLH0": {
+        "primary": "TRNFCCPLH0",
+        "wire": "TRNFCCPLH0",
+        "dir": "OUTPUT"
+      },
+      "TRNFCCPLH1": {
+        "primary": "TRNFCCPLH1",
+        "wire": "TRNFCCPLH1",
+        "dir": "OUTPUT"
+      },
+      "TRNFCCPLH2": {
+        "primary": "TRNFCCPLH2",
+        "wire": "TRNFCCPLH2",
+        "dir": "OUTPUT"
+      },
+      "TRNFCCPLH3": {
+        "primary": "TRNFCCPLH3",
+        "wire": "TRNFCCPLH3",
+        "dir": "OUTPUT"
+      },
+      "TRNFCCPLH4": {
+        "primary": "TRNFCCPLH4",
+        "wire": "TRNFCCPLH4",
+        "dir": "OUTPUT"
+      },
+      "TRNFCCPLH5": {
+        "primary": "TRNFCCPLH5",
+        "wire": "TRNFCCPLH5",
+        "dir": "OUTPUT"
+      },
+      "TRNFCCPLH6": {
+        "primary": "TRNFCCPLH6",
+        "wire": "TRNFCCPLH6",
+        "dir": "OUTPUT"
+      },
+      "TRNFCCPLH7": {
+        "primary": "TRNFCCPLH7",
+        "wire": "TRNFCCPLH7",
+        "dir": "OUTPUT"
+      },
+      "TRNFCNPD0": {
+        "primary": "TRNFCNPD0",
+        "wire": "TRNFCNPD0",
+        "dir": "OUTPUT"
+      },
+      "TRNFCNPD1": {
+        "primary": "TRNFCNPD1",
+        "wire": "TRNFCNPD1",
+        "dir": "OUTPUT"
+      },
+      "TRNFCNPD2": {
+        "primary": "TRNFCNPD2",
+        "wire": "TRNFCNPD2",
+        "dir": "OUTPUT"
+      },
+      "TRNFCNPD3": {
+        "primary": "TRNFCNPD3",
+        "wire": "TRNFCNPD3",
+        "dir": "OUTPUT"
+      },
+      "TRNFCNPD4": {
+        "primary": "TRNFCNPD4",
+        "wire": "TRNFCNPD4",
+        "dir": "OUTPUT"
+      },
+      "TRNFCNPD5": {
+        "primary": "TRNFCNPD5",
+        "wire": "TRNFCNPD5",
+        "dir": "OUTPUT"
+      },
+      "TRNFCNPD6": {
+        "primary": "TRNFCNPD6",
+        "wire": "TRNFCNPD6",
+        "dir": "OUTPUT"
+      },
+      "TRNFCNPD7": {
+        "primary": "TRNFCNPD7",
+        "wire": "TRNFCNPD7",
+        "dir": "OUTPUT"
+      },
+      "TRNFCNPD8": {
+        "primary": "TRNFCNPD8",
+        "wire": "TRNFCNPD8",
+        "dir": "OUTPUT"
+      },
+      "TRNFCNPD9": {
+        "primary": "TRNFCNPD9",
+        "wire": "TRNFCNPD9",
+        "dir": "OUTPUT"
+      },
+      "TRNFCNPD10": {
+        "primary": "TRNFCNPD10",
+        "wire": "TRNFCNPD10",
+        "dir": "OUTPUT"
+      },
+      "TRNFCNPD11": {
+        "primary": "TRNFCNPD11",
+        "wire": "TRNFCNPD11",
+        "dir": "OUTPUT"
+      },
+      "TRNFCNPH0": {
+        "primary": "TRNFCNPH0",
+        "wire": "TRNFCNPH0",
+        "dir": "OUTPUT"
+      },
+      "TRNFCNPH1": {
+        "primary": "TRNFCNPH1",
+        "wire": "TRNFCNPH1",
+        "dir": "OUTPUT"
+      },
+      "TRNFCNPH2": {
+        "primary": "TRNFCNPH2",
+        "wire": "TRNFCNPH2",
+        "dir": "OUTPUT"
+      },
+      "TRNFCNPH3": {
+        "primary": "TRNFCNPH3",
+        "wire": "TRNFCNPH3",
+        "dir": "OUTPUT"
+      },
+      "TRNFCNPH4": {
+        "primary": "TRNFCNPH4",
+        "wire": "TRNFCNPH4",
+        "dir": "OUTPUT"
+      },
+      "TRNFCNPH5": {
+        "primary": "TRNFCNPH5",
+        "wire": "TRNFCNPH5",
+        "dir": "OUTPUT"
+      },
+      "TRNFCNPH6": {
+        "primary": "TRNFCNPH6",
+        "wire": "TRNFCNPH6",
+        "dir": "OUTPUT"
+      },
+      "TRNFCNPH7": {
+        "primary": "TRNFCNPH7",
+        "wire": "TRNFCNPH7",
+        "dir": "OUTPUT"
+      },
+      "TRNFCPD0": {
+        "primary": "TRNFCPD0",
+        "wire": "TRNFCPD0",
+        "dir": "OUTPUT"
+      },
+      "TRNFCPD1": {
+        "primary": "TRNFCPD1",
+        "wire": "TRNFCPD1",
+        "dir": "OUTPUT"
+      },
+      "TRNFCPD2": {
+        "primary": "TRNFCPD2",
+        "wire": "TRNFCPD2",
+        "dir": "OUTPUT"
+      },
+      "TRNFCPD3": {
+        "primary": "TRNFCPD3",
+        "wire": "TRNFCPD3",
+        "dir": "OUTPUT"
+      },
+      "TRNFCPD4": {
+        "primary": "TRNFCPD4",
+        "wire": "TRNFCPD4",
+        "dir": "OUTPUT"
+      },
+      "TRNFCPD5": {
+        "primary": "TRNFCPD5",
+        "wire": "TRNFCPD5",
+        "dir": "OUTPUT"
+      },
+      "TRNFCPD6": {
+        "primary": "TRNFCPD6",
+        "wire": "TRNFCPD6",
+        "dir": "OUTPUT"
+      },
+      "TRNFCPD7": {
+        "primary": "TRNFCPD7",
+        "wire": "TRNFCPD7",
+        "dir": "OUTPUT"
+      },
+      "TRNFCPD8": {
+        "primary": "TRNFCPD8",
+        "wire": "TRNFCPD8",
+        "dir": "OUTPUT"
+      },
+      "TRNFCPD9": {
+        "primary": "TRNFCPD9",
+        "wire": "TRNFCPD9",
+        "dir": "OUTPUT"
+      },
+      "TRNFCPD10": {
+        "primary": "TRNFCPD10",
+        "wire": "TRNFCPD10",
+        "dir": "OUTPUT"
+      },
+      "TRNFCPD11": {
+        "primary": "TRNFCPD11",
+        "wire": "TRNFCPD11",
+        "dir": "OUTPUT"
+      },
+      "TRNFCPH0": {
+        "primary": "TRNFCPH0",
+        "wire": "TRNFCPH0",
+        "dir": "OUTPUT"
+      },
+      "TRNFCPH1": {
+        "primary": "TRNFCPH1",
+        "wire": "TRNFCPH1",
+        "dir": "OUTPUT"
+      },
+      "TRNFCPH2": {
+        "primary": "TRNFCPH2",
+        "wire": "TRNFCPH2",
+        "dir": "OUTPUT"
+      },
+      "TRNFCPH3": {
+        "primary": "TRNFCPH3",
+        "wire": "TRNFCPH3",
+        "dir": "OUTPUT"
+      },
+      "TRNFCPH4": {
+        "primary": "TRNFCPH4",
+        "wire": "TRNFCPH4",
+        "dir": "OUTPUT"
+      },
+      "TRNFCPH5": {
+        "primary": "TRNFCPH5",
+        "wire": "TRNFCPH5",
+        "dir": "OUTPUT"
+      },
+      "TRNFCPH6": {
+        "primary": "TRNFCPH6",
+        "wire": "TRNFCPH6",
+        "dir": "OUTPUT"
+      },
+      "TRNFCPH7": {
+        "primary": "TRNFCPH7",
+        "wire": "TRNFCPH7",
+        "dir": "OUTPUT"
+      },
+      "TRNFCSEL0": {
+        "primary": "TRNFCSEL0",
+        "wire": "TRNFCSEL0",
+        "dir": "INPUT"
+      },
+      "TRNFCSEL1": {
+        "primary": "TRNFCSEL1",
+        "wire": "TRNFCSEL1",
+        "dir": "INPUT"
+      },
+      "TRNFCSEL2": {
+        "primary": "TRNFCSEL2",
+        "wire": "TRNFCSEL2",
+        "dir": "INPUT"
+      },
+      "TRNLNKUP": {
+        "primary": "TRNLNKUP",
+        "wire": "TRNLNKUP",
+        "dir": "OUTPUT"
+      },
+      "TRNRBARHIT0": {
+        "primary": "TRNRBARHIT0",
+        "wire": "TRNRBARHIT0",
+        "dir": "OUTPUT"
+      },
+      "TRNRBARHIT1": {
+        "primary": "TRNRBARHIT1",
+        "wire": "TRNRBARHIT1",
+        "dir": "OUTPUT"
+      },
+      "TRNRBARHIT2": {
+        "primary": "TRNRBARHIT2",
+        "wire": "TRNRBARHIT2",
+        "dir": "OUTPUT"
+      },
+      "TRNRBARHIT3": {
+        "primary": "TRNRBARHIT3",
+        "wire": "TRNRBARHIT3",
+        "dir": "OUTPUT"
+      },
+      "TRNRBARHIT4": {
+        "primary": "TRNRBARHIT4",
+        "wire": "TRNRBARHIT4",
+        "dir": "OUTPUT"
+      },
+      "TRNRBARHIT5": {
+        "primary": "TRNRBARHIT5",
+        "wire": "TRNRBARHIT5",
+        "dir": "OUTPUT"
+      },
+      "TRNRBARHIT6": {
+        "primary": "TRNRBARHIT6",
+        "wire": "TRNRBARHIT6",
+        "dir": "OUTPUT"
+      },
+      "TRNRBARHIT7": {
+        "primary": "TRNRBARHIT7",
+        "wire": "TRNRBARHIT7",
+        "dir": "OUTPUT"
+      },
+      "TRNRD0": {
+        "primary": "TRNRD0",
+        "wire": "TRNRD0",
+        "dir": "OUTPUT"
+      },
+      "TRNRD1": {
+        "primary": "TRNRD1",
+        "wire": "TRNRD1",
+        "dir": "OUTPUT"
+      },
+      "TRNRD2": {
+        "primary": "TRNRD2",
+        "wire": "TRNRD2",
+        "dir": "OUTPUT"
+      },
+      "TRNRD3": {
+        "primary": "TRNRD3",
+        "wire": "TRNRD3",
+        "dir": "OUTPUT"
+      },
+      "TRNRD4": {
+        "primary": "TRNRD4",
+        "wire": "TRNRD4",
+        "dir": "OUTPUT"
+      },
+      "TRNRD5": {
+        "primary": "TRNRD5",
+        "wire": "TRNRD5",
+        "dir": "OUTPUT"
+      },
+      "TRNRD6": {
+        "primary": "TRNRD6",
+        "wire": "TRNRD6",
+        "dir": "OUTPUT"
+      },
+      "TRNRD7": {
+        "primary": "TRNRD7",
+        "wire": "TRNRD7",
+        "dir": "OUTPUT"
+      },
+      "TRNRD8": {
+        "primary": "TRNRD8",
+        "wire": "TRNRD8",
+        "dir": "OUTPUT"
+      },
+      "TRNRD9": {
+        "primary": "TRNRD9",
+        "wire": "TRNRD9",
+        "dir": "OUTPUT"
+      },
+      "TRNRD10": {
+        "primary": "TRNRD10",
+        "wire": "TRNRD10",
+        "dir": "OUTPUT"
+      },
+      "TRNRD11": {
+        "primary": "TRNRD11",
+        "wire": "TRNRD11",
+        "dir": "OUTPUT"
+      },
+      "TRNRD12": {
+        "primary": "TRNRD12",
+        "wire": "TRNRD12",
+        "dir": "OUTPUT"
+      },
+      "TRNRD13": {
+        "primary": "TRNRD13",
+        "wire": "TRNRD13",
+        "dir": "OUTPUT"
+      },
+      "TRNRD14": {
+        "primary": "TRNRD14",
+        "wire": "TRNRD14",
+        "dir": "OUTPUT"
+      },
+      "TRNRD15": {
+        "primary": "TRNRD15",
+        "wire": "TRNRD15",
+        "dir": "OUTPUT"
+      },
+      "TRNRD16": {
+        "primary": "TRNRD16",
+        "wire": "TRNRD16",
+        "dir": "OUTPUT"
+      },
+      "TRNRD17": {
+        "primary": "TRNRD17",
+        "wire": "TRNRD17",
+        "dir": "OUTPUT"
+      },
+      "TRNRD18": {
+        "primary": "TRNRD18",
+        "wire": "TRNRD18",
+        "dir": "OUTPUT"
+      },
+      "TRNRD19": {
+        "primary": "TRNRD19",
+        "wire": "TRNRD19",
+        "dir": "OUTPUT"
+      },
+      "TRNRD20": {
+        "primary": "TRNRD20",
+        "wire": "TRNRD20",
+        "dir": "OUTPUT"
+      },
+      "TRNRD21": {
+        "primary": "TRNRD21",
+        "wire": "TRNRD21",
+        "dir": "OUTPUT"
+      },
+      "TRNRD22": {
+        "primary": "TRNRD22",
+        "wire": "TRNRD22",
+        "dir": "OUTPUT"
+      },
+      "TRNRD23": {
+        "primary": "TRNRD23",
+        "wire": "TRNRD23",
+        "dir": "OUTPUT"
+      },
+      "TRNRD24": {
+        "primary": "TRNRD24",
+        "wire": "TRNRD24",
+        "dir": "OUTPUT"
+      },
+      "TRNRD25": {
+        "primary": "TRNRD25",
+        "wire": "TRNRD25",
+        "dir": "OUTPUT"
+      },
+      "TRNRD26": {
+        "primary": "TRNRD26",
+        "wire": "TRNRD26",
+        "dir": "OUTPUT"
+      },
+      "TRNRD27": {
+        "primary": "TRNRD27",
+        "wire": "TRNRD27",
+        "dir": "OUTPUT"
+      },
+      "TRNRD28": {
+        "primary": "TRNRD28",
+        "wire": "TRNRD28",
+        "dir": "OUTPUT"
+      },
+      "TRNRD29": {
+        "primary": "TRNRD29",
+        "wire": "TRNRD29",
+        "dir": "OUTPUT"
+      },
+      "TRNRD30": {
+        "primary": "TRNRD30",
+        "wire": "TRNRD30",
+        "dir": "OUTPUT"
+      },
+      "TRNRD31": {
+        "primary": "TRNRD31",
+        "wire": "TRNRD31",
+        "dir": "OUTPUT"
+      },
+      "TRNRD32": {
+        "primary": "TRNRD32",
+        "wire": "TRNRD32",
+        "dir": "OUTPUT"
+      },
+      "TRNRD33": {
+        "primary": "TRNRD33",
+        "wire": "TRNRD33",
+        "dir": "OUTPUT"
+      },
+      "TRNRD34": {
+        "primary": "TRNRD34",
+        "wire": "TRNRD34",
+        "dir": "OUTPUT"
+      },
+      "TRNRD35": {
+        "primary": "TRNRD35",
+        "wire": "TRNRD35",
+        "dir": "OUTPUT"
+      },
+      "TRNRD36": {
+        "primary": "TRNRD36",
+        "wire": "TRNRD36",
+        "dir": "OUTPUT"
+      },
+      "TRNRD37": {
+        "primary": "TRNRD37",
+        "wire": "TRNRD37",
+        "dir": "OUTPUT"
+      },
+      "TRNRD38": {
+        "primary": "TRNRD38",
+        "wire": "TRNRD38",
+        "dir": "OUTPUT"
+      },
+      "TRNRD39": {
+        "primary": "TRNRD39",
+        "wire": "TRNRD39",
+        "dir": "OUTPUT"
+      },
+      "TRNRD40": {
+        "primary": "TRNRD40",
+        "wire": "TRNRD40",
+        "dir": "OUTPUT"
+      },
+      "TRNRD41": {
+        "primary": "TRNRD41",
+        "wire": "TRNRD41",
+        "dir": "OUTPUT"
+      },
+      "TRNRD42": {
+        "primary": "TRNRD42",
+        "wire": "TRNRD42",
+        "dir": "OUTPUT"
+      },
+      "TRNRD43": {
+        "primary": "TRNRD43",
+        "wire": "TRNRD43",
+        "dir": "OUTPUT"
+      },
+      "TRNRD44": {
+        "primary": "TRNRD44",
+        "wire": "TRNRD44",
+        "dir": "OUTPUT"
+      },
+      "TRNRD45": {
+        "primary": "TRNRD45",
+        "wire": "TRNRD45",
+        "dir": "OUTPUT"
+      },
+      "TRNRD46": {
+        "primary": "TRNRD46",
+        "wire": "TRNRD46",
+        "dir": "OUTPUT"
+      },
+      "TRNRD47": {
+        "primary": "TRNRD47",
+        "wire": "TRNRD47",
+        "dir": "OUTPUT"
+      },
+      "TRNRD48": {
+        "primary": "TRNRD48",
+        "wire": "TRNRD48",
+        "dir": "OUTPUT"
+      },
+      "TRNRD49": {
+        "primary": "TRNRD49",
+        "wire": "TRNRD49",
+        "dir": "OUTPUT"
+      },
+      "TRNRD50": {
+        "primary": "TRNRD50",
+        "wire": "TRNRD50",
+        "dir": "OUTPUT"
+      },
+      "TRNRD51": {
+        "primary": "TRNRD51",
+        "wire": "TRNRD51",
+        "dir": "OUTPUT"
+      },
+      "TRNRD52": {
+        "primary": "TRNRD52",
+        "wire": "TRNRD52",
+        "dir": "OUTPUT"
+      },
+      "TRNRD53": {
+        "primary": "TRNRD53",
+        "wire": "TRNRD53",
+        "dir": "OUTPUT"
+      },
+      "TRNRD54": {
+        "primary": "TRNRD54",
+        "wire": "TRNRD54",
+        "dir": "OUTPUT"
+      },
+      "TRNRD55": {
+        "primary": "TRNRD55",
+        "wire": "TRNRD55",
+        "dir": "OUTPUT"
+      },
+      "TRNRD56": {
+        "primary": "TRNRD56",
+        "wire": "TRNRD56",
+        "dir": "OUTPUT"
+      },
+      "TRNRD57": {
+        "primary": "TRNRD57",
+        "wire": "TRNRD57",
+        "dir": "OUTPUT"
+      },
+      "TRNRD58": {
+        "primary": "TRNRD58",
+        "wire": "TRNRD58",
+        "dir": "OUTPUT"
+      },
+      "TRNRD59": {
+        "primary": "TRNRD59",
+        "wire": "TRNRD59",
+        "dir": "OUTPUT"
+      },
+      "TRNRD60": {
+        "primary": "TRNRD60",
+        "wire": "TRNRD60",
+        "dir": "OUTPUT"
+      },
+      "TRNRD61": {
+        "primary": "TRNRD61",
+        "wire": "TRNRD61",
+        "dir": "OUTPUT"
+      },
+      "TRNRD62": {
+        "primary": "TRNRD62",
+        "wire": "TRNRD62",
+        "dir": "OUTPUT"
+      },
+      "TRNRD63": {
+        "primary": "TRNRD63",
+        "wire": "TRNRD63",
+        "dir": "OUTPUT"
+      },
+      "TRNRD64": {
+        "primary": "TRNRD64",
+        "wire": "TRNRD64",
+        "dir": "OUTPUT"
+      },
+      "TRNRD65": {
+        "primary": "TRNRD65",
+        "wire": "TRNRD65",
+        "dir": "OUTPUT"
+      },
+      "TRNRD66": {
+        "primary": "TRNRD66",
+        "wire": "TRNRD66",
+        "dir": "OUTPUT"
+      },
+      "TRNRD67": {
+        "primary": "TRNRD67",
+        "wire": "TRNRD67",
+        "dir": "OUTPUT"
+      },
+      "TRNRD68": {
+        "primary": "TRNRD68",
+        "wire": "TRNRD68",
+        "dir": "OUTPUT"
+      },
+      "TRNRD69": {
+        "primary": "TRNRD69",
+        "wire": "TRNRD69",
+        "dir": "OUTPUT"
+      },
+      "TRNRD70": {
+        "primary": "TRNRD70",
+        "wire": "TRNRD70",
+        "dir": "OUTPUT"
+      },
+      "TRNRD71": {
+        "primary": "TRNRD71",
+        "wire": "TRNRD71",
+        "dir": "OUTPUT"
+      },
+      "TRNRD72": {
+        "primary": "TRNRD72",
+        "wire": "TRNRD72",
+        "dir": "OUTPUT"
+      },
+      "TRNRD73": {
+        "primary": "TRNRD73",
+        "wire": "TRNRD73",
+        "dir": "OUTPUT"
+      },
+      "TRNRD74": {
+        "primary": "TRNRD74",
+        "wire": "TRNRD74",
+        "dir": "OUTPUT"
+      },
+      "TRNRD75": {
+        "primary": "TRNRD75",
+        "wire": "TRNRD75",
+        "dir": "OUTPUT"
+      },
+      "TRNRD76": {
+        "primary": "TRNRD76",
+        "wire": "TRNRD76",
+        "dir": "OUTPUT"
+      },
+      "TRNRD77": {
+        "primary": "TRNRD77",
+        "wire": "TRNRD77",
+        "dir": "OUTPUT"
+      },
+      "TRNRD78": {
+        "primary": "TRNRD78",
+        "wire": "TRNRD78",
+        "dir": "OUTPUT"
+      },
+      "TRNRD79": {
+        "primary": "TRNRD79",
+        "wire": "TRNRD79",
+        "dir": "OUTPUT"
+      },
+      "TRNRD80": {
+        "primary": "TRNRD80",
+        "wire": "TRNRD80",
+        "dir": "OUTPUT"
+      },
+      "TRNRD81": {
+        "primary": "TRNRD81",
+        "wire": "TRNRD81",
+        "dir": "OUTPUT"
+      },
+      "TRNRD82": {
+        "primary": "TRNRD82",
+        "wire": "TRNRD82",
+        "dir": "OUTPUT"
+      },
+      "TRNRD83": {
+        "primary": "TRNRD83",
+        "wire": "TRNRD83",
+        "dir": "OUTPUT"
+      },
+      "TRNRD84": {
+        "primary": "TRNRD84",
+        "wire": "TRNRD84",
+        "dir": "OUTPUT"
+      },
+      "TRNRD85": {
+        "primary": "TRNRD85",
+        "wire": "TRNRD85",
+        "dir": "OUTPUT"
+      },
+      "TRNRD86": {
+        "primary": "TRNRD86",
+        "wire": "TRNRD86",
+        "dir": "OUTPUT"
+      },
+      "TRNRD87": {
+        "primary": "TRNRD87",
+        "wire": "TRNRD87",
+        "dir": "OUTPUT"
+      },
+      "TRNRD88": {
+        "primary": "TRNRD88",
+        "wire": "TRNRD88",
+        "dir": "OUTPUT"
+      },
+      "TRNRD89": {
+        "primary": "TRNRD89",
+        "wire": "TRNRD89",
+        "dir": "OUTPUT"
+      },
+      "TRNRD90": {
+        "primary": "TRNRD90",
+        "wire": "TRNRD90",
+        "dir": "OUTPUT"
+      },
+      "TRNRD91": {
+        "primary": "TRNRD91",
+        "wire": "TRNRD91",
+        "dir": "OUTPUT"
+      },
+      "TRNRD92": {
+        "primary": "TRNRD92",
+        "wire": "TRNRD92",
+        "dir": "OUTPUT"
+      },
+      "TRNRD93": {
+        "primary": "TRNRD93",
+        "wire": "TRNRD93",
+        "dir": "OUTPUT"
+      },
+      "TRNRD94": {
+        "primary": "TRNRD94",
+        "wire": "TRNRD94",
+        "dir": "OUTPUT"
+      },
+      "TRNRD95": {
+        "primary": "TRNRD95",
+        "wire": "TRNRD95",
+        "dir": "OUTPUT"
+      },
+      "TRNRD96": {
+        "primary": "TRNRD96",
+        "wire": "TRNRD96",
+        "dir": "OUTPUT"
+      },
+      "TRNRD97": {
+        "primary": "TRNRD97",
+        "wire": "TRNRD97",
+        "dir": "OUTPUT"
+      },
+      "TRNRD98": {
+        "primary": "TRNRD98",
+        "wire": "TRNRD98",
+        "dir": "OUTPUT"
+      },
+      "TRNRD99": {
+        "primary": "TRNRD99",
+        "wire": "TRNRD99",
+        "dir": "OUTPUT"
+      },
+      "TRNRD100": {
+        "primary": "TRNRD100",
+        "wire": "TRNRD100",
+        "dir": "OUTPUT"
+      },
+      "TRNRD101": {
+        "primary": "TRNRD101",
+        "wire": "TRNRD101",
+        "dir": "OUTPUT"
+      },
+      "TRNRD102": {
+        "primary": "TRNRD102",
+        "wire": "TRNRD102",
+        "dir": "OUTPUT"
+      },
+      "TRNRD103": {
+        "primary": "TRNRD103",
+        "wire": "TRNRD103",
+        "dir": "OUTPUT"
+      },
+      "TRNRD104": {
+        "primary": "TRNRD104",
+        "wire": "TRNRD104",
+        "dir": "OUTPUT"
+      },
+      "TRNRD105": {
+        "primary": "TRNRD105",
+        "wire": "TRNRD105",
+        "dir": "OUTPUT"
+      },
+      "TRNRD106": {
+        "primary": "TRNRD106",
+        "wire": "TRNRD106",
+        "dir": "OUTPUT"
+      },
+      "TRNRD107": {
+        "primary": "TRNRD107",
+        "wire": "TRNRD107",
+        "dir": "OUTPUT"
+      },
+      "TRNRD108": {
+        "primary": "TRNRD108",
+        "wire": "TRNRD108",
+        "dir": "OUTPUT"
+      },
+      "TRNRD109": {
+        "primary": "TRNRD109",
+        "wire": "TRNRD109",
+        "dir": "OUTPUT"
+      },
+      "TRNRD110": {
+        "primary": "TRNRD110",
+        "wire": "TRNRD110",
+        "dir": "OUTPUT"
+      },
+      "TRNRD111": {
+        "primary": "TRNRD111",
+        "wire": "TRNRD111",
+        "dir": "OUTPUT"
+      },
+      "TRNRD112": {
+        "primary": "TRNRD112",
+        "wire": "TRNRD112",
+        "dir": "OUTPUT"
+      },
+      "TRNRD113": {
+        "primary": "TRNRD113",
+        "wire": "TRNRD113",
+        "dir": "OUTPUT"
+      },
+      "TRNRD114": {
+        "primary": "TRNRD114",
+        "wire": "TRNRD114",
+        "dir": "OUTPUT"
+      },
+      "TRNRD115": {
+        "primary": "TRNRD115",
+        "wire": "TRNRD115",
+        "dir": "OUTPUT"
+      },
+      "TRNRD116": {
+        "primary": "TRNRD116",
+        "wire": "TRNRD116",
+        "dir": "OUTPUT"
+      },
+      "TRNRD117": {
+        "primary": "TRNRD117",
+        "wire": "TRNRD117",
+        "dir": "OUTPUT"
+      },
+      "TRNRD118": {
+        "primary": "TRNRD118",
+        "wire": "TRNRD118",
+        "dir": "OUTPUT"
+      },
+      "TRNRD119": {
+        "primary": "TRNRD119",
+        "wire": "TRNRD119",
+        "dir": "OUTPUT"
+      },
+      "TRNRD120": {
+        "primary": "TRNRD120",
+        "wire": "TRNRD120",
+        "dir": "OUTPUT"
+      },
+      "TRNRD121": {
+        "primary": "TRNRD121",
+        "wire": "TRNRD121",
+        "dir": "OUTPUT"
+      },
+      "TRNRD122": {
+        "primary": "TRNRD122",
+        "wire": "TRNRD122",
+        "dir": "OUTPUT"
+      },
+      "TRNRD123": {
+        "primary": "TRNRD123",
+        "wire": "TRNRD123",
+        "dir": "OUTPUT"
+      },
+      "TRNRD124": {
+        "primary": "TRNRD124",
+        "wire": "TRNRD124",
+        "dir": "OUTPUT"
+      },
+      "TRNRD125": {
+        "primary": "TRNRD125",
+        "wire": "TRNRD125",
+        "dir": "OUTPUT"
+      },
+      "TRNRD126": {
+        "primary": "TRNRD126",
+        "wire": "TRNRD126",
+        "dir": "OUTPUT"
+      },
+      "TRNRD127": {
+        "primary": "TRNRD127",
+        "wire": "TRNRD127",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA0": {
+        "primary": "TRNRDLLPDATA0",
+        "wire": "TRNRDLLPDATA0",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA1": {
+        "primary": "TRNRDLLPDATA1",
+        "wire": "TRNRDLLPDATA1",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA2": {
+        "primary": "TRNRDLLPDATA2",
+        "wire": "TRNRDLLPDATA2",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA3": {
+        "primary": "TRNRDLLPDATA3",
+        "wire": "TRNRDLLPDATA3",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA4": {
+        "primary": "TRNRDLLPDATA4",
+        "wire": "TRNRDLLPDATA4",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA5": {
+        "primary": "TRNRDLLPDATA5",
+        "wire": "TRNRDLLPDATA5",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA6": {
+        "primary": "TRNRDLLPDATA6",
+        "wire": "TRNRDLLPDATA6",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA7": {
+        "primary": "TRNRDLLPDATA7",
+        "wire": "TRNRDLLPDATA7",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA8": {
+        "primary": "TRNRDLLPDATA8",
+        "wire": "TRNRDLLPDATA8",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA9": {
+        "primary": "TRNRDLLPDATA9",
+        "wire": "TRNRDLLPDATA9",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA10": {
+        "primary": "TRNRDLLPDATA10",
+        "wire": "TRNRDLLPDATA10",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA11": {
+        "primary": "TRNRDLLPDATA11",
+        "wire": "TRNRDLLPDATA11",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA12": {
+        "primary": "TRNRDLLPDATA12",
+        "wire": "TRNRDLLPDATA12",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA13": {
+        "primary": "TRNRDLLPDATA13",
+        "wire": "TRNRDLLPDATA13",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA14": {
+        "primary": "TRNRDLLPDATA14",
+        "wire": "TRNRDLLPDATA14",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA15": {
+        "primary": "TRNRDLLPDATA15",
+        "wire": "TRNRDLLPDATA15",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA16": {
+        "primary": "TRNRDLLPDATA16",
+        "wire": "TRNRDLLPDATA16",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA17": {
+        "primary": "TRNRDLLPDATA17",
+        "wire": "TRNRDLLPDATA17",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA18": {
+        "primary": "TRNRDLLPDATA18",
+        "wire": "TRNRDLLPDATA18",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA19": {
+        "primary": "TRNRDLLPDATA19",
+        "wire": "TRNRDLLPDATA19",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA20": {
+        "primary": "TRNRDLLPDATA20",
+        "wire": "TRNRDLLPDATA20",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA21": {
+        "primary": "TRNRDLLPDATA21",
+        "wire": "TRNRDLLPDATA21",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA22": {
+        "primary": "TRNRDLLPDATA22",
+        "wire": "TRNRDLLPDATA22",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA23": {
+        "primary": "TRNRDLLPDATA23",
+        "wire": "TRNRDLLPDATA23",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA24": {
+        "primary": "TRNRDLLPDATA24",
+        "wire": "TRNRDLLPDATA24",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA25": {
+        "primary": "TRNRDLLPDATA25",
+        "wire": "TRNRDLLPDATA25",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA26": {
+        "primary": "TRNRDLLPDATA26",
+        "wire": "TRNRDLLPDATA26",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA27": {
+        "primary": "TRNRDLLPDATA27",
+        "wire": "TRNRDLLPDATA27",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA28": {
+        "primary": "TRNRDLLPDATA28",
+        "wire": "TRNRDLLPDATA28",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA29": {
+        "primary": "TRNRDLLPDATA29",
+        "wire": "TRNRDLLPDATA29",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA30": {
+        "primary": "TRNRDLLPDATA30",
+        "wire": "TRNRDLLPDATA30",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA31": {
+        "primary": "TRNRDLLPDATA31",
+        "wire": "TRNRDLLPDATA31",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA32": {
+        "primary": "TRNRDLLPDATA32",
+        "wire": "TRNRDLLPDATA32",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA33": {
+        "primary": "TRNRDLLPDATA33",
+        "wire": "TRNRDLLPDATA33",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA34": {
+        "primary": "TRNRDLLPDATA34",
+        "wire": "TRNRDLLPDATA34",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA35": {
+        "primary": "TRNRDLLPDATA35",
+        "wire": "TRNRDLLPDATA35",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA36": {
+        "primary": "TRNRDLLPDATA36",
+        "wire": "TRNRDLLPDATA36",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA37": {
+        "primary": "TRNRDLLPDATA37",
+        "wire": "TRNRDLLPDATA37",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA38": {
+        "primary": "TRNRDLLPDATA38",
+        "wire": "TRNRDLLPDATA38",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA39": {
+        "primary": "TRNRDLLPDATA39",
+        "wire": "TRNRDLLPDATA39",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA40": {
+        "primary": "TRNRDLLPDATA40",
+        "wire": "TRNRDLLPDATA40",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA41": {
+        "primary": "TRNRDLLPDATA41",
+        "wire": "TRNRDLLPDATA41",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA42": {
+        "primary": "TRNRDLLPDATA42",
+        "wire": "TRNRDLLPDATA42",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA43": {
+        "primary": "TRNRDLLPDATA43",
+        "wire": "TRNRDLLPDATA43",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA44": {
+        "primary": "TRNRDLLPDATA44",
+        "wire": "TRNRDLLPDATA44",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA45": {
+        "primary": "TRNRDLLPDATA45",
+        "wire": "TRNRDLLPDATA45",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA46": {
+        "primary": "TRNRDLLPDATA46",
+        "wire": "TRNRDLLPDATA46",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA47": {
+        "primary": "TRNRDLLPDATA47",
+        "wire": "TRNRDLLPDATA47",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA48": {
+        "primary": "TRNRDLLPDATA48",
+        "wire": "TRNRDLLPDATA48",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA49": {
+        "primary": "TRNRDLLPDATA49",
+        "wire": "TRNRDLLPDATA49",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA50": {
+        "primary": "TRNRDLLPDATA50",
+        "wire": "TRNRDLLPDATA50",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA51": {
+        "primary": "TRNRDLLPDATA51",
+        "wire": "TRNRDLLPDATA51",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA52": {
+        "primary": "TRNRDLLPDATA52",
+        "wire": "TRNRDLLPDATA52",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA53": {
+        "primary": "TRNRDLLPDATA53",
+        "wire": "TRNRDLLPDATA53",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA54": {
+        "primary": "TRNRDLLPDATA54",
+        "wire": "TRNRDLLPDATA54",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA55": {
+        "primary": "TRNRDLLPDATA55",
+        "wire": "TRNRDLLPDATA55",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA56": {
+        "primary": "TRNRDLLPDATA56",
+        "wire": "TRNRDLLPDATA56",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA57": {
+        "primary": "TRNRDLLPDATA57",
+        "wire": "TRNRDLLPDATA57",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA58": {
+        "primary": "TRNRDLLPDATA58",
+        "wire": "TRNRDLLPDATA58",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA59": {
+        "primary": "TRNRDLLPDATA59",
+        "wire": "TRNRDLLPDATA59",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA60": {
+        "primary": "TRNRDLLPDATA60",
+        "wire": "TRNRDLLPDATA60",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA61": {
+        "primary": "TRNRDLLPDATA61",
+        "wire": "TRNRDLLPDATA61",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA62": {
+        "primary": "TRNRDLLPDATA62",
+        "wire": "TRNRDLLPDATA62",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPDATA63": {
+        "primary": "TRNRDLLPDATA63",
+        "wire": "TRNRDLLPDATA63",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPSRCRDY0": {
+        "primary": "TRNRDLLPSRCRDY0",
+        "wire": "TRNRDLLPSRCRDY0",
+        "dir": "OUTPUT"
+      },
+      "TRNRDLLPSRCRDY1": {
+        "primary": "TRNRDLLPSRCRDY1",
+        "wire": "TRNRDLLPSRCRDY1",
+        "dir": "OUTPUT"
+      },
+      "TRNRDSTRDY": {
+        "primary": "TRNRDSTRDY",
+        "wire": "TRNRDSTRDY",
+        "dir": "INPUT"
+      },
+      "TRNRECRCERR": {
+        "primary": "TRNRECRCERR",
+        "wire": "TRNRECRCERR",
+        "dir": "OUTPUT"
+      },
+      "TRNREOF": {
+        "primary": "TRNREOF",
+        "wire": "TRNREOF",
+        "dir": "OUTPUT"
+      },
+      "TRNRERRFWD": {
+        "primary": "TRNRERRFWD",
+        "wire": "TRNRERRFWD",
+        "dir": "OUTPUT"
+      },
+      "TRNRFCPRET": {
+        "primary": "TRNRFCPRET",
+        "wire": "TRNRFCPRET",
+        "dir": "INPUT"
+      },
+      "TRNRNPOK": {
+        "primary": "TRNRNPOK",
+        "wire": "TRNRNPOK",
+        "dir": "INPUT"
+      },
+      "TRNRNPREQ": {
+        "primary": "TRNRNPREQ",
+        "wire": "TRNRNPREQ",
+        "dir": "INPUT"
+      },
+      "TRNRREM0": {
+        "primary": "TRNRREM0",
+        "wire": "TRNRREM0",
+        "dir": "OUTPUT"
+      },
+      "TRNRREM1": {
+        "primary": "TRNRREM1",
+        "wire": "TRNRREM1",
+        "dir": "OUTPUT"
+      },
+      "TRNRSOF": {
+        "primary": "TRNRSOF",
+        "wire": "TRNRSOF",
+        "dir": "OUTPUT"
+      },
+      "TRNRSRCDSC": {
+        "primary": "TRNRSRCDSC",
+        "wire": "TRNRSRCDSC",
+        "dir": "OUTPUT"
+      },
+      "TRNRSRCRDY": {
+        "primary": "TRNRSRCRDY",
+        "wire": "TRNRSRCRDY",
+        "dir": "OUTPUT"
+      },
+      "TRNTBUFAV0": {
+        "primary": "TRNTBUFAV0",
+        "wire": "TRNTBUFAV0",
+        "dir": "OUTPUT"
+      },
+      "TRNTBUFAV1": {
+        "primary": "TRNTBUFAV1",
+        "wire": "TRNTBUFAV1",
+        "dir": "OUTPUT"
+      },
+      "TRNTBUFAV2": {
+        "primary": "TRNTBUFAV2",
+        "wire": "TRNTBUFAV2",
+        "dir": "OUTPUT"
+      },
+      "TRNTBUFAV3": {
+        "primary": "TRNTBUFAV3",
+        "wire": "TRNTBUFAV3",
+        "dir": "OUTPUT"
+      },
+      "TRNTBUFAV4": {
+        "primary": "TRNTBUFAV4",
+        "wire": "TRNTBUFAV4",
+        "dir": "OUTPUT"
+      },
+      "TRNTBUFAV5": {
+        "primary": "TRNTBUFAV5",
+        "wire": "TRNTBUFAV5",
+        "dir": "OUTPUT"
+      },
+      "TRNTCFGGNT": {
+        "primary": "TRNTCFGGNT",
+        "wire": "TRNTCFGGNT",
+        "dir": "INPUT"
+      },
+      "TRNTCFGREQ": {
+        "primary": "TRNTCFGREQ",
+        "wire": "TRNTCFGREQ",
+        "dir": "OUTPUT"
+      },
+      "TRNTD0": {
+        "primary": "TRNTD0",
+        "wire": "TRNTD0",
+        "dir": "INPUT"
+      },
+      "TRNTD1": {
+        "primary": "TRNTD1",
+        "wire": "TRNTD1",
+        "dir": "INPUT"
+      },
+      "TRNTD2": {
+        "primary": "TRNTD2",
+        "wire": "TRNTD2",
+        "dir": "INPUT"
+      },
+      "TRNTD3": {
+        "primary": "TRNTD3",
+        "wire": "TRNTD3",
+        "dir": "INPUT"
+      },
+      "TRNTD4": {
+        "primary": "TRNTD4",
+        "wire": "TRNTD4",
+        "dir": "INPUT"
+      },
+      "TRNTD5": {
+        "primary": "TRNTD5",
+        "wire": "TRNTD5",
+        "dir": "INPUT"
+      },
+      "TRNTD6": {
+        "primary": "TRNTD6",
+        "wire": "TRNTD6",
+        "dir": "INPUT"
+      },
+      "TRNTD7": {
+        "primary": "TRNTD7",
+        "wire": "TRNTD7",
+        "dir": "INPUT"
+      },
+      "TRNTD8": {
+        "primary": "TRNTD8",
+        "wire": "TRNTD8",
+        "dir": "INPUT"
+      },
+      "TRNTD9": {
+        "primary": "TRNTD9",
+        "wire": "TRNTD9",
+        "dir": "INPUT"
+      },
+      "TRNTD10": {
+        "primary": "TRNTD10",
+        "wire": "TRNTD10",
+        "dir": "INPUT"
+      },
+      "TRNTD11": {
+        "primary": "TRNTD11",
+        "wire": "TRNTD11",
+        "dir": "INPUT"
+      },
+      "TRNTD12": {
+        "primary": "TRNTD12",
+        "wire": "TRNTD12",
+        "dir": "INPUT"
+      },
+      "TRNTD13": {
+        "primary": "TRNTD13",
+        "wire": "TRNTD13",
+        "dir": "INPUT"
+      },
+      "TRNTD14": {
+        "primary": "TRNTD14",
+        "wire": "TRNTD14",
+        "dir": "INPUT"
+      },
+      "TRNTD15": {
+        "primary": "TRNTD15",
+        "wire": "TRNTD15",
+        "dir": "INPUT"
+      },
+      "TRNTD16": {
+        "primary": "TRNTD16",
+        "wire": "TRNTD16",
+        "dir": "INPUT"
+      },
+      "TRNTD17": {
+        "primary": "TRNTD17",
+        "wire": "TRNTD17",
+        "dir": "INPUT"
+      },
+      "TRNTD18": {
+        "primary": "TRNTD18",
+        "wire": "TRNTD18",
+        "dir": "INPUT"
+      },
+      "TRNTD19": {
+        "primary": "TRNTD19",
+        "wire": "TRNTD19",
+        "dir": "INPUT"
+      },
+      "TRNTD20": {
+        "primary": "TRNTD20",
+        "wire": "TRNTD20",
+        "dir": "INPUT"
+      },
+      "TRNTD21": {
+        "primary": "TRNTD21",
+        "wire": "TRNTD21",
+        "dir": "INPUT"
+      },
+      "TRNTD22": {
+        "primary": "TRNTD22",
+        "wire": "TRNTD22",
+        "dir": "INPUT"
+      },
+      "TRNTD23": {
+        "primary": "TRNTD23",
+        "wire": "TRNTD23",
+        "dir": "INPUT"
+      },
+      "TRNTD24": {
+        "primary": "TRNTD24",
+        "wire": "TRNTD24",
+        "dir": "INPUT"
+      },
+      "TRNTD25": {
+        "primary": "TRNTD25",
+        "wire": "TRNTD25",
+        "dir": "INPUT"
+      },
+      "TRNTD26": {
+        "primary": "TRNTD26",
+        "wire": "TRNTD26",
+        "dir": "INPUT"
+      },
+      "TRNTD27": {
+        "primary": "TRNTD27",
+        "wire": "TRNTD27",
+        "dir": "INPUT"
+      },
+      "TRNTD28": {
+        "primary": "TRNTD28",
+        "wire": "TRNTD28",
+        "dir": "INPUT"
+      },
+      "TRNTD29": {
+        "primary": "TRNTD29",
+        "wire": "TRNTD29",
+        "dir": "INPUT"
+      },
+      "TRNTD30": {
+        "primary": "TRNTD30",
+        "wire": "TRNTD30",
+        "dir": "INPUT"
+      },
+      "TRNTD31": {
+        "primary": "TRNTD31",
+        "wire": "TRNTD31",
+        "dir": "INPUT"
+      },
+      "TRNTD32": {
+        "primary": "TRNTD32",
+        "wire": "TRNTD32",
+        "dir": "INPUT"
+      },
+      "TRNTD33": {
+        "primary": "TRNTD33",
+        "wire": "TRNTD33",
+        "dir": "INPUT"
+      },
+      "TRNTD34": {
+        "primary": "TRNTD34",
+        "wire": "TRNTD34",
+        "dir": "INPUT"
+      },
+      "TRNTD35": {
+        "primary": "TRNTD35",
+        "wire": "TRNTD35",
+        "dir": "INPUT"
+      },
+      "TRNTD36": {
+        "primary": "TRNTD36",
+        "wire": "TRNTD36",
+        "dir": "INPUT"
+      },
+      "TRNTD37": {
+        "primary": "TRNTD37",
+        "wire": "TRNTD37",
+        "dir": "INPUT"
+      },
+      "TRNTD38": {
+        "primary": "TRNTD38",
+        "wire": "TRNTD38",
+        "dir": "INPUT"
+      },
+      "TRNTD39": {
+        "primary": "TRNTD39",
+        "wire": "TRNTD39",
+        "dir": "INPUT"
+      },
+      "TRNTD40": {
+        "primary": "TRNTD40",
+        "wire": "TRNTD40",
+        "dir": "INPUT"
+      },
+      "TRNTD41": {
+        "primary": "TRNTD41",
+        "wire": "TRNTD41",
+        "dir": "INPUT"
+      },
+      "TRNTD42": {
+        "primary": "TRNTD42",
+        "wire": "TRNTD42",
+        "dir": "INPUT"
+      },
+      "TRNTD43": {
+        "primary": "TRNTD43",
+        "wire": "TRNTD43",
+        "dir": "INPUT"
+      },
+      "TRNTD44": {
+        "primary": "TRNTD44",
+        "wire": "TRNTD44",
+        "dir": "INPUT"
+      },
+      "TRNTD45": {
+        "primary": "TRNTD45",
+        "wire": "TRNTD45",
+        "dir": "INPUT"
+      },
+      "TRNTD46": {
+        "primary": "TRNTD46",
+        "wire": "TRNTD46",
+        "dir": "INPUT"
+      },
+      "TRNTD47": {
+        "primary": "TRNTD47",
+        "wire": "TRNTD47",
+        "dir": "INPUT"
+      },
+      "TRNTD48": {
+        "primary": "TRNTD48",
+        "wire": "TRNTD48",
+        "dir": "INPUT"
+      },
+      "TRNTD49": {
+        "primary": "TRNTD49",
+        "wire": "TRNTD49",
+        "dir": "INPUT"
+      },
+      "TRNTD50": {
+        "primary": "TRNTD50",
+        "wire": "TRNTD50",
+        "dir": "INPUT"
+      },
+      "TRNTD51": {
+        "primary": "TRNTD51",
+        "wire": "TRNTD51",
+        "dir": "INPUT"
+      },
+      "TRNTD52": {
+        "primary": "TRNTD52",
+        "wire": "TRNTD52",
+        "dir": "INPUT"
+      },
+      "TRNTD53": {
+        "primary": "TRNTD53",
+        "wire": "TRNTD53",
+        "dir": "INPUT"
+      },
+      "TRNTD54": {
+        "primary": "TRNTD54",
+        "wire": "TRNTD54",
+        "dir": "INPUT"
+      },
+      "TRNTD55": {
+        "primary": "TRNTD55",
+        "wire": "TRNTD55",
+        "dir": "INPUT"
+      },
+      "TRNTD56": {
+        "primary": "TRNTD56",
+        "wire": "TRNTD56",
+        "dir": "INPUT"
+      },
+      "TRNTD57": {
+        "primary": "TRNTD57",
+        "wire": "TRNTD57",
+        "dir": "INPUT"
+      },
+      "TRNTD58": {
+        "primary": "TRNTD58",
+        "wire": "TRNTD58",
+        "dir": "INPUT"
+      },
+      "TRNTD59": {
+        "primary": "TRNTD59",
+        "wire": "TRNTD59",
+        "dir": "INPUT"
+      },
+      "TRNTD60": {
+        "primary": "TRNTD60",
+        "wire": "TRNTD60",
+        "dir": "INPUT"
+      },
+      "TRNTD61": {
+        "primary": "TRNTD61",
+        "wire": "TRNTD61",
+        "dir": "INPUT"
+      },
+      "TRNTD62": {
+        "primary": "TRNTD62",
+        "wire": "TRNTD62",
+        "dir": "INPUT"
+      },
+      "TRNTD63": {
+        "primary": "TRNTD63",
+        "wire": "TRNTD63",
+        "dir": "INPUT"
+      },
+      "TRNTD64": {
+        "primary": "TRNTD64",
+        "wire": "TRNTD64",
+        "dir": "INPUT"
+      },
+      "TRNTD65": {
+        "primary": "TRNTD65",
+        "wire": "TRNTD65",
+        "dir": "INPUT"
+      },
+      "TRNTD66": {
+        "primary": "TRNTD66",
+        "wire": "TRNTD66",
+        "dir": "INPUT"
+      },
+      "TRNTD67": {
+        "primary": "TRNTD67",
+        "wire": "TRNTD67",
+        "dir": "INPUT"
+      },
+      "TRNTD68": {
+        "primary": "TRNTD68",
+        "wire": "TRNTD68",
+        "dir": "INPUT"
+      },
+      "TRNTD69": {
+        "primary": "TRNTD69",
+        "wire": "TRNTD69",
+        "dir": "INPUT"
+      },
+      "TRNTD70": {
+        "primary": "TRNTD70",
+        "wire": "TRNTD70",
+        "dir": "INPUT"
+      },
+      "TRNTD71": {
+        "primary": "TRNTD71",
+        "wire": "TRNTD71",
+        "dir": "INPUT"
+      },
+      "TRNTD72": {
+        "primary": "TRNTD72",
+        "wire": "TRNTD72",
+        "dir": "INPUT"
+      },
+      "TRNTD73": {
+        "primary": "TRNTD73",
+        "wire": "TRNTD73",
+        "dir": "INPUT"
+      },
+      "TRNTD74": {
+        "primary": "TRNTD74",
+        "wire": "TRNTD74",
+        "dir": "INPUT"
+      },
+      "TRNTD75": {
+        "primary": "TRNTD75",
+        "wire": "TRNTD75",
+        "dir": "INPUT"
+      },
+      "TRNTD76": {
+        "primary": "TRNTD76",
+        "wire": "TRNTD76",
+        "dir": "INPUT"
+      },
+      "TRNTD77": {
+        "primary": "TRNTD77",
+        "wire": "TRNTD77",
+        "dir": "INPUT"
+      },
+      "TRNTD78": {
+        "primary": "TRNTD78",
+        "wire": "TRNTD78",
+        "dir": "INPUT"
+      },
+      "TRNTD79": {
+        "primary": "TRNTD79",
+        "wire": "TRNTD79",
+        "dir": "INPUT"
+      },
+      "TRNTD80": {
+        "primary": "TRNTD80",
+        "wire": "TRNTD80",
+        "dir": "INPUT"
+      },
+      "TRNTD81": {
+        "primary": "TRNTD81",
+        "wire": "TRNTD81",
+        "dir": "INPUT"
+      },
+      "TRNTD82": {
+        "primary": "TRNTD82",
+        "wire": "TRNTD82",
+        "dir": "INPUT"
+      },
+      "TRNTD83": {
+        "primary": "TRNTD83",
+        "wire": "TRNTD83",
+        "dir": "INPUT"
+      },
+      "TRNTD84": {
+        "primary": "TRNTD84",
+        "wire": "TRNTD84",
+        "dir": "INPUT"
+      },
+      "TRNTD85": {
+        "primary": "TRNTD85",
+        "wire": "TRNTD85",
+        "dir": "INPUT"
+      },
+      "TRNTD86": {
+        "primary": "TRNTD86",
+        "wire": "TRNTD86",
+        "dir": "INPUT"
+      },
+      "TRNTD87": {
+        "primary": "TRNTD87",
+        "wire": "TRNTD87",
+        "dir": "INPUT"
+      },
+      "TRNTD88": {
+        "primary": "TRNTD88",
+        "wire": "TRNTD88",
+        "dir": "INPUT"
+      },
+      "TRNTD89": {
+        "primary": "TRNTD89",
+        "wire": "TRNTD89",
+        "dir": "INPUT"
+      },
+      "TRNTD90": {
+        "primary": "TRNTD90",
+        "wire": "TRNTD90",
+        "dir": "INPUT"
+      },
+      "TRNTD91": {
+        "primary": "TRNTD91",
+        "wire": "TRNTD91",
+        "dir": "INPUT"
+      },
+      "TRNTD92": {
+        "primary": "TRNTD92",
+        "wire": "TRNTD92",
+        "dir": "INPUT"
+      },
+      "TRNTD93": {
+        "primary": "TRNTD93",
+        "wire": "TRNTD93",
+        "dir": "INPUT"
+      },
+      "TRNTD94": {
+        "primary": "TRNTD94",
+        "wire": "TRNTD94",
+        "dir": "INPUT"
+      },
+      "TRNTD95": {
+        "primary": "TRNTD95",
+        "wire": "TRNTD95",
+        "dir": "INPUT"
+      },
+      "TRNTD96": {
+        "primary": "TRNTD96",
+        "wire": "TRNTD96",
+        "dir": "INPUT"
+      },
+      "TRNTD97": {
+        "primary": "TRNTD97",
+        "wire": "TRNTD97",
+        "dir": "INPUT"
+      },
+      "TRNTD98": {
+        "primary": "TRNTD98",
+        "wire": "TRNTD98",
+        "dir": "INPUT"
+      },
+      "TRNTD99": {
+        "primary": "TRNTD99",
+        "wire": "TRNTD99",
+        "dir": "INPUT"
+      },
+      "TRNTD100": {
+        "primary": "TRNTD100",
+        "wire": "TRNTD100",
+        "dir": "INPUT"
+      },
+      "TRNTD101": {
+        "primary": "TRNTD101",
+        "wire": "TRNTD101",
+        "dir": "INPUT"
+      },
+      "TRNTD102": {
+        "primary": "TRNTD102",
+        "wire": "TRNTD102",
+        "dir": "INPUT"
+      },
+      "TRNTD103": {
+        "primary": "TRNTD103",
+        "wire": "TRNTD103",
+        "dir": "INPUT"
+      },
+      "TRNTD104": {
+        "primary": "TRNTD104",
+        "wire": "TRNTD104",
+        "dir": "INPUT"
+      },
+      "TRNTD105": {
+        "primary": "TRNTD105",
+        "wire": "TRNTD105",
+        "dir": "INPUT"
+      },
+      "TRNTD106": {
+        "primary": "TRNTD106",
+        "wire": "TRNTD106",
+        "dir": "INPUT"
+      },
+      "TRNTD107": {
+        "primary": "TRNTD107",
+        "wire": "TRNTD107",
+        "dir": "INPUT"
+      },
+      "TRNTD108": {
+        "primary": "TRNTD108",
+        "wire": "TRNTD108",
+        "dir": "INPUT"
+      },
+      "TRNTD109": {
+        "primary": "TRNTD109",
+        "wire": "TRNTD109",
+        "dir": "INPUT"
+      },
+      "TRNTD110": {
+        "primary": "TRNTD110",
+        "wire": "TRNTD110",
+        "dir": "INPUT"
+      },
+      "TRNTD111": {
+        "primary": "TRNTD111",
+        "wire": "TRNTD111",
+        "dir": "INPUT"
+      },
+      "TRNTD112": {
+        "primary": "TRNTD112",
+        "wire": "TRNTD112",
+        "dir": "INPUT"
+      },
+      "TRNTD113": {
+        "primary": "TRNTD113",
+        "wire": "TRNTD113",
+        "dir": "INPUT"
+      },
+      "TRNTD114": {
+        "primary": "TRNTD114",
+        "wire": "TRNTD114",
+        "dir": "INPUT"
+      },
+      "TRNTD115": {
+        "primary": "TRNTD115",
+        "wire": "TRNTD115",
+        "dir": "INPUT"
+      },
+      "TRNTD116": {
+        "primary": "TRNTD116",
+        "wire": "TRNTD116",
+        "dir": "INPUT"
+      },
+      "TRNTD117": {
+        "primary": "TRNTD117",
+        "wire": "TRNTD117",
+        "dir": "INPUT"
+      },
+      "TRNTD118": {
+        "primary": "TRNTD118",
+        "wire": "TRNTD118",
+        "dir": "INPUT"
+      },
+      "TRNTD119": {
+        "primary": "TRNTD119",
+        "wire": "TRNTD119",
+        "dir": "INPUT"
+      },
+      "TRNTD120": {
+        "primary": "TRNTD120",
+        "wire": "TRNTD120",
+        "dir": "INPUT"
+      },
+      "TRNTD121": {
+        "primary": "TRNTD121",
+        "wire": "TRNTD121",
+        "dir": "INPUT"
+      },
+      "TRNTD122": {
+        "primary": "TRNTD122",
+        "wire": "TRNTD122",
+        "dir": "INPUT"
+      },
+      "TRNTD123": {
+        "primary": "TRNTD123",
+        "wire": "TRNTD123",
+        "dir": "INPUT"
+      },
+      "TRNTD124": {
+        "primary": "TRNTD124",
+        "wire": "TRNTD124",
+        "dir": "INPUT"
+      },
+      "TRNTD125": {
+        "primary": "TRNTD125",
+        "wire": "TRNTD125",
+        "dir": "INPUT"
+      },
+      "TRNTD126": {
+        "primary": "TRNTD126",
+        "wire": "TRNTD126",
+        "dir": "INPUT"
+      },
+      "TRNTD127": {
+        "primary": "TRNTD127",
+        "wire": "TRNTD127",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDATA0": {
+        "primary": "TRNTDLLPDATA0",
+        "wire": "TRNTDLLPDATA0",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDATA1": {
+        "primary": "TRNTDLLPDATA1",
+        "wire": "TRNTDLLPDATA1",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDATA2": {
+        "primary": "TRNTDLLPDATA2",
+        "wire": "TRNTDLLPDATA2",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDATA3": {
+        "primary": "TRNTDLLPDATA3",
+        "wire": "TRNTDLLPDATA3",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDATA4": {
+        "primary": "TRNTDLLPDATA4",
+        "wire": "TRNTDLLPDATA4",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDATA5": {
+        "primary": "TRNTDLLPDATA5",
+        "wire": "TRNTDLLPDATA5",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDATA6": {
+        "primary": "TRNTDLLPDATA6",
+        "wire": "TRNTDLLPDATA6",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDATA7": {
+        "primary": "TRNTDLLPDATA7",
+        "wire": "TRNTDLLPDATA7",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDATA8": {
+        "primary": "TRNTDLLPDATA8",
+        "wire": "TRNTDLLPDATA8",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDATA9": {
+        "primary": "TRNTDLLPDATA9",
+        "wire": "TRNTDLLPDATA9",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDATA10": {
+        "primary": "TRNTDLLPDATA10",
+        "wire": "TRNTDLLPDATA10",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDATA11": {
+        "primary": "TRNTDLLPDATA11",
+        "wire": "TRNTDLLPDATA11",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDATA12": {
+        "primary": "TRNTDLLPDATA12",
+        "wire": "TRNTDLLPDATA12",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDATA13": {
+        "primary": "TRNTDLLPDATA13",
+        "wire": "TRNTDLLPDATA13",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDATA14": {
+        "primary": "TRNTDLLPDATA14",
+        "wire": "TRNTDLLPDATA14",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDATA15": {
+        "primary": "TRNTDLLPDATA15",
+        "wire": "TRNTDLLPDATA15",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDATA16": {
+        "primary": "TRNTDLLPDATA16",
+        "wire": "TRNTDLLPDATA16",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDATA17": {
+        "primary": "TRNTDLLPDATA17",
+        "wire": "TRNTDLLPDATA17",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDATA18": {
+        "primary": "TRNTDLLPDATA18",
+        "wire": "TRNTDLLPDATA18",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDATA19": {
+        "primary": "TRNTDLLPDATA19",
+        "wire": "TRNTDLLPDATA19",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDATA20": {
+        "primary": "TRNTDLLPDATA20",
+        "wire": "TRNTDLLPDATA20",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDATA21": {
+        "primary": "TRNTDLLPDATA21",
+        "wire": "TRNTDLLPDATA21",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDATA22": {
+        "primary": "TRNTDLLPDATA22",
+        "wire": "TRNTDLLPDATA22",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDATA23": {
+        "primary": "TRNTDLLPDATA23",
+        "wire": "TRNTDLLPDATA23",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDATA24": {
+        "primary": "TRNTDLLPDATA24",
+        "wire": "TRNTDLLPDATA24",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDATA25": {
+        "primary": "TRNTDLLPDATA25",
+        "wire": "TRNTDLLPDATA25",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDATA26": {
+        "primary": "TRNTDLLPDATA26",
+        "wire": "TRNTDLLPDATA26",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDATA27": {
+        "primary": "TRNTDLLPDATA27",
+        "wire": "TRNTDLLPDATA27",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDATA28": {
+        "primary": "TRNTDLLPDATA28",
+        "wire": "TRNTDLLPDATA28",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDATA29": {
+        "primary": "TRNTDLLPDATA29",
+        "wire": "TRNTDLLPDATA29",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDATA30": {
+        "primary": "TRNTDLLPDATA30",
+        "wire": "TRNTDLLPDATA30",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDATA31": {
+        "primary": "TRNTDLLPDATA31",
+        "wire": "TRNTDLLPDATA31",
+        "dir": "INPUT"
+      },
+      "TRNTDLLPDSTRDY": {
+        "primary": "TRNTDLLPDSTRDY",
+        "wire": "TRNTDLLPDSTRDY",
+        "dir": "OUTPUT"
+      },
+      "TRNTDLLPSRCRDY": {
+        "primary": "TRNTDLLPSRCRDY",
+        "wire": "TRNTDLLPSRCRDY",
+        "dir": "INPUT"
+      },
+      "TRNTDSTRDY0": {
+        "primary": "TRNTDSTRDY0",
+        "wire": "TRNTDSTRDY0",
+        "dir": "OUTPUT"
+      },
+      "TRNTDSTRDY1": {
+        "primary": "TRNTDSTRDY1",
+        "wire": "TRNTDSTRDY1",
+        "dir": "OUTPUT"
+      },
+      "TRNTDSTRDY2": {
+        "primary": "TRNTDSTRDY2",
+        "wire": "TRNTDSTRDY2",
+        "dir": "OUTPUT"
+      },
+      "TRNTDSTRDY3": {
+        "primary": "TRNTDSTRDY3",
+        "wire": "TRNTDSTRDY3",
+        "dir": "OUTPUT"
+      },
+      "TRNTECRCGEN": {
+        "primary": "TRNTECRCGEN",
+        "wire": "TRNTECRCGEN",
+        "dir": "INPUT"
+      },
+      "TRNTEOF": {
+        "primary": "TRNTEOF",
+        "wire": "TRNTEOF",
+        "dir": "INPUT"
+      },
+      "TRNTERRDROP": {
+        "primary": "TRNTERRDROP",
+        "wire": "TRNTERRDROP",
+        "dir": "OUTPUT"
+      },
+      "TRNTERRFWD": {
+        "primary": "TRNTERRFWD",
+        "wire": "TRNTERRFWD",
+        "dir": "INPUT"
+      },
+      "TRNTREM0": {
+        "primary": "TRNTREM0",
+        "wire": "TRNTREM0",
+        "dir": "INPUT"
+      },
+      "TRNTREM1": {
+        "primary": "TRNTREM1",
+        "wire": "TRNTREM1",
+        "dir": "INPUT"
+      },
+      "TRNTSOF": {
+        "primary": "TRNTSOF",
+        "wire": "TRNTSOF",
+        "dir": "INPUT"
+      },
+      "TRNTSRCDSC": {
+        "primary": "TRNTSRCDSC",
+        "wire": "TRNTSRCDSC",
+        "dir": "INPUT"
+      },
+      "TRNTSRCRDY": {
+        "primary": "TRNTSRCRDY",
+        "wire": "TRNTSRCRDY",
+        "dir": "INPUT"
+      },
+      "TRNTSTR": {
+        "primary": "TRNTSTR",
+        "wire": "TRNTSTR",
+        "dir": "INPUT"
+      },
+      "USERCLK": {
+        "primary": "USERCLK",
+        "wire": "USERCLK",
+        "dir": "INPUT"
+      },
+      "USERCLK2": {
+        "primary": "USERCLK2",
+        "wire": "USERCLK2",
+        "dir": "INPUT"
+      },
+      "USERCLKPREBUF": {
+        "primary": "USERCLKPREBUF",
+        "wire": "USERCLKPREBUF",
+        "dir": "INPUT"
+      },
+      "USERCLKPREBUFEN": {
+        "primary": "USERCLKPREBUFEN",
+        "wire": "USERCLKPREBUFEN",
+        "dir": "INPUT"
+      },
+      "USERRSTN": {
+        "primary": "USERRSTN",
+        "wire": "USERRSTN",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT0": {
+        "primary": "XILUNCONNOUT0",
+        "wire": "XILUNCONNOUT0",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT1": {
+        "primary": "XILUNCONNOUT1",
+        "wire": "XILUNCONNOUT1",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT2": {
+        "primary": "XILUNCONNOUT2",
+        "wire": "XILUNCONNOUT2",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT3": {
+        "primary": "XILUNCONNOUT3",
+        "wire": "XILUNCONNOUT3",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT4": {
+        "primary": "XILUNCONNOUT4",
+        "wire": "XILUNCONNOUT4",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT5": {
+        "primary": "XILUNCONNOUT5",
+        "wire": "XILUNCONNOUT5",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT6": {
+        "primary": "XILUNCONNOUT6",
+        "wire": "XILUNCONNOUT6",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT7": {
+        "primary": "XILUNCONNOUT7",
+        "wire": "XILUNCONNOUT7",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT8": {
+        "primary": "XILUNCONNOUT8",
+        "wire": "XILUNCONNOUT8",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT9": {
+        "primary": "XILUNCONNOUT9",
+        "wire": "XILUNCONNOUT9",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT10": {
+        "primary": "XILUNCONNOUT10",
+        "wire": "XILUNCONNOUT10",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT11": {
+        "primary": "XILUNCONNOUT11",
+        "wire": "XILUNCONNOUT11",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT12": {
+        "primary": "XILUNCONNOUT12",
+        "wire": "XILUNCONNOUT12",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT13": {
+        "primary": "XILUNCONNOUT13",
+        "wire": "XILUNCONNOUT13",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT14": {
+        "primary": "XILUNCONNOUT14",
+        "wire": "XILUNCONNOUT14",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT15": {
+        "primary": "XILUNCONNOUT15",
+        "wire": "XILUNCONNOUT15",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT16": {
+        "primary": "XILUNCONNOUT16",
+        "wire": "XILUNCONNOUT16",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT17": {
+        "primary": "XILUNCONNOUT17",
+        "wire": "XILUNCONNOUT17",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT18": {
+        "primary": "XILUNCONNOUT18",
+        "wire": "XILUNCONNOUT18",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT19": {
+        "primary": "XILUNCONNOUT19",
+        "wire": "XILUNCONNOUT19",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT20": {
+        "primary": "XILUNCONNOUT20",
+        "wire": "XILUNCONNOUT20",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT21": {
+        "primary": "XILUNCONNOUT21",
+        "wire": "XILUNCONNOUT21",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT22": {
+        "primary": "XILUNCONNOUT22",
+        "wire": "XILUNCONNOUT22",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT23": {
+        "primary": "XILUNCONNOUT23",
+        "wire": "XILUNCONNOUT23",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT24": {
+        "primary": "XILUNCONNOUT24",
+        "wire": "XILUNCONNOUT24",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT25": {
+        "primary": "XILUNCONNOUT25",
+        "wire": "XILUNCONNOUT25",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT26": {
+        "primary": "XILUNCONNOUT26",
+        "wire": "XILUNCONNOUT26",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT27": {
+        "primary": "XILUNCONNOUT27",
+        "wire": "XILUNCONNOUT27",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT28": {
+        "primary": "XILUNCONNOUT28",
+        "wire": "XILUNCONNOUT28",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT29": {
+        "primary": "XILUNCONNOUT29",
+        "wire": "XILUNCONNOUT29",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT30": {
+        "primary": "XILUNCONNOUT30",
+        "wire": "XILUNCONNOUT30",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT31": {
+        "primary": "XILUNCONNOUT31",
+        "wire": "XILUNCONNOUT31",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT32": {
+        "primary": "XILUNCONNOUT32",
+        "wire": "XILUNCONNOUT32",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT33": {
+        "primary": "XILUNCONNOUT33",
+        "wire": "XILUNCONNOUT33",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT34": {
+        "primary": "XILUNCONNOUT34",
+        "wire": "XILUNCONNOUT34",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT35": {
+        "primary": "XILUNCONNOUT35",
+        "wire": "XILUNCONNOUT35",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT36": {
+        "primary": "XILUNCONNOUT36",
+        "wire": "XILUNCONNOUT36",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT37": {
+        "primary": "XILUNCONNOUT37",
+        "wire": "XILUNCONNOUT37",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT38": {
+        "primary": "XILUNCONNOUT38",
+        "wire": "XILUNCONNOUT38",
+        "dir": "OUTPUT"
+      },
+      "XILUNCONNOUT39": {
+        "primary": "XILUNCONNOUT39",
+        "wire": "XILUNCONNOUT39",
+        "dir": "OUTPUT"
+      }
+    }
+  }
+}

--- a/zynq7/site_type_IOB18.json
+++ b/zynq7/site_type_IOB18.json
@@ -1,0 +1,322 @@
+{
+  "IOB18": {
+    "bels": {
+      "INBUF_DCIEN": {
+        "type": "IOB18_INBUF_DCIEN",
+        "class": "BEL",
+        "pins": {
+          "DIFFI_IN": {
+            "dir": "INPUT",
+            "wire": "DIFFI_INUSED_OUT"
+          },
+          "IBUFDISABLE": {
+            "dir": "INPUT",
+            "wire": "IBUFDISABLE_SEL_OUT"
+          },
+          "PAD": {
+            "dir": "INPUT",
+            "wire": "OUTBUF_DCIEN_OUT"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "INBUF_DCIEN_OUT"
+          }
+        }
+      },
+      "OUTBUF_DCIEN": {
+        "type": "IOB18_OUTBUF_DCIEN",
+        "class": "BEL",
+        "pins": {
+          "DCITERMDISABLE": {
+            "dir": "INPUT",
+            "wire": "DCITERMDISABLE_SEL_OUT"
+          },
+          "IN": {
+            "dir": "INPUT",
+            "wire": "OUSED_OUT"
+          },
+          "TRI": {
+            "dir": "INPUT",
+            "wire": "TUSED_OUT"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "OUTBUF_DCIEN_OUT"
+          }
+        }
+      },
+      "TERM_OVERRIDE": {
+        "type": "IOB18_TERM_OVERRIDE",
+        "class": "BEL",
+        "pins": {
+          "DIFF_TERM_EN": {
+            "dir": "INPUT",
+            "wire": "DIFF_TERM_INT_EN"
+          },
+          "KEEPER_EN": {
+            "dir": "INPUT",
+            "wire": "KEEPER_INT_EN"
+          },
+          "PD_EN": {
+            "dir": "INPUT",
+            "wire": "PD_INT_EN"
+          },
+          "PU_EN": {
+            "dir": "INPUT",
+            "wire": "PU_INT_EN"
+          }
+        }
+      },
+      "PAD": {
+        "type": "PAD",
+        "class": "BEL",
+        "pins": {
+          "PAD": {
+            "dir": "BIDIR",
+            "wire": "OUTBUF_DCIEN_OUT"
+          }
+        }
+      },
+      "PULL": {
+        "type": "PULL_OR_KEEP1",
+        "class": "BEL",
+        "pins": {
+          "PAD": {
+            "dir": "BIDIR",
+            "wire": "OUTBUF_DCIEN_OUT"
+          }
+        }
+      },
+      "IBUFDISABLE_GND": {
+        "type": "HARD0",
+        "class": "BEL",
+        "pins": {
+          "0": {
+            "dir": "OUTPUT",
+            "wire": "IBUFDISABLE_GND_HARD0"
+          }
+        }
+      },
+      "DCITERMDISABLE_GND": {
+        "type": "HARD0",
+        "class": "BEL",
+        "pins": {
+          "0": {
+            "dir": "OUTPUT",
+            "wire": "DCITERMDISABLE_GND_HARD0"
+          }
+        }
+      },
+      "IUSED": {
+        "type": "IOB18_IUSED",
+        "class": "RBEL",
+        "pins": {
+          "0": {
+            "dir": "INPUT",
+            "wire": "INBUF_DCIEN_OUT"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "I"
+          }
+        }
+      },
+      "DIFFI_INUSED": {
+        "type": "IOB18_DIFFI_INUSED",
+        "class": "RBEL",
+        "pins": {
+          "0": {
+            "dir": "INPUT",
+            "wire": "DIFFI_IN"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "DIFFI_INUSED_OUT"
+          }
+        }
+      },
+      "TUSED": {
+        "type": "IOB18_TUSED",
+        "class": "RBEL",
+        "pins": {
+          "0": {
+            "dir": "INPUT",
+            "wire": "T"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "TUSED_OUT"
+          }
+        }
+      },
+      "OUSED": {
+        "type": "IOB18_OUSED",
+        "class": "RBEL",
+        "pins": {
+          "0": {
+            "dir": "INPUT",
+            "wire": "O"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "OUSED_OUT"
+          }
+        }
+      },
+      "IBUFDISABLE_SEL": {
+        "type": "IOB18_IBUFDISABLE_SEL",
+        "class": "RBEL",
+        "pins": {
+          "GND": {
+            "dir": "INPUT",
+            "wire": "IBUFDISABLE_GND_HARD0"
+          },
+          "I": {
+            "dir": "INPUT",
+            "wire": "IBUFDISABLE"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "IBUFDISABLE_SEL_OUT"
+          }
+        }
+      },
+      "DCITERMDISABLE_SEL": {
+        "type": "IOB18_DCITERMDISABLE_SEL",
+        "class": "RBEL",
+        "pins": {
+          "GND": {
+            "dir": "INPUT",
+            "wire": "DCITERMDISABLE_GND_HARD0"
+          },
+          "I": {
+            "dir": "INPUT",
+            "wire": "DCITERMDISABLE"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "DCITERMDISABLE_SEL_OUT"
+          }
+        }
+      },
+      "PADOUTUSED": {
+        "type": "NULLMUX",
+        "class": "RBEL",
+        "pins": {
+          "0": {
+            "dir": "INPUT",
+            "wire": "OUTBUF_DCIEN_OUT"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "PADOUT"
+          }
+        }
+      }
+    },
+    "pips": [
+      {
+        "bel": "IUSED",
+        "from_pin": "0",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "DIFFI_INUSED",
+        "from_pin": "0",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "TUSED",
+        "from_pin": "0",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "OUSED",
+        "from_pin": "0",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "IBUFDISABLE_SEL",
+        "from_pin": "GND",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "IBUFDISABLE_SEL",
+        "from_pin": "I",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "DCITERMDISABLE_SEL",
+        "from_pin": "GND",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "DCITERMDISABLE_SEL",
+        "from_pin": "I",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "PADOUTUSED",
+        "from_pin": "0",
+        "to_pin": "OUT"
+      }
+    ],
+    "pins": {
+      "DIFF_TERM_INT_EN": {
+        "primary": "DIFF_TERM_INT_EN",
+        "wire": "DIFF_TERM_INT_EN",
+        "dir": "INPUT"
+      },
+      "KEEPER_INT_EN": {
+        "primary": "KEEPER_INT_EN",
+        "wire": "KEEPER_INT_EN",
+        "dir": "INPUT"
+      },
+      "PD_INT_EN": {
+        "primary": "PD_INT_EN",
+        "wire": "PD_INT_EN",
+        "dir": "INPUT"
+      },
+      "PU_INT_EN": {
+        "primary": "PU_INT_EN",
+        "wire": "PU_INT_EN",
+        "dir": "INPUT"
+      },
+      "I": {
+        "primary": "I",
+        "wire": "I",
+        "dir": "OUTPUT"
+      },
+      "DIFFI_IN": {
+        "primary": "DIFFI_IN",
+        "wire": "DIFFI_IN",
+        "dir": "INPUT"
+      },
+      "T": {
+        "primary": "T",
+        "wire": "T",
+        "dir": "INPUT"
+      },
+      "O": {
+        "primary": "O",
+        "wire": "O",
+        "dir": "INPUT"
+      },
+      "IBUFDISABLE": {
+        "primary": "IBUFDISABLE",
+        "wire": "IBUFDISABLE",
+        "dir": "INPUT"
+      },
+      "DCITERMDISABLE": {
+        "primary": "DCITERMDISABLE",
+        "wire": "DCITERMDISABLE",
+        "dir": "INPUT"
+      },
+      "PADOUT": {
+        "primary": "PADOUT",
+        "wire": "PADOUT",
+        "dir": "OUTPUT"
+      }
+    }
+  }
+}

--- a/zynq7/site_type_IOB18M.json
+++ b/zynq7/site_type_IOB18M.json
@@ -1,0 +1,718 @@
+{
+  "IOB18M": {
+    "bels": {
+      "INBUF_DCIEN": {
+        "type": "IOB18M_INBUF_DCIEN",
+        "class": "BEL",
+        "pins": {
+          "DIFFI_IN": {
+            "dir": "INPUT",
+            "wire": "DIFFI_INUSED_OUT"
+          },
+          "IBUFDISABLE": {
+            "dir": "INPUT",
+            "wire": "IBUFDISABLE_SEL_OUT"
+          },
+          "PAD": {
+            "dir": "INPUT",
+            "wire": "OUTBUF_DCIEN_OUT"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "INBUF_DCIEN_OUT"
+          }
+        }
+      },
+      "OUTBUF_DCIEN": {
+        "type": "IOB18M_OUTBUF_DCIEN",
+        "class": "BEL",
+        "pins": {
+          "DCITERMDISABLE": {
+            "dir": "INPUT",
+            "wire": "DCITERMDISABLE_SEL_OUT"
+          },
+          "IN": {
+            "dir": "INPUT",
+            "wire": "OUSED_OUT"
+          },
+          "TRI": {
+            "dir": "INPUT",
+            "wire": "TUSED_OUT"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "OUTBUF_DCIEN_OUT"
+          },
+          "OUTN": {
+            "dir": "OUTPUT",
+            "wire": "OUTBUF_DCIEN_OUTN"
+          }
+        }
+      },
+      "TERM_OVERRIDE": {
+        "type": "IOB18M_TERM_OVERRIDE",
+        "class": "BEL",
+        "pins": {
+          "DIFF_TERM_EN": {
+            "dir": "INPUT",
+            "wire": "DIFF_TERM_INT_EN"
+          },
+          "KEEPER_EN": {
+            "dir": "INPUT",
+            "wire": "KEEPER_INT_EN"
+          },
+          "PD_EN": {
+            "dir": "INPUT",
+            "wire": "PD_INT_EN"
+          },
+          "PU_EN": {
+            "dir": "INPUT",
+            "wire": "PU_INT_EN"
+          }
+        }
+      },
+      "PAD": {
+        "type": "PAD",
+        "class": "BEL",
+        "pins": {
+          "PAD": {
+            "dir": "BIDIR",
+            "wire": "OUTBUF_DCIEN_OUT"
+          }
+        }
+      },
+      "PULL": {
+        "type": "PULL_OR_KEEP1",
+        "class": "BEL",
+        "pins": {
+          "PAD": {
+            "dir": "BIDIR",
+            "wire": "OUTBUF_DCIEN_OUT"
+          }
+        }
+      },
+      "IBUFDISABLE_GND": {
+        "type": "HARD0",
+        "class": "BEL",
+        "pins": {
+          "0": {
+            "dir": "OUTPUT",
+            "wire": "IBUFDISABLE_GND_HARD0"
+          }
+        }
+      },
+      "DCITERMDISABLE_GND": {
+        "type": "HARD0",
+        "class": "BEL",
+        "pins": {
+          "0": {
+            "dir": "OUTPUT",
+            "wire": "DCITERMDISABLE_GND_HARD0"
+          }
+        }
+      },
+      "IUSED": {
+        "type": "IOB18M_IUSED",
+        "class": "RBEL",
+        "pins": {
+          "0": {
+            "dir": "INPUT",
+            "wire": "INBUF_DCIEN_OUT"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "I"
+          }
+        }
+      },
+      "DIFFI_INUSED": {
+        "type": "IOB18M_DIFFI_INUSED",
+        "class": "RBEL",
+        "pins": {
+          "0": {
+            "dir": "INPUT",
+            "wire": "DIFFI_IN"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "DIFFI_INUSED_OUT"
+          }
+        }
+      },
+      "TUSED": {
+        "type": "IOB18M_TUSED",
+        "class": "RBEL",
+        "pins": {
+          "0": {
+            "dir": "INPUT",
+            "wire": "T"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "TUSED_OUT"
+          }
+        }
+      },
+      "OUSED": {
+        "type": "IOB18M_OUSED",
+        "class": "RBEL",
+        "pins": {
+          "0": {
+            "dir": "INPUT",
+            "wire": "O"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "OUSED_OUT"
+          }
+        }
+      },
+      "DIFFO_OUTUSED": {
+        "type": "IOB18M_DIFFO_OUTUSED",
+        "class": "RBEL",
+        "pins": {
+          "0": {
+            "dir": "INPUT",
+            "wire": "OUTBUF_DCIEN_OUTN"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "DIFFO_OUT"
+          }
+        }
+      },
+      "O_OUTUSED": {
+        "type": "IOB18M_O_OUTUSED",
+        "class": "RBEL",
+        "pins": {
+          "0": {
+            "dir": "INPUT",
+            "wire": "O"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "O_OUT"
+          }
+        }
+      },
+      "T_OUTUSED": {
+        "type": "IOB18M_T_OUTUSED",
+        "class": "RBEL",
+        "pins": {
+          "0": {
+            "dir": "INPUT",
+            "wire": "T"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "T_OUT"
+          }
+        }
+      },
+      "IBUFDISABLE_SEL": {
+        "type": "IOB18M_IBUFDISABLE_SEL",
+        "class": "RBEL",
+        "pins": {
+          "GND": {
+            "dir": "INPUT",
+            "wire": "IBUFDISABLE_GND_HARD0"
+          },
+          "I": {
+            "dir": "INPUT",
+            "wire": "IBUFDISABLE"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "IBUFDISABLE_SEL_OUT"
+          }
+        }
+      },
+      "DCITERMDISABLE_SEL": {
+        "type": "IOB18M_DCITERMDISABLE_SEL",
+        "class": "RBEL",
+        "pins": {
+          "GND": {
+            "dir": "INPUT",
+            "wire": "DCITERMDISABLE_GND_HARD0"
+          },
+          "I": {
+            "dir": "INPUT",
+            "wire": "DCITERMDISABLE"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "DCITERMDISABLE_SEL_OUT"
+          }
+        }
+      },
+      "PADOUTUSED": {
+        "type": "NULLMUX",
+        "class": "RBEL",
+        "pins": {
+          "0": {
+            "dir": "INPUT",
+            "wire": "OUTBUF_DCIEN_OUT"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "PADOUT"
+          }
+        }
+      }
+    },
+    "pips": [
+      {
+        "bel": "IUSED",
+        "from_pin": "0",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "DIFFI_INUSED",
+        "from_pin": "0",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "TUSED",
+        "from_pin": "0",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "OUSED",
+        "from_pin": "0",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "DIFFO_OUTUSED",
+        "from_pin": "0",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "O_OUTUSED",
+        "from_pin": "0",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "T_OUTUSED",
+        "from_pin": "0",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "IBUFDISABLE_SEL",
+        "from_pin": "GND",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "IBUFDISABLE_SEL",
+        "from_pin": "I",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "DCITERMDISABLE_SEL",
+        "from_pin": "GND",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "DCITERMDISABLE_SEL",
+        "from_pin": "I",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "PADOUTUSED",
+        "from_pin": "0",
+        "to_pin": "OUT"
+      }
+    ],
+    "pins": {
+      "DIFF_TERM_INT_EN": {
+        "primary": "DIFF_TERM_INT_EN",
+        "wire": "DIFF_TERM_INT_EN",
+        "dir": "INPUT"
+      },
+      "KEEPER_INT_EN": {
+        "primary": "KEEPER_INT_EN",
+        "wire": "KEEPER_INT_EN",
+        "dir": "INPUT"
+      },
+      "PD_INT_EN": {
+        "primary": "PD_INT_EN",
+        "wire": "PD_INT_EN",
+        "dir": "INPUT"
+      },
+      "PU_INT_EN": {
+        "primary": "PU_INT_EN",
+        "wire": "PU_INT_EN",
+        "dir": "INPUT"
+      },
+      "I": {
+        "primary": "I",
+        "wire": "I",
+        "dir": "OUTPUT"
+      },
+      "DIFFI_IN": {
+        "primary": "DIFFI_IN",
+        "wire": "DIFFI_IN",
+        "dir": "INPUT"
+      },
+      "T": {
+        "primary": "T",
+        "wire": "T",
+        "dir": "INPUT"
+      },
+      "O": {
+        "primary": "O",
+        "wire": "O",
+        "dir": "INPUT"
+      },
+      "DIFFO_OUT": {
+        "primary": "DIFFO_OUT",
+        "wire": "DIFFO_OUT",
+        "dir": "OUTPUT"
+      },
+      "O_OUT": {
+        "primary": "O_OUT",
+        "wire": "O_OUT",
+        "dir": "OUTPUT"
+      },
+      "T_OUT": {
+        "primary": "T_OUT",
+        "wire": "T_OUT",
+        "dir": "OUTPUT"
+      },
+      "IBUFDISABLE": {
+        "primary": "IBUFDISABLE",
+        "wire": "IBUFDISABLE",
+        "dir": "INPUT"
+      },
+      "DCITERMDISABLE": {
+        "primary": "DCITERMDISABLE",
+        "wire": "DCITERMDISABLE",
+        "dir": "INPUT"
+      },
+      "PADOUT": {
+        "primary": "PADOUT",
+        "wire": "PADOUT",
+        "dir": "OUTPUT"
+      }
+    }
+  },
+  "IOB18": {
+    "bels": {
+      "INBUF_DCIEN": {
+        "type": "IOB18_INBUF_DCIEN",
+        "class": "BEL",
+        "pins": {
+          "DIFFI_IN": {
+            "dir": "INPUT",
+            "wire": "DIFFI_INUSED_OUT"
+          },
+          "IBUFDISABLE": {
+            "dir": "INPUT",
+            "wire": "IBUFDISABLE_SEL_OUT"
+          },
+          "PAD": {
+            "dir": "INPUT",
+            "wire": "OUTBUF_DCIEN_OUT"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "INBUF_DCIEN_OUT"
+          }
+        }
+      },
+      "OUTBUF_DCIEN": {
+        "type": "IOB18_OUTBUF_DCIEN",
+        "class": "BEL",
+        "pins": {
+          "DCITERMDISABLE": {
+            "dir": "INPUT",
+            "wire": "DCITERMDISABLE_SEL_OUT"
+          },
+          "IN": {
+            "dir": "INPUT",
+            "wire": "OUSED_OUT"
+          },
+          "TRI": {
+            "dir": "INPUT",
+            "wire": "TUSED_OUT"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "OUTBUF_DCIEN_OUT"
+          }
+        }
+      },
+      "TERM_OVERRIDE": {
+        "type": "IOB18_TERM_OVERRIDE",
+        "class": "BEL",
+        "pins": {
+          "DIFF_TERM_EN": {
+            "dir": "INPUT",
+            "wire": "DIFF_TERM_INT_EN"
+          },
+          "KEEPER_EN": {
+            "dir": "INPUT",
+            "wire": "KEEPER_INT_EN"
+          },
+          "PD_EN": {
+            "dir": "INPUT",
+            "wire": "PD_INT_EN"
+          },
+          "PU_EN": {
+            "dir": "INPUT",
+            "wire": "PU_INT_EN"
+          }
+        }
+      },
+      "PAD": {
+        "type": "PAD",
+        "class": "BEL",
+        "pins": {
+          "PAD": {
+            "dir": "BIDIR",
+            "wire": "OUTBUF_DCIEN_OUT"
+          }
+        }
+      },
+      "PULL": {
+        "type": "PULL_OR_KEEP1",
+        "class": "BEL",
+        "pins": {
+          "PAD": {
+            "dir": "BIDIR",
+            "wire": "OUTBUF_DCIEN_OUT"
+          }
+        }
+      },
+      "IBUFDISABLE_GND": {
+        "type": "HARD0",
+        "class": "BEL",
+        "pins": {
+          "0": {
+            "dir": "OUTPUT",
+            "wire": "IBUFDISABLE_GND_HARD0"
+          }
+        }
+      },
+      "DCITERMDISABLE_GND": {
+        "type": "HARD0",
+        "class": "BEL",
+        "pins": {
+          "0": {
+            "dir": "OUTPUT",
+            "wire": "DCITERMDISABLE_GND_HARD0"
+          }
+        }
+      },
+      "IUSED": {
+        "type": "IOB18_IUSED",
+        "class": "RBEL",
+        "pins": {
+          "0": {
+            "dir": "INPUT",
+            "wire": "INBUF_DCIEN_OUT"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "I"
+          }
+        }
+      },
+      "DIFFI_INUSED": {
+        "type": "IOB18_DIFFI_INUSED",
+        "class": "RBEL",
+        "pins": {
+          "0": {
+            "dir": "INPUT",
+            "wire": "DIFFI_IN"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "DIFFI_INUSED_OUT"
+          }
+        }
+      },
+      "TUSED": {
+        "type": "IOB18_TUSED",
+        "class": "RBEL",
+        "pins": {
+          "0": {
+            "dir": "INPUT",
+            "wire": "T"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "TUSED_OUT"
+          }
+        }
+      },
+      "OUSED": {
+        "type": "IOB18_OUSED",
+        "class": "RBEL",
+        "pins": {
+          "0": {
+            "dir": "INPUT",
+            "wire": "O"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "OUSED_OUT"
+          }
+        }
+      },
+      "IBUFDISABLE_SEL": {
+        "type": "IOB18_IBUFDISABLE_SEL",
+        "class": "RBEL",
+        "pins": {
+          "GND": {
+            "dir": "INPUT",
+            "wire": "IBUFDISABLE_GND_HARD0"
+          },
+          "I": {
+            "dir": "INPUT",
+            "wire": "IBUFDISABLE"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "IBUFDISABLE_SEL_OUT"
+          }
+        }
+      },
+      "DCITERMDISABLE_SEL": {
+        "type": "IOB18_DCITERMDISABLE_SEL",
+        "class": "RBEL",
+        "pins": {
+          "GND": {
+            "dir": "INPUT",
+            "wire": "DCITERMDISABLE_GND_HARD0"
+          },
+          "I": {
+            "dir": "INPUT",
+            "wire": "DCITERMDISABLE"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "DCITERMDISABLE_SEL_OUT"
+          }
+        }
+      },
+      "PADOUTUSED": {
+        "type": "NULLMUX",
+        "class": "RBEL",
+        "pins": {
+          "0": {
+            "dir": "INPUT",
+            "wire": "OUTBUF_DCIEN_OUT"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "PADOUT"
+          }
+        }
+      }
+    },
+    "pips": [
+      {
+        "bel": "IUSED",
+        "from_pin": "0",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "DIFFI_INUSED",
+        "from_pin": "0",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "TUSED",
+        "from_pin": "0",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "OUSED",
+        "from_pin": "0",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "IBUFDISABLE_SEL",
+        "from_pin": "GND",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "IBUFDISABLE_SEL",
+        "from_pin": "I",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "DCITERMDISABLE_SEL",
+        "from_pin": "GND",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "DCITERMDISABLE_SEL",
+        "from_pin": "I",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "PADOUTUSED",
+        "from_pin": "0",
+        "to_pin": "OUT"
+      }
+    ],
+    "pins": {
+      "DIFF_TERM_INT_EN": {
+        "primary": "DIFF_TERM_INT_EN",
+        "wire": "DIFF_TERM_INT_EN",
+        "dir": "INPUT"
+      },
+      "KEEPER_INT_EN": {
+        "primary": "KEEPER_INT_EN",
+        "wire": "KEEPER_INT_EN",
+        "dir": "INPUT"
+      },
+      "PD_INT_EN": {
+        "primary": "PD_INT_EN",
+        "wire": "PD_INT_EN",
+        "dir": "INPUT"
+      },
+      "PU_INT_EN": {
+        "primary": "PU_INT_EN",
+        "wire": "PU_INT_EN",
+        "dir": "INPUT"
+      },
+      "I": {
+        "primary": "I",
+        "wire": "I",
+        "dir": "OUTPUT"
+      },
+      "DIFFI_IN": {
+        "primary": "DIFFI_IN",
+        "wire": "DIFFI_IN",
+        "dir": "INPUT"
+      },
+      "T": {
+        "primary": "T",
+        "wire": "T",
+        "dir": "INPUT"
+      },
+      "O": {
+        "primary": "O",
+        "wire": "O",
+        "dir": "INPUT"
+      },
+      "IBUFDISABLE": {
+        "primary": "IBUFDISABLE",
+        "wire": "IBUFDISABLE",
+        "dir": "INPUT"
+      },
+      "DCITERMDISABLE": {
+        "primary": "DCITERMDISABLE",
+        "wire": "DCITERMDISABLE",
+        "dir": "INPUT"
+      },
+      "PADOUT": {
+        "primary": "PADOUT",
+        "wire": "PADOUT",
+        "dir": "OUTPUT"
+      }
+    }
+  }
+}

--- a/zynq7/site_type_IOB18S.json
+++ b/zynq7/site_type_IOB18S.json
@@ -1,0 +1,736 @@
+{
+  "IOB18S": {
+    "bels": {
+      "INBUF_DCIEN": {
+        "type": "IOB18S_INBUF_DCIEN",
+        "class": "BEL",
+        "pins": {
+          "DIFFI_IN": {
+            "dir": "INPUT",
+            "wire": "DIFFI_INUSED_OUT"
+          },
+          "IBUFDISABLE": {
+            "dir": "INPUT",
+            "wire": "IBUFDISABLE_SEL_OUT"
+          },
+          "PAD": {
+            "dir": "INPUT",
+            "wire": "OUTMUX_OUT"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "INBUF_DCIEN_OUT"
+          }
+        }
+      },
+      "OUTBUF_DCIEN": {
+        "type": "IOB18S_OUTBUF_DCIEN",
+        "class": "BEL",
+        "pins": {
+          "DCITERMDISABLE": {
+            "dir": "INPUT",
+            "wire": "DCITERMDISABLE_SEL_OUT"
+          },
+          "IN": {
+            "dir": "INPUT",
+            "wire": "OINMUX_OUT"
+          },
+          "TRI": {
+            "dir": "INPUT",
+            "wire": "TINMUX_OUT"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "OUTBUF_DCIEN_OUT"
+          }
+        }
+      },
+      "TERM_OVERRIDE": {
+        "type": "IOB18S_TERM_OVERRIDE",
+        "class": "BEL",
+        "pins": {
+          "DIFF_TERM_EN": {
+            "dir": "INPUT",
+            "wire": "DIFF_TERM_INT_EN"
+          },
+          "KEEPER_EN": {
+            "dir": "INPUT",
+            "wire": "KEEPER_INT_EN"
+          },
+          "PD_EN": {
+            "dir": "INPUT",
+            "wire": "PD_INT_EN"
+          },
+          "PU_EN": {
+            "dir": "INPUT",
+            "wire": "PU_INT_EN"
+          }
+        }
+      },
+      "O_ININV": {
+        "type": "INVERTER",
+        "class": "BEL",
+        "pins": {
+          "IN": {
+            "dir": "INPUT",
+            "wire": "O_IN"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "O_ININV_OUT"
+          }
+        }
+      },
+      "PAD": {
+        "type": "PAD",
+        "class": "BEL",
+        "pins": {
+          "PAD": {
+            "dir": "BIDIR",
+            "wire": "OUTMUX_OUT"
+          }
+        }
+      },
+      "PULL": {
+        "type": "PULL_OR_KEEP1",
+        "class": "BEL",
+        "pins": {
+          "PAD": {
+            "dir": "BIDIR",
+            "wire": "OUTMUX_OUT"
+          }
+        }
+      },
+      "IBUFDISABLE_GND": {
+        "type": "HARD0",
+        "class": "BEL",
+        "pins": {
+          "0": {
+            "dir": "OUTPUT",
+            "wire": "IBUFDISABLE_GND_HARD0"
+          }
+        }
+      },
+      "DCITERMDISABLE_GND": {
+        "type": "HARD0",
+        "class": "BEL",
+        "pins": {
+          "0": {
+            "dir": "OUTPUT",
+            "wire": "DCITERMDISABLE_GND_HARD0"
+          }
+        }
+      },
+      "IUSED": {
+        "type": "IOB18S_IUSED",
+        "class": "RBEL",
+        "pins": {
+          "0": {
+            "dir": "INPUT",
+            "wire": "INBUF_DCIEN_OUT"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "I"
+          }
+        }
+      },
+      "DIFFI_INUSED": {
+        "type": "IOB18S_DIFFI_INUSED",
+        "class": "RBEL",
+        "pins": {
+          "0": {
+            "dir": "INPUT",
+            "wire": "DIFFI_IN"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "DIFFI_INUSED_OUT"
+          }
+        }
+      },
+      "TINMUX": {
+        "type": "IOB18S_TINMUX",
+        "class": "RBEL",
+        "pins": {
+          "0": {
+            "dir": "INPUT",
+            "wire": "T"
+          },
+          "1": {
+            "dir": "INPUT",
+            "wire": "T_IN"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "TINMUX_OUT"
+          }
+        }
+      },
+      "OINMUX": {
+        "type": "IOB18S_OINMUX",
+        "class": "RBEL",
+        "pins": {
+          "0": {
+            "dir": "INPUT",
+            "wire": "O"
+          },
+          "1": {
+            "dir": "INPUT",
+            "wire": "O_ININV_OUT"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "OINMUX_OUT"
+          }
+        }
+      },
+      "OUTMUX": {
+        "type": "IOB18S_OUTMUX",
+        "class": "RBEL",
+        "pins": {
+          "0": {
+            "dir": "INPUT",
+            "wire": "OUTBUF_DCIEN_OUT"
+          },
+          "1": {
+            "dir": "INPUT",
+            "wire": "DIFFO_INUSED_OUT"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "OUTMUX_OUT"
+          }
+        }
+      },
+      "DIFFO_INUSED": {
+        "type": "IOB18S_DIFFO_INUSED",
+        "class": "RBEL",
+        "pins": {
+          "0": {
+            "dir": "INPUT",
+            "wire": "DIFFO_IN"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "DIFFO_INUSED_OUT"
+          }
+        }
+      },
+      "IBUFDISABLE_SEL": {
+        "type": "IOB18S_IBUFDISABLE_SEL",
+        "class": "RBEL",
+        "pins": {
+          "GND": {
+            "dir": "INPUT",
+            "wire": "IBUFDISABLE_GND_HARD0"
+          },
+          "I": {
+            "dir": "INPUT",
+            "wire": "IBUFDISABLE"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "IBUFDISABLE_SEL_OUT"
+          }
+        }
+      },
+      "DCITERMDISABLE_SEL": {
+        "type": "IOB18S_DCITERMDISABLE_SEL",
+        "class": "RBEL",
+        "pins": {
+          "GND": {
+            "dir": "INPUT",
+            "wire": "DCITERMDISABLE_GND_HARD0"
+          },
+          "I": {
+            "dir": "INPUT",
+            "wire": "DCITERMDISABLE"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "DCITERMDISABLE_SEL_OUT"
+          }
+        }
+      },
+      "PADOUTUSED": {
+        "type": "NULLMUX",
+        "class": "RBEL",
+        "pins": {
+          "0": {
+            "dir": "INPUT",
+            "wire": "OUTMUX_OUT"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "PADOUT"
+          }
+        }
+      }
+    },
+    "pips": [
+      {
+        "bel": "IUSED",
+        "from_pin": "0",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "DIFFI_INUSED",
+        "from_pin": "0",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "TINMUX",
+        "from_pin": "0",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "TINMUX",
+        "from_pin": "1",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "OINMUX",
+        "from_pin": "0",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "OINMUX",
+        "from_pin": "1",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "OUTMUX",
+        "from_pin": "0",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "OUTMUX",
+        "from_pin": "1",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "DIFFO_INUSED",
+        "from_pin": "0",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "IBUFDISABLE_SEL",
+        "from_pin": "GND",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "IBUFDISABLE_SEL",
+        "from_pin": "I",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "DCITERMDISABLE_SEL",
+        "from_pin": "GND",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "DCITERMDISABLE_SEL",
+        "from_pin": "I",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "PADOUTUSED",
+        "from_pin": "0",
+        "to_pin": "OUT"
+      }
+    ],
+    "pins": {
+      "DIFF_TERM_INT_EN": {
+        "primary": "DIFF_TERM_INT_EN",
+        "wire": "DIFF_TERM_INT_EN",
+        "dir": "INPUT"
+      },
+      "KEEPER_INT_EN": {
+        "primary": "KEEPER_INT_EN",
+        "wire": "KEEPER_INT_EN",
+        "dir": "INPUT"
+      },
+      "PD_INT_EN": {
+        "primary": "PD_INT_EN",
+        "wire": "PD_INT_EN",
+        "dir": "INPUT"
+      },
+      "PU_INT_EN": {
+        "primary": "PU_INT_EN",
+        "wire": "PU_INT_EN",
+        "dir": "INPUT"
+      },
+      "O_IN": {
+        "primary": "O_IN",
+        "wire": "O_IN",
+        "dir": "INPUT"
+      },
+      "I": {
+        "primary": "I",
+        "wire": "I",
+        "dir": "OUTPUT"
+      },
+      "DIFFI_IN": {
+        "primary": "DIFFI_IN",
+        "wire": "DIFFI_IN",
+        "dir": "INPUT"
+      },
+      "T": {
+        "primary": "T",
+        "wire": "T",
+        "dir": "INPUT"
+      },
+      "T_IN": {
+        "primary": "T_IN",
+        "wire": "T_IN",
+        "dir": "INPUT"
+      },
+      "O": {
+        "primary": "O",
+        "wire": "O",
+        "dir": "INPUT"
+      },
+      "DIFFO_IN": {
+        "primary": "DIFFO_IN",
+        "wire": "DIFFO_IN",
+        "dir": "INPUT"
+      },
+      "IBUFDISABLE": {
+        "primary": "IBUFDISABLE",
+        "wire": "IBUFDISABLE",
+        "dir": "INPUT"
+      },
+      "DCITERMDISABLE": {
+        "primary": "DCITERMDISABLE",
+        "wire": "DCITERMDISABLE",
+        "dir": "INPUT"
+      },
+      "PADOUT": {
+        "primary": "PADOUT",
+        "wire": "PADOUT",
+        "dir": "OUTPUT"
+      }
+    }
+  },
+  "IOB18": {
+    "bels": {
+      "INBUF_DCIEN": {
+        "type": "IOB18_INBUF_DCIEN",
+        "class": "BEL",
+        "pins": {
+          "DIFFI_IN": {
+            "dir": "INPUT",
+            "wire": "DIFFI_INUSED_OUT"
+          },
+          "IBUFDISABLE": {
+            "dir": "INPUT",
+            "wire": "IBUFDISABLE_SEL_OUT"
+          },
+          "PAD": {
+            "dir": "INPUT",
+            "wire": "OUTBUF_DCIEN_OUT"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "INBUF_DCIEN_OUT"
+          }
+        }
+      },
+      "OUTBUF_DCIEN": {
+        "type": "IOB18_OUTBUF_DCIEN",
+        "class": "BEL",
+        "pins": {
+          "DCITERMDISABLE": {
+            "dir": "INPUT",
+            "wire": "DCITERMDISABLE_SEL_OUT"
+          },
+          "IN": {
+            "dir": "INPUT",
+            "wire": "OUSED_OUT"
+          },
+          "TRI": {
+            "dir": "INPUT",
+            "wire": "TUSED_OUT"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "OUTBUF_DCIEN_OUT"
+          }
+        }
+      },
+      "TERM_OVERRIDE": {
+        "type": "IOB18_TERM_OVERRIDE",
+        "class": "BEL",
+        "pins": {
+          "DIFF_TERM_EN": {
+            "dir": "INPUT",
+            "wire": "DIFF_TERM_INT_EN"
+          },
+          "KEEPER_EN": {
+            "dir": "INPUT",
+            "wire": "KEEPER_INT_EN"
+          },
+          "PD_EN": {
+            "dir": "INPUT",
+            "wire": "PD_INT_EN"
+          },
+          "PU_EN": {
+            "dir": "INPUT",
+            "wire": "PU_INT_EN"
+          }
+        }
+      },
+      "PAD": {
+        "type": "PAD",
+        "class": "BEL",
+        "pins": {
+          "PAD": {
+            "dir": "BIDIR",
+            "wire": "OUTBUF_DCIEN_OUT"
+          }
+        }
+      },
+      "PULL": {
+        "type": "PULL_OR_KEEP1",
+        "class": "BEL",
+        "pins": {
+          "PAD": {
+            "dir": "BIDIR",
+            "wire": "OUTBUF_DCIEN_OUT"
+          }
+        }
+      },
+      "IBUFDISABLE_GND": {
+        "type": "HARD0",
+        "class": "BEL",
+        "pins": {
+          "0": {
+            "dir": "OUTPUT",
+            "wire": "IBUFDISABLE_GND_HARD0"
+          }
+        }
+      },
+      "DCITERMDISABLE_GND": {
+        "type": "HARD0",
+        "class": "BEL",
+        "pins": {
+          "0": {
+            "dir": "OUTPUT",
+            "wire": "DCITERMDISABLE_GND_HARD0"
+          }
+        }
+      },
+      "IUSED": {
+        "type": "IOB18_IUSED",
+        "class": "RBEL",
+        "pins": {
+          "0": {
+            "dir": "INPUT",
+            "wire": "INBUF_DCIEN_OUT"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "I"
+          }
+        }
+      },
+      "DIFFI_INUSED": {
+        "type": "IOB18_DIFFI_INUSED",
+        "class": "RBEL",
+        "pins": {
+          "0": {
+            "dir": "INPUT",
+            "wire": "DIFFI_IN"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "DIFFI_INUSED_OUT"
+          }
+        }
+      },
+      "TUSED": {
+        "type": "IOB18_TUSED",
+        "class": "RBEL",
+        "pins": {
+          "0": {
+            "dir": "INPUT",
+            "wire": "T"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "TUSED_OUT"
+          }
+        }
+      },
+      "OUSED": {
+        "type": "IOB18_OUSED",
+        "class": "RBEL",
+        "pins": {
+          "0": {
+            "dir": "INPUT",
+            "wire": "O"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "OUSED_OUT"
+          }
+        }
+      },
+      "IBUFDISABLE_SEL": {
+        "type": "IOB18_IBUFDISABLE_SEL",
+        "class": "RBEL",
+        "pins": {
+          "GND": {
+            "dir": "INPUT",
+            "wire": "IBUFDISABLE_GND_HARD0"
+          },
+          "I": {
+            "dir": "INPUT",
+            "wire": "IBUFDISABLE"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "IBUFDISABLE_SEL_OUT"
+          }
+        }
+      },
+      "DCITERMDISABLE_SEL": {
+        "type": "IOB18_DCITERMDISABLE_SEL",
+        "class": "RBEL",
+        "pins": {
+          "GND": {
+            "dir": "INPUT",
+            "wire": "DCITERMDISABLE_GND_HARD0"
+          },
+          "I": {
+            "dir": "INPUT",
+            "wire": "DCITERMDISABLE"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "DCITERMDISABLE_SEL_OUT"
+          }
+        }
+      },
+      "PADOUTUSED": {
+        "type": "NULLMUX",
+        "class": "RBEL",
+        "pins": {
+          "0": {
+            "dir": "INPUT",
+            "wire": "OUTBUF_DCIEN_OUT"
+          },
+          "OUT": {
+            "dir": "OUTPUT",
+            "wire": "PADOUT"
+          }
+        }
+      }
+    },
+    "pips": [
+      {
+        "bel": "IUSED",
+        "from_pin": "0",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "DIFFI_INUSED",
+        "from_pin": "0",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "TUSED",
+        "from_pin": "0",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "OUSED",
+        "from_pin": "0",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "IBUFDISABLE_SEL",
+        "from_pin": "GND",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "IBUFDISABLE_SEL",
+        "from_pin": "I",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "DCITERMDISABLE_SEL",
+        "from_pin": "GND",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "DCITERMDISABLE_SEL",
+        "from_pin": "I",
+        "to_pin": "OUT"
+      },
+      {
+        "bel": "PADOUTUSED",
+        "from_pin": "0",
+        "to_pin": "OUT"
+      }
+    ],
+    "pins": {
+      "DIFF_TERM_INT_EN": {
+        "primary": "DIFF_TERM_INT_EN",
+        "wire": "DIFF_TERM_INT_EN",
+        "dir": "INPUT"
+      },
+      "KEEPER_INT_EN": {
+        "primary": "KEEPER_INT_EN",
+        "wire": "KEEPER_INT_EN",
+        "dir": "INPUT"
+      },
+      "PD_INT_EN": {
+        "primary": "PD_INT_EN",
+        "wire": "PD_INT_EN",
+        "dir": "INPUT"
+      },
+      "PU_INT_EN": {
+        "primary": "PU_INT_EN",
+        "wire": "PU_INT_EN",
+        "dir": "INPUT"
+      },
+      "I": {
+        "primary": "I",
+        "wire": "I",
+        "dir": "OUTPUT"
+      },
+      "DIFFI_IN": {
+        "primary": "DIFFI_IN",
+        "wire": "DIFFI_IN",
+        "dir": "INPUT"
+      },
+      "T": {
+        "primary": "T",
+        "wire": "T",
+        "dir": "INPUT"
+      },
+      "O": {
+        "primary": "O",
+        "wire": "O",
+        "dir": "INPUT"
+      },
+      "IBUFDISABLE": {
+        "primary": "IBUFDISABLE",
+        "wire": "IBUFDISABLE",
+        "dir": "INPUT"
+      },
+      "DCITERMDISABLE": {
+        "primary": "DCITERMDISABLE",
+        "wire": "DCITERMDISABLE",
+        "dir": "INPUT"
+      },
+      "PADOUT": {
+        "primary": "PADOUT",
+        "wire": "PADOUT",
+        "dir": "OUTPUT"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds the required site_type files for Artix 7 PCIe and Zynq with Kintex fabric's HP IO bank. Both have been tested on real hardware (PCIe hasn't fully worked with OpenXC7 yet, but I can see the hard block in action already). 

nextpnr and prjxray-db code updates will be added later. 