### PR TITLE
add kintex7 GTX site_type json

### DIFF
--- a/kintex7/site_type_GTXE2_CHANNEL.json
+++ b/kintex7/site_type_GTXE2_CHANNEL.json
@@ -1,0 +1,6648 @@
+{
+    "GTXE2_CHANNEL": {
+        "bels": {
+            "GTXE2_CHANNEL": {
+                "class": "BEL",
+                "pins": {
+                    "CFGRESET": {
+                        "dir": "INPUT",
+                        "wire": "CFGRESET"
+                    },
+                    "CLKRSVD0": {
+                        "dir": "INPUT",
+                        "wire": "CLKRSVD0"
+                    },
+                    "CLKRSVD1": {
+                        "dir": "INPUT",
+                        "wire": "CLKRSVD1"
+                    },
+                    "CLKRSVD2": {
+                        "dir": "INPUT",
+                        "wire": "CLKRSVD2"
+                    },
+                    "CLKRSVD3": {
+                        "dir": "INPUT",
+                        "wire": "CLKRSVD3"
+                    },
+                    "CPLLFBCLKLOST": {
+                        "dir": "OUTPUT",
+                        "wire": "CPLLFBCLKLOST"
+                    },
+                    "CPLLLOCK": {
+                        "dir": "OUTPUT",
+                        "wire": "CPLLLOCK"
+                    },
+                    "CPLLLOCKDETCLK": {
+                        "dir": "INPUT",
+                        "wire": "CPLLLOCKDETCLKINV_OUT"
+                    },
+                    "CPLLLOCKEN": {
+                        "dir": "INPUT",
+                        "wire": "CPLLLOCKEN"
+                    },
+                    "CPLLPD": {
+                        "dir": "INPUT",
+                        "wire": "CPLLPD"
+                    },
+                    "CPLLREFCLKLOST": {
+                        "dir": "OUTPUT",
+                        "wire": "CPLLREFCLKLOST"
+                    },
+                    "CPLLREFCLKSEL0": {
+                        "dir": "INPUT",
+                        "wire": "CPLLREFCLKSEL0"
+                    },
+                    "CPLLREFCLKSEL1": {
+                        "dir": "INPUT",
+                        "wire": "CPLLREFCLKSEL1"
+                    },
+                    "CPLLREFCLKSEL2": {
+                        "dir": "INPUT",
+                        "wire": "CPLLREFCLKSEL2"
+                    },
+                    "CPLLRESET": {
+                        "dir": "INPUT",
+                        "wire": "CPLLRESET"
+                    },
+                    "DMONITOROUT0": {
+                        "dir": "OUTPUT",
+                        "wire": "DMONITOROUT0"
+                    },
+                    "DMONITOROUT1": {
+                        "dir": "OUTPUT",
+                        "wire": "DMONITOROUT1"
+                    },
+                    "DMONITOROUT2": {
+                        "dir": "OUTPUT",
+                        "wire": "DMONITOROUT2"
+                    },
+                    "DMONITOROUT3": {
+                        "dir": "OUTPUT",
+                        "wire": "DMONITOROUT3"
+                    },
+                    "DMONITOROUT4": {
+                        "dir": "OUTPUT",
+                        "wire": "DMONITOROUT4"
+                    },
+                    "DMONITOROUT5": {
+                        "dir": "OUTPUT",
+                        "wire": "DMONITOROUT5"
+                    },
+                    "DMONITOROUT6": {
+                        "dir": "OUTPUT",
+                        "wire": "DMONITOROUT6"
+                    },
+                    "DMONITOROUT7": {
+                        "dir": "OUTPUT",
+                        "wire": "DMONITOROUT7"
+                    },
+                    "DRPADDR0": {
+                        "dir": "INPUT",
+                        "wire": "DRPADDR0"
+                    },
+                    "DRPADDR1": {
+                        "dir": "INPUT",
+                        "wire": "DRPADDR1"
+                    },
+                    "DRPADDR2": {
+                        "dir": "INPUT",
+                        "wire": "DRPADDR2"
+                    },
+                    "DRPADDR3": {
+                        "dir": "INPUT",
+                        "wire": "DRPADDR3"
+                    },
+                    "DRPADDR4": {
+                        "dir": "INPUT",
+                        "wire": "DRPADDR4"
+                    },
+                    "DRPADDR5": {
+                        "dir": "INPUT",
+                        "wire": "DRPADDR5"
+                    },
+                    "DRPADDR6": {
+                        "dir": "INPUT",
+                        "wire": "DRPADDR6"
+                    },
+                    "DRPADDR7": {
+                        "dir": "INPUT",
+                        "wire": "DRPADDR7"
+                    },
+                    "DRPADDR8": {
+                        "dir": "INPUT",
+                        "wire": "DRPADDR8"
+                    },
+                    "DRPCLK": {
+                        "dir": "INPUT",
+                        "wire": "DRPCLKINV_OUT"
+                    },
+                    "DRPDI0": {
+                        "dir": "INPUT",
+                        "wire": "DRPDI0"
+                    },
+                    "DRPDI1": {
+                        "dir": "INPUT",
+                        "wire": "DRPDI1"
+                    },
+                    "DRPDI2": {
+                        "dir": "INPUT",
+                        "wire": "DRPDI2"
+                    },
+                    "DRPDI3": {
+                        "dir": "INPUT",
+                        "wire": "DRPDI3"
+                    },
+                    "DRPDI4": {
+                        "dir": "INPUT",
+                        "wire": "DRPDI4"
+                    },
+                    "DRPDI5": {
+                        "dir": "INPUT",
+                        "wire": "DRPDI5"
+                    },
+                    "DRPDI6": {
+                        "dir": "INPUT",
+                        "wire": "DRPDI6"
+                    },
+                    "DRPDI7": {
+                        "dir": "INPUT",
+                        "wire": "DRPDI7"
+                    },
+                    "DRPDI8": {
+                        "dir": "INPUT",
+                        "wire": "DRPDI8"
+                    },
+                    "DRPDI9": {
+                        "dir": "INPUT",
+                        "wire": "DRPDI9"
+                    },
+                    "DRPDI10": {
+                        "dir": "INPUT",
+                        "wire": "DRPDI10"
+                    },
+                    "DRPDI11": {
+                        "dir": "INPUT",
+                        "wire": "DRPDI11"
+                    },
+                    "DRPDI12": {
+                        "dir": "INPUT",
+                        "wire": "DRPDI12"
+                    },
+                    "DRPDI13": {
+                        "dir": "INPUT",
+                        "wire": "DRPDI13"
+                    },
+                    "DRPDI14": {
+                        "dir": "INPUT",
+                        "wire": "DRPDI14"
+                    },
+                    "DRPDI15": {
+                        "dir": "INPUT",
+                        "wire": "DRPDI15"
+                    },
+                    "DRPDO0": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPDO0"
+                    },
+                    "DRPDO1": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPDO1"
+                    },
+                    "DRPDO2": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPDO2"
+                    },
+                    "DRPDO3": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPDO3"
+                    },
+                    "DRPDO4": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPDO4"
+                    },
+                    "DRPDO5": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPDO5"
+                    },
+                    "DRPDO6": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPDO6"
+                    },
+                    "DRPDO7": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPDO7"
+                    },
+                    "DRPDO8": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPDO8"
+                    },
+                    "DRPDO9": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPDO9"
+                    },
+                    "DRPDO10": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPDO10"
+                    },
+                    "DRPDO11": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPDO11"
+                    },
+                    "DRPDO12": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPDO12"
+                    },
+                    "DRPDO13": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPDO13"
+                    },
+                    "DRPDO14": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPDO14"
+                    },
+                    "DRPDO15": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPDO15"
+                    },
+                    "DRPEN": {
+                        "dir": "INPUT",
+                        "wire": "DRPEN"
+                    },
+                    "DRPRDY": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPRDY"
+                    },
+                    "DRPWE": {
+                        "dir": "INPUT",
+                        "wire": "DRPWE"
+                    },
+                    "EDTBYPASS": {
+                        "dir": "INPUT",
+                        "wire": "EDTBYPASS"
+                    },
+                    "EDTCLOCK": {
+                        "dir": "INPUT",
+                        "wire": "EDTCLOCKINV_OUT"
+                    },
+                    "EDTCONFIGURATION": {
+                        "dir": "INPUT",
+                        "wire": "EDTCONFIGURATION"
+                    },
+                    "EDTSINGLEBYPASSCHAIN": {
+                        "dir": "INPUT",
+                        "wire": "EDTSINGLEBYPASSCHAIN"
+                    },
+                    "EDTUPDATE": {
+                        "dir": "INPUT",
+                        "wire": "EDTUPDATE"
+                    },
+                    "EYESCANDATAERROR": {
+                        "dir": "OUTPUT",
+                        "wire": "EYESCANDATAERROR"
+                    },
+                    "EYESCANMODE": {
+                        "dir": "INPUT",
+                        "wire": "EYESCANMODE"
+                    },
+                    "EYESCANRESET": {
+                        "dir": "INPUT",
+                        "wire": "EYESCANRESET"
+                    },
+                    "EYESCANTRIGGER": {
+                        "dir": "INPUT",
+                        "wire": "EYESCANTRIGGER"
+                    },
+                    "GTGREFCLK": {
+                        "dir": "INPUT",
+                        "wire": "GTGREFCLKINV_OUT"
+                    },
+                    "GTNORTHREFCLK0": {
+                        "dir": "INPUT",
+                        "wire": "GTNORTHREFCLK0"
+                    },
+                    "GTNORTHREFCLK1": {
+                        "dir": "INPUT",
+                        "wire": "GTNORTHREFCLK1"
+                    },
+                    "GTREFCLK0": {
+                        "dir": "INPUT",
+                        "wire": "GTREFCLK0"
+                    },
+                    "GTREFCLK1": {
+                        "dir": "INPUT",
+                        "wire": "GTREFCLK1"
+                    },
+                    "GTREFCLKMONITOR": {
+                        "dir": "OUTPUT",
+                        "wire": "GTREFCLKMONITOR"
+                    },
+                    "GTRESETSEL": {
+                        "dir": "INPUT",
+                        "wire": "GTRESETSEL"
+                    },
+                    "GTRSVD0": {
+                        "dir": "INPUT",
+                        "wire": "GTRSVD0"
+                    },
+                    "GTRSVD1": {
+                        "dir": "INPUT",
+                        "wire": "GTRSVD1"
+                    },
+                    "GTRSVD2": {
+                        "dir": "INPUT",
+                        "wire": "GTRSVD2"
+                    },
+                    "GTRSVD3": {
+                        "dir": "INPUT",
+                        "wire": "GTRSVD3"
+                    },
+                    "GTRSVD4": {
+                        "dir": "INPUT",
+                        "wire": "GTRSVD4"
+                    },
+                    "GTRSVD5": {
+                        "dir": "INPUT",
+                        "wire": "GTRSVD5"
+                    },
+                    "GTRSVD6": {
+                        "dir": "INPUT",
+                        "wire": "GTRSVD6"
+                    },
+                    "GTRSVD7": {
+                        "dir": "INPUT",
+                        "wire": "GTRSVD7"
+                    },
+                    "GTRSVD8": {
+                        "dir": "INPUT",
+                        "wire": "GTRSVD8"
+                    },
+                    "GTRSVD9": {
+                        "dir": "INPUT",
+                        "wire": "GTRSVD9"
+                    },
+                    "GTRSVD10": {
+                        "dir": "INPUT",
+                        "wire": "GTRSVD10"
+                    },
+                    "GTRSVD11": {
+                        "dir": "INPUT",
+                        "wire": "GTRSVD11"
+                    },
+                    "GTRSVD12": {
+                        "dir": "INPUT",
+                        "wire": "GTRSVD12"
+                    },
+                    "GTRSVD13": {
+                        "dir": "INPUT",
+                        "wire": "GTRSVD13"
+                    },
+                    "GTRSVD14": {
+                        "dir": "INPUT",
+                        "wire": "GTRSVD14"
+                    },
+                    "GTRSVD15": {
+                        "dir": "INPUT",
+                        "wire": "GTRSVD15"
+                    },
+                    "GTRXRESET": {
+                        "dir": "INPUT",
+                        "wire": "GTRXRESET"
+                    },
+                    "GTSOUTHREFCLK0": {
+                        "dir": "INPUT",
+                        "wire": "GTSOUTHREFCLK0"
+                    },
+                    "GTSOUTHREFCLK1": {
+                        "dir": "INPUT",
+                        "wire": "GTSOUTHREFCLK1"
+                    },
+                    "GTTXRESET": {
+                        "dir": "INPUT",
+                        "wire": "GTTXRESET"
+                    },
+                    "GTXRXN": {
+                        "dir": "INPUT",
+                        "wire": "GTXRXN"
+                    },
+                    "GTXRXP": {
+                        "dir": "INPUT",
+                        "wire": "GTXRXP"
+                    },
+                    "GTXTXN": {
+                        "dir": "OUTPUT",
+                        "wire": "GTXTXN"
+                    },
+                    "GTXTXP": {
+                        "dir": "OUTPUT",
+                        "wire": "GTXTXP"
+                    },
+                    "LOOPBACK0": {
+                        "dir": "INPUT",
+                        "wire": "LOOPBACK0"
+                    },
+                    "LOOPBACK1": {
+                        "dir": "INPUT",
+                        "wire": "LOOPBACK1"
+                    },
+                    "LOOPBACK2": {
+                        "dir": "INPUT",
+                        "wire": "LOOPBACK2"
+                    },
+                    "PCSRSVDIN0": {
+                        "dir": "INPUT",
+                        "wire": "PCSRSVDIN0"
+                    },
+                    "PCSRSVDIN1": {
+                        "dir": "INPUT",
+                        "wire": "PCSRSVDIN1"
+                    },
+                    "PCSRSVDIN2": {
+                        "dir": "INPUT",
+                        "wire": "PCSRSVDIN2"
+                    },
+                    "PCSRSVDIN3": {
+                        "dir": "INPUT",
+                        "wire": "PCSRSVDIN3"
+                    },
+                    "PCSRSVDIN4": {
+                        "dir": "INPUT",
+                        "wire": "PCSRSVDIN4"
+                    },
+                    "PCSRSVDIN5": {
+                        "dir": "INPUT",
+                        "wire": "PCSRSVDIN5"
+                    },
+                    "PCSRSVDIN6": {
+                        "dir": "INPUT",
+                        "wire": "PCSRSVDIN6"
+                    },
+                    "PCSRSVDIN7": {
+                        "dir": "INPUT",
+                        "wire": "PCSRSVDIN7"
+                    },
+                    "PCSRSVDIN8": {
+                        "dir": "INPUT",
+                        "wire": "PCSRSVDIN8"
+                    },
+                    "PCSRSVDIN9": {
+                        "dir": "INPUT",
+                        "wire": "PCSRSVDIN9"
+                    },
+                    "PCSRSVDIN10": {
+                        "dir": "INPUT",
+                        "wire": "PCSRSVDIN10"
+                    },
+                    "PCSRSVDIN11": {
+                        "dir": "INPUT",
+                        "wire": "PCSRSVDIN11"
+                    },
+                    "PCSRSVDIN12": {
+                        "dir": "INPUT",
+                        "wire": "PCSRSVDIN12"
+                    },
+                    "PCSRSVDIN13": {
+                        "dir": "INPUT",
+                        "wire": "PCSRSVDIN13"
+                    },
+                    "PCSRSVDIN14": {
+                        "dir": "INPUT",
+                        "wire": "PCSRSVDIN14"
+                    },
+                    "PCSRSVDIN15": {
+                        "dir": "INPUT",
+                        "wire": "PCSRSVDIN15"
+                    },
+                    "PCSRSVDIN20": {
+                        "dir": "INPUT",
+                        "wire": "PCSRSVDIN20"
+                    },
+                    "PCSRSVDIN21": {
+                        "dir": "INPUT",
+                        "wire": "PCSRSVDIN21"
+                    },
+                    "PCSRSVDIN22": {
+                        "dir": "INPUT",
+                        "wire": "PCSRSVDIN22"
+                    },
+                    "PCSRSVDIN23": {
+                        "dir": "INPUT",
+                        "wire": "PCSRSVDIN23"
+                    },
+                    "PCSRSVDIN24": {
+                        "dir": "INPUT",
+                        "wire": "PCSRSVDIN24"
+                    },
+                    "PCSRSVDOUT0": {
+                        "dir": "OUTPUT",
+                        "wire": "PCSRSVDOUT0"
+                    },
+                    "PCSRSVDOUT1": {
+                        "dir": "OUTPUT",
+                        "wire": "PCSRSVDOUT1"
+                    },
+                    "PCSRSVDOUT2": {
+                        "dir": "OUTPUT",
+                        "wire": "PCSRSVDOUT2"
+                    },
+                    "PCSRSVDOUT3": {
+                        "dir": "OUTPUT",
+                        "wire": "PCSRSVDOUT3"
+                    },
+                    "PCSRSVDOUT4": {
+                        "dir": "OUTPUT",
+                        "wire": "PCSRSVDOUT4"
+                    },
+                    "PCSRSVDOUT5": {
+                        "dir": "OUTPUT",
+                        "wire": "PCSRSVDOUT5"
+                    },
+                    "PCSRSVDOUT6": {
+                        "dir": "OUTPUT",
+                        "wire": "PCSRSVDOUT6"
+                    },
+                    "PCSRSVDOUT7": {
+                        "dir": "OUTPUT",
+                        "wire": "PCSRSVDOUT7"
+                    },
+                    "PCSRSVDOUT8": {
+                        "dir": "OUTPUT",
+                        "wire": "PCSRSVDOUT8"
+                    },
+                    "PCSRSVDOUT9": {
+                        "dir": "OUTPUT",
+                        "wire": "PCSRSVDOUT9"
+                    },
+                    "PCSRSVDOUT10": {
+                        "dir": "OUTPUT",
+                        "wire": "PCSRSVDOUT10"
+                    },
+                    "PCSRSVDOUT11": {
+                        "dir": "OUTPUT",
+                        "wire": "PCSRSVDOUT11"
+                    },
+                    "PCSRSVDOUT12": {
+                        "dir": "OUTPUT",
+                        "wire": "PCSRSVDOUT12"
+                    },
+                    "PCSRSVDOUT13": {
+                        "dir": "OUTPUT",
+                        "wire": "PCSRSVDOUT13"
+                    },
+                    "PCSRSVDOUT14": {
+                        "dir": "OUTPUT",
+                        "wire": "PCSRSVDOUT14"
+                    },
+                    "PCSRSVDOUT15": {
+                        "dir": "OUTPUT",
+                        "wire": "PCSRSVDOUT15"
+                    },
+                    "PHYSTATUS": {
+                        "dir": "OUTPUT",
+                        "wire": "PHYSTATUS"
+                    },
+                    "PMARSVDIN0": {
+                        "dir": "INPUT",
+                        "wire": "PMARSVDIN0"
+                    },
+                    "PMARSVDIN1": {
+                        "dir": "INPUT",
+                        "wire": "PMARSVDIN1"
+                    },
+                    "PMARSVDIN2": {
+                        "dir": "INPUT",
+                        "wire": "PMARSVDIN2"
+                    },
+                    "PMARSVDIN3": {
+                        "dir": "INPUT",
+                        "wire": "PMARSVDIN3"
+                    },
+                    "PMARSVDIN4": {
+                        "dir": "INPUT",
+                        "wire": "PMARSVDIN4"
+                    },
+                    "PMARSVDIN20": {
+                        "dir": "INPUT",
+                        "wire": "PMARSVDIN20"
+                    },
+                    "PMARSVDIN21": {
+                        "dir": "INPUT",
+                        "wire": "PMARSVDIN21"
+                    },
+                    "PMARSVDIN22": {
+                        "dir": "INPUT",
+                        "wire": "PMARSVDIN22"
+                    },
+                    "PMARSVDIN23": {
+                        "dir": "INPUT",
+                        "wire": "PMARSVDIN23"
+                    },
+                    "PMARSVDIN24": {
+                        "dir": "INPUT",
+                        "wire": "PMARSVDIN24"
+                    },
+                    "PMASCANCLK0": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANCLK0INV_OUT"
+                    },
+                    "PMASCANCLK1": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANCLK1INV_OUT"
+                    },
+                    "PMASCANCLK2": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANCLK2INV_OUT"
+                    },
+                    "PMASCANCLK3": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANCLK3INV_OUT"
+                    },
+                    "PMASCANCLK4": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANCLK4INV_OUT"
+                    },
+                    "PMASCANENB": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANENB"
+                    },
+                    "PMASCANIN0": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANIN0"
+                    },
+                    "PMASCANIN1": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANIN1"
+                    },
+                    "PMASCANIN2": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANIN2"
+                    },
+                    "PMASCANIN3": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANIN3"
+                    },
+                    "PMASCANIN4": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANIN4"
+                    },
+                    "PMASCANMODEB": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANMODEB"
+                    },
+                    "PMASCANOUT0": {
+                        "dir": "OUTPUT",
+                        "wire": "PMASCANOUT0"
+                    },
+                    "PMASCANOUT1": {
+                        "dir": "OUTPUT",
+                        "wire": "PMASCANOUT1"
+                    },
+                    "PMASCANOUT2": {
+                        "dir": "OUTPUT",
+                        "wire": "PMASCANOUT2"
+                    },
+                    "PMASCANOUT3": {
+                        "dir": "OUTPUT",
+                        "wire": "PMASCANOUT3"
+                    },
+                    "PMASCANOUT4": {
+                        "dir": "OUTPUT",
+                        "wire": "PMASCANOUT4"
+                    },
+                    "PMASCANRSTEN": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANRSTEN"
+                    },
+                    "QPLLCLK": {
+                        "dir": "INPUT",
+                        "wire": "QPLLCLK"
+                    },
+                    "QPLLREFCLK": {
+                        "dir": "INPUT",
+                        "wire": "QPLLREFCLK"
+                    },
+                    "RESETOVRD": {
+                        "dir": "INPUT",
+                        "wire": "RESETOVRD"
+                    },
+                    "RX8B10BEN": {
+                        "dir": "INPUT",
+                        "wire": "RX8B10BEN"
+                    },
+                    "RXBUFRESET": {
+                        "dir": "INPUT",
+                        "wire": "RXBUFRESET"
+                    },
+                    "RXBUFSTATUS0": {
+                        "dir": "OUTPUT",
+                        "wire": "RXBUFSTATUS0"
+                    },
+                    "RXBUFSTATUS1": {
+                        "dir": "OUTPUT",
+                        "wire": "RXBUFSTATUS1"
+                    },
+                    "RXBUFSTATUS2": {
+                        "dir": "OUTPUT",
+                        "wire": "RXBUFSTATUS2"
+                    },
+                    "RXBYTEISALIGNED": {
+                        "dir": "OUTPUT",
+                        "wire": "RXBYTEISALIGNED"
+                    },
+                    "RXBYTEREALIGN": {
+                        "dir": "OUTPUT",
+                        "wire": "RXBYTEREALIGN"
+                    },
+                    "RXCDRFREQRESET": {
+                        "dir": "INPUT",
+                        "wire": "RXCDRFREQRESET"
+                    },
+                    "RXCDRHOLD": {
+                        "dir": "INPUT",
+                        "wire": "RXCDRHOLD"
+                    },
+                    "RXCDRLOCK": {
+                        "dir": "OUTPUT",
+                        "wire": "RXCDRLOCK"
+                    },
+                    "RXCDROVRDEN": {
+                        "dir": "INPUT",
+                        "wire": "RXCDROVRDEN"
+                    },
+                    "RXCDRRESET": {
+                        "dir": "INPUT",
+                        "wire": "RXCDRRESET"
+                    },
+                    "RXCDRRESETRSV": {
+                        "dir": "INPUT",
+                        "wire": "RXCDRRESETRSV"
+                    },
+                    "RXCHANBONDSEQ": {
+                        "dir": "OUTPUT",
+                        "wire": "RXCHANBONDSEQ"
+                    },
+                    "RXCHANISALIGNED": {
+                        "dir": "OUTPUT",
+                        "wire": "RXCHANISALIGNED"
+                    },
+                    "RXCHANREALIGN": {
+                        "dir": "OUTPUT",
+                        "wire": "RXCHANREALIGN"
+                    },
+                    "RXCHARISCOMMA0": {
+                        "dir": "OUTPUT",
+                        "wire": "RXCHARISCOMMA0"
+                    },
+                    "RXCHARISCOMMA1": {
+                        "dir": "OUTPUT",
+                        "wire": "RXCHARISCOMMA1"
+                    },
+                    "RXCHARISCOMMA2": {
+                        "dir": "OUTPUT",
+                        "wire": "RXCHARISCOMMA2"
+                    },
+                    "RXCHARISCOMMA3": {
+                        "dir": "OUTPUT",
+                        "wire": "RXCHARISCOMMA3"
+                    },
+                    "RXCHARISCOMMA4": {
+                        "dir": "OUTPUT",
+                        "wire": "RXCHARISCOMMA4"
+                    },
+                    "RXCHARISCOMMA5": {
+                        "dir": "OUTPUT",
+                        "wire": "RXCHARISCOMMA5"
+                    },
+                    "RXCHARISCOMMA6": {
+                        "dir": "OUTPUT",
+                        "wire": "RXCHARISCOMMA6"
+                    },
+                    "RXCHARISCOMMA7": {
+                        "dir": "OUTPUT",
+                        "wire": "RXCHARISCOMMA7"
+                    },
+                    "RXCHARISK0": {
+                        "dir": "OUTPUT",
+                        "wire": "RXCHARISK0"
+                    },
+                    "RXCHARISK1": {
+                        "dir": "OUTPUT",
+                        "wire": "RXCHARISK1"
+                    },
+                    "RXCHARISK2": {
+                        "dir": "OUTPUT",
+                        "wire": "RXCHARISK2"
+                    },
+                    "RXCHARISK3": {
+                        "dir": "OUTPUT",
+                        "wire": "RXCHARISK3"
+                    },
+                    "RXCHARISK4": {
+                        "dir": "OUTPUT",
+                        "wire": "RXCHARISK4"
+                    },
+                    "RXCHARISK5": {
+                        "dir": "OUTPUT",
+                        "wire": "RXCHARISK5"
+                    },
+                    "RXCHARISK6": {
+                        "dir": "OUTPUT",
+                        "wire": "RXCHARISK6"
+                    },
+                    "RXCHARISK7": {
+                        "dir": "OUTPUT",
+                        "wire": "RXCHARISK7"
+                    },
+                    "RXCHBONDEN": {
+                        "dir": "INPUT",
+                        "wire": "RXCHBONDEN"
+                    },
+                    "RXCHBONDI0": {
+                        "dir": "INPUT",
+                        "wire": "RXCHBONDI0"
+                    },
+                    "RXCHBONDI1": {
+                        "dir": "INPUT",
+                        "wire": "RXCHBONDI1"
+                    },
+                    "RXCHBONDI2": {
+                        "dir": "INPUT",
+                        "wire": "RXCHBONDI2"
+                    },
+                    "RXCHBONDI3": {
+                        "dir": "INPUT",
+                        "wire": "RXCHBONDI3"
+                    },
+                    "RXCHBONDI4": {
+                        "dir": "INPUT",
+                        "wire": "RXCHBONDI4"
+                    },
+                    "RXCHBONDLEVEL0": {
+                        "dir": "INPUT",
+                        "wire": "RXCHBONDLEVEL0"
+                    },
+                    "RXCHBONDLEVEL1": {
+                        "dir": "INPUT",
+                        "wire": "RXCHBONDLEVEL1"
+                    },
+                    "RXCHBONDLEVEL2": {
+                        "dir": "INPUT",
+                        "wire": "RXCHBONDLEVEL2"
+                    },
+                    "RXCHBONDMASTER": {
+                        "dir": "INPUT",
+                        "wire": "RXCHBONDMASTER"
+                    },
+                    "RXCHBONDO0": {
+                        "dir": "OUTPUT",
+                        "wire": "RXCHBONDO0"
+                    },
+                    "RXCHBONDO1": {
+                        "dir": "OUTPUT",
+                        "wire": "RXCHBONDO1"
+                    },
+                    "RXCHBONDO2": {
+                        "dir": "OUTPUT",
+                        "wire": "RXCHBONDO2"
+                    },
+                    "RXCHBONDO3": {
+                        "dir": "OUTPUT",
+                        "wire": "RXCHBONDO3"
+                    },
+                    "RXCHBONDO4": {
+                        "dir": "OUTPUT",
+                        "wire": "RXCHBONDO4"
+                    },
+                    "RXCHBONDSLAVE": {
+                        "dir": "INPUT",
+                        "wire": "RXCHBONDSLAVE"
+                    },
+                    "RXCLKCORCNT0": {
+                        "dir": "OUTPUT",
+                        "wire": "RXCLKCORCNT0"
+                    },
+                    "RXCLKCORCNT1": {
+                        "dir": "OUTPUT",
+                        "wire": "RXCLKCORCNT1"
+                    },
+                    "RXCOMINITDET": {
+                        "dir": "OUTPUT",
+                        "wire": "RXCOMINITDET"
+                    },
+                    "RXCOMMADET": {
+                        "dir": "OUTPUT",
+                        "wire": "RXCOMMADET"
+                    },
+                    "RXCOMMADETEN": {
+                        "dir": "INPUT",
+                        "wire": "RXCOMMADETEN"
+                    },
+                    "RXCOMSASDET": {
+                        "dir": "OUTPUT",
+                        "wire": "RXCOMSASDET"
+                    },
+                    "RXCOMWAKEDET": {
+                        "dir": "OUTPUT",
+                        "wire": "RXCOMWAKEDET"
+                    },
+                    "RXDATA0": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA0"
+                    },
+                    "RXDATA1": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA1"
+                    },
+                    "RXDATA2": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA2"
+                    },
+                    "RXDATA3": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA3"
+                    },
+                    "RXDATA4": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA4"
+                    },
+                    "RXDATA5": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA5"
+                    },
+                    "RXDATA6": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA6"
+                    },
+                    "RXDATA7": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA7"
+                    },
+                    "RXDATA8": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA8"
+                    },
+                    "RXDATA9": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA9"
+                    },
+                    "RXDATA10": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA10"
+                    },
+                    "RXDATA11": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA11"
+                    },
+                    "RXDATA12": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA12"
+                    },
+                    "RXDATA13": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA13"
+                    },
+                    "RXDATA14": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA14"
+                    },
+                    "RXDATA15": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA15"
+                    },
+                    "RXDATA16": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA16"
+                    },
+                    "RXDATA17": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA17"
+                    },
+                    "RXDATA18": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA18"
+                    },
+                    "RXDATA19": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA19"
+                    },
+                    "RXDATA20": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA20"
+                    },
+                    "RXDATA21": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA21"
+                    },
+                    "RXDATA22": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA22"
+                    },
+                    "RXDATA23": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA23"
+                    },
+                    "RXDATA24": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA24"
+                    },
+                    "RXDATA25": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA25"
+                    },
+                    "RXDATA26": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA26"
+                    },
+                    "RXDATA27": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA27"
+                    },
+                    "RXDATA28": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA28"
+                    },
+                    "RXDATA29": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA29"
+                    },
+                    "RXDATA30": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA30"
+                    },
+                    "RXDATA31": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA31"
+                    },
+                    "RXDATA32": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA32"
+                    },
+                    "RXDATA33": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA33"
+                    },
+                    "RXDATA34": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA34"
+                    },
+                    "RXDATA35": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA35"
+                    },
+                    "RXDATA36": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA36"
+                    },
+                    "RXDATA37": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA37"
+                    },
+                    "RXDATA38": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA38"
+                    },
+                    "RXDATA39": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA39"
+                    },
+                    "RXDATA40": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA40"
+                    },
+                    "RXDATA41": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA41"
+                    },
+                    "RXDATA42": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA42"
+                    },
+                    "RXDATA43": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA43"
+                    },
+                    "RXDATA44": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA44"
+                    },
+                    "RXDATA45": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA45"
+                    },
+                    "RXDATA46": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA46"
+                    },
+                    "RXDATA47": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA47"
+                    },
+                    "RXDATA48": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA48"
+                    },
+                    "RXDATA49": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA49"
+                    },
+                    "RXDATA50": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA50"
+                    },
+                    "RXDATA51": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA51"
+                    },
+                    "RXDATA52": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA52"
+                    },
+                    "RXDATA53": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA53"
+                    },
+                    "RXDATA54": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA54"
+                    },
+                    "RXDATA55": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA55"
+                    },
+                    "RXDATA56": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA56"
+                    },
+                    "RXDATA57": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA57"
+                    },
+                    "RXDATA58": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA58"
+                    },
+                    "RXDATA59": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA59"
+                    },
+                    "RXDATA60": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA60"
+                    },
+                    "RXDATA61": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA61"
+                    },
+                    "RXDATA62": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA62"
+                    },
+                    "RXDATA63": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATA63"
+                    },
+                    "RXDATAVALID": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDATAVALID"
+                    },
+                    "RXDDIEN": {
+                        "dir": "INPUT",
+                        "wire": "RXDDIEN"
+                    },
+                    "RXDEBUGPULSE": {
+                        "dir": "INPUT",
+                        "wire": "RXDEBUGPULSE"
+                    },
+                    "RXDFEAGCHOLD": {
+                        "dir": "INPUT",
+                        "wire": "RXDFEAGCHOLD"
+                    },
+                    "RXDFEAGCOVRDEN": {
+                        "dir": "INPUT",
+                        "wire": "RXDFEAGCOVRDEN"
+                    },
+                    "RXDFECM1EN": {
+                        "dir": "INPUT",
+                        "wire": "RXDFECM1EN"
+                    },
+                    "RXDFELFHOLD": {
+                        "dir": "INPUT",
+                        "wire": "RXDFELFHOLD"
+                    },
+                    "RXDFELFOVRDEN": {
+                        "dir": "INPUT",
+                        "wire": "RXDFELFOVRDEN"
+                    },
+                    "RXDFELPMRESET": {
+                        "dir": "INPUT",
+                        "wire": "RXDFELPMRESET"
+                    },
+                    "RXDFETAP2HOLD": {
+                        "dir": "INPUT",
+                        "wire": "RXDFETAP2HOLD"
+                    },
+                    "RXDFETAP2OVRDEN": {
+                        "dir": "INPUT",
+                        "wire": "RXDFETAP2OVRDEN"
+                    },
+                    "RXDFETAP3HOLD": {
+                        "dir": "INPUT",
+                        "wire": "RXDFETAP3HOLD"
+                    },
+                    "RXDFETAP3OVRDEN": {
+                        "dir": "INPUT",
+                        "wire": "RXDFETAP3OVRDEN"
+                    },
+                    "RXDFETAP4HOLD": {
+                        "dir": "INPUT",
+                        "wire": "RXDFETAP4HOLD"
+                    },
+                    "RXDFETAP4OVRDEN": {
+                        "dir": "INPUT",
+                        "wire": "RXDFETAP4OVRDEN"
+                    },
+                    "RXDFETAP5HOLD": {
+                        "dir": "INPUT",
+                        "wire": "RXDFETAP5HOLD"
+                    },
+                    "RXDFETAP5OVRDEN": {
+                        "dir": "INPUT",
+                        "wire": "RXDFETAP5OVRDEN"
+                    },
+                    "RXDFEUTHOLD": {
+                        "dir": "INPUT",
+                        "wire": "RXDFEUTHOLD"
+                    },
+                    "RXDFEUTOVRDEN": {
+                        "dir": "INPUT",
+                        "wire": "RXDFEUTOVRDEN"
+                    },
+                    "RXDFEVPHOLD": {
+                        "dir": "INPUT",
+                        "wire": "RXDFEVPHOLD"
+                    },
+                    "RXDFEVPOVRDEN": {
+                        "dir": "INPUT",
+                        "wire": "RXDFEVPOVRDEN"
+                    },
+                    "RXDFEVSEN": {
+                        "dir": "INPUT",
+                        "wire": "RXDFEVSEN"
+                    },
+                    "RXDFEXYDEN": {
+                        "dir": "INPUT",
+                        "wire": "RXDFEXYDEN"
+                    },
+                    "RXDFEXYDHOLD": {
+                        "dir": "INPUT",
+                        "wire": "RXDFEXYDHOLD"
+                    },
+                    "RXDFEXYDOVRDEN": {
+                        "dir": "INPUT",
+                        "wire": "RXDFEXYDOVRDEN"
+                    },
+                    "RXDISPERR0": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDISPERR0"
+                    },
+                    "RXDISPERR1": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDISPERR1"
+                    },
+                    "RXDISPERR2": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDISPERR2"
+                    },
+                    "RXDISPERR3": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDISPERR3"
+                    },
+                    "RXDISPERR4": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDISPERR4"
+                    },
+                    "RXDISPERR5": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDISPERR5"
+                    },
+                    "RXDISPERR6": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDISPERR6"
+                    },
+                    "RXDISPERR7": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDISPERR7"
+                    },
+                    "RXDLYBYPASS": {
+                        "dir": "INPUT",
+                        "wire": "RXDLYBYPASS"
+                    },
+                    "RXDLYEN": {
+                        "dir": "INPUT",
+                        "wire": "RXDLYEN"
+                    },
+                    "RXDLYOVRDEN": {
+                        "dir": "INPUT",
+                        "wire": "RXDLYOVRDEN"
+                    },
+                    "RXDLYSRESET": {
+                        "dir": "INPUT",
+                        "wire": "RXDLYSRESET"
+                    },
+                    "RXDLYSRESETDONE": {
+                        "dir": "OUTPUT",
+                        "wire": "RXDLYSRESETDONE"
+                    },
+                    "RXDLYTESTENB": {
+                        "dir": "INPUT",
+                        "wire": "RXDLYTESTENB"
+                    },
+                    "RXELECIDLE": {
+                        "dir": "OUTPUT",
+                        "wire": "RXELECIDLE"
+                    },
+                    "RXELECIDLEMODE0": {
+                        "dir": "INPUT",
+                        "wire": "RXELECIDLEMODE0"
+                    },
+                    "RXELECIDLEMODE1": {
+                        "dir": "INPUT",
+                        "wire": "RXELECIDLEMODE1"
+                    },
+                    "RXGEARBOXSLIP": {
+                        "dir": "INPUT",
+                        "wire": "RXGEARBOXSLIP"
+                    },
+                    "RXHEADER0": {
+                        "dir": "OUTPUT",
+                        "wire": "RXHEADER0"
+                    },
+                    "RXHEADER1": {
+                        "dir": "OUTPUT",
+                        "wire": "RXHEADER1"
+                    },
+                    "RXHEADER2": {
+                        "dir": "OUTPUT",
+                        "wire": "RXHEADER2"
+                    },
+                    "RXHEADERVALID": {
+                        "dir": "OUTPUT",
+                        "wire": "RXHEADERVALID"
+                    },
+                    "RXLPMEN": {
+                        "dir": "INPUT",
+                        "wire": "RXLPMEN"
+                    },
+                    "RXLPMHFHOLD": {
+                        "dir": "INPUT",
+                        "wire": "RXLPMHFHOLD"
+                    },
+                    "RXLPMHFOVRDEN": {
+                        "dir": "INPUT",
+                        "wire": "RXLPMHFOVRDEN"
+                    },
+                    "RXLPMLFHOLD": {
+                        "dir": "INPUT",
+                        "wire": "RXLPMLFHOLD"
+                    },
+                    "RXLPMLFKLOVRDEN": {
+                        "dir": "INPUT",
+                        "wire": "RXLPMLFKLOVRDEN"
+                    },
+                    "RXMCOMMAALIGNEN": {
+                        "dir": "INPUT",
+                        "wire": "RXMCOMMAALIGNEN"
+                    },
+                    "RXMONITOROUT0": {
+                        "dir": "OUTPUT",
+                        "wire": "RXMONITOROUT0"
+                    },
+                    "RXMONITOROUT1": {
+                        "dir": "OUTPUT",
+                        "wire": "RXMONITOROUT1"
+                    },
+                    "RXMONITOROUT2": {
+                        "dir": "OUTPUT",
+                        "wire": "RXMONITOROUT2"
+                    },
+                    "RXMONITOROUT3": {
+                        "dir": "OUTPUT",
+                        "wire": "RXMONITOROUT3"
+                    },
+                    "RXMONITOROUT4": {
+                        "dir": "OUTPUT",
+                        "wire": "RXMONITOROUT4"
+                    },
+                    "RXMONITOROUT5": {
+                        "dir": "OUTPUT",
+                        "wire": "RXMONITOROUT5"
+                    },
+                    "RXMONITOROUT6": {
+                        "dir": "OUTPUT",
+                        "wire": "RXMONITOROUT6"
+                    },
+                    "RXMONITORSEL0": {
+                        "dir": "INPUT",
+                        "wire": "RXMONITORSEL0"
+                    },
+                    "RXMONITORSEL1": {
+                        "dir": "INPUT",
+                        "wire": "RXMONITORSEL1"
+                    },
+                    "RXNOTINTABLE0": {
+                        "dir": "OUTPUT",
+                        "wire": "RXNOTINTABLE0"
+                    },
+                    "RXNOTINTABLE1": {
+                        "dir": "OUTPUT",
+                        "wire": "RXNOTINTABLE1"
+                    },
+                    "RXNOTINTABLE2": {
+                        "dir": "OUTPUT",
+                        "wire": "RXNOTINTABLE2"
+                    },
+                    "RXNOTINTABLE3": {
+                        "dir": "OUTPUT",
+                        "wire": "RXNOTINTABLE3"
+                    },
+                    "RXNOTINTABLE4": {
+                        "dir": "OUTPUT",
+                        "wire": "RXNOTINTABLE4"
+                    },
+                    "RXNOTINTABLE5": {
+                        "dir": "OUTPUT",
+                        "wire": "RXNOTINTABLE5"
+                    },
+                    "RXNOTINTABLE6": {
+                        "dir": "OUTPUT",
+                        "wire": "RXNOTINTABLE6"
+                    },
+                    "RXNOTINTABLE7": {
+                        "dir": "OUTPUT",
+                        "wire": "RXNOTINTABLE7"
+                    },
+                    "RXOOBRESET": {
+                        "dir": "INPUT",
+                        "wire": "RXOOBRESET"
+                    },
+                    "RXOSHOLD": {
+                        "dir": "INPUT",
+                        "wire": "RXOSHOLD"
+                    },
+                    "RXOSOVRDEN": {
+                        "dir": "INPUT",
+                        "wire": "RXOSOVRDEN"
+                    },
+                    "RXOUTCLK": {
+                        "dir": "OUTPUT",
+                        "wire": "RXOUTCLK"
+                    },
+                    "RXOUTCLKFABRIC": {
+                        "dir": "OUTPUT",
+                        "wire": "RXOUTCLKFABRIC"
+                    },
+                    "RXOUTCLKPCS": {
+                        "dir": "OUTPUT",
+                        "wire": "RXOUTCLKPCS"
+                    },
+                    "RXOUTCLKSEL0": {
+                        "dir": "INPUT",
+                        "wire": "RXOUTCLKSEL0"
+                    },
+                    "RXOUTCLKSEL1": {
+                        "dir": "INPUT",
+                        "wire": "RXOUTCLKSEL1"
+                    },
+                    "RXOUTCLKSEL2": {
+                        "dir": "INPUT",
+                        "wire": "RXOUTCLKSEL2"
+                    },
+                    "RXPCD1DONE": {
+                        "dir": "OUTPUT",
+                        "wire": "RXPCD1DONE"
+                    },
+                    "RXPCOMMAALIGNEN": {
+                        "dir": "INPUT",
+                        "wire": "RXPCOMMAALIGNEN"
+                    },
+                    "RXPCSRESET": {
+                        "dir": "INPUT",
+                        "wire": "RXPCSRESET"
+                    },
+                    "RXPD0": {
+                        "dir": "INPUT",
+                        "wire": "RXPD0"
+                    },
+                    "RXPD1": {
+                        "dir": "INPUT",
+                        "wire": "RXPD1"
+                    },
+                    "RXPHALIGN": {
+                        "dir": "INPUT",
+                        "wire": "RXPHALIGN"
+                    },
+                    "RXPHALIGNDONE": {
+                        "dir": "OUTPUT",
+                        "wire": "RXPHALIGNDONE"
+                    },
+                    "RXPHALIGNEN": {
+                        "dir": "INPUT",
+                        "wire": "RXPHALIGNEN"
+                    },
+                    "RXPHDLYPD": {
+                        "dir": "INPUT",
+                        "wire": "RXPHDLYPD"
+                    },
+                    "RXPHDLYRESET": {
+                        "dir": "INPUT",
+                        "wire": "RXPHDLYRESET"
+                    },
+                    "RXPHMONITOR0": {
+                        "dir": "OUTPUT",
+                        "wire": "RXPHMONITOR0"
+                    },
+                    "RXPHMONITOR1": {
+                        "dir": "OUTPUT",
+                        "wire": "RXPHMONITOR1"
+                    },
+                    "RXPHMONITOR2": {
+                        "dir": "OUTPUT",
+                        "wire": "RXPHMONITOR2"
+                    },
+                    "RXPHMONITOR3": {
+                        "dir": "OUTPUT",
+                        "wire": "RXPHMONITOR3"
+                    },
+                    "RXPHMONITOR4": {
+                        "dir": "OUTPUT",
+                        "wire": "RXPHMONITOR4"
+                    },
+                    "RXPHOVRDEN": {
+                        "dir": "INPUT",
+                        "wire": "RXPHOVRDEN"
+                    },
+                    "RXPHSLIPMONITOR0": {
+                        "dir": "OUTPUT",
+                        "wire": "RXPHSLIPMONITOR0"
+                    },
+                    "RXPHSLIPMONITOR1": {
+                        "dir": "OUTPUT",
+                        "wire": "RXPHSLIPMONITOR1"
+                    },
+                    "RXPHSLIPMONITOR2": {
+                        "dir": "OUTPUT",
+                        "wire": "RXPHSLIPMONITOR2"
+                    },
+                    "RXPHSLIPMONITOR3": {
+                        "dir": "OUTPUT",
+                        "wire": "RXPHSLIPMONITOR3"
+                    },
+                    "RXPHSLIPMONITOR4": {
+                        "dir": "OUTPUT",
+                        "wire": "RXPHSLIPMONITOR4"
+                    },
+                    "RXPMARESET": {
+                        "dir": "INPUT",
+                        "wire": "RXPMARESET"
+                    },
+                    "RXPOLARITY": {
+                        "dir": "INPUT",
+                        "wire": "RXPOLARITY"
+                    },
+                    "RXPRBSCNTRESET": {
+                        "dir": "INPUT",
+                        "wire": "RXPRBSCNTRESET"
+                    },
+                    "RXPRBSERR": {
+                        "dir": "OUTPUT",
+                        "wire": "RXPRBSERR"
+                    },
+                    "RXPRBSSEL0": {
+                        "dir": "INPUT",
+                        "wire": "RXPRBSSEL0"
+                    },
+                    "RXPRBSSEL1": {
+                        "dir": "INPUT",
+                        "wire": "RXPRBSSEL1"
+                    },
+                    "RXPRBSSEL2": {
+                        "dir": "INPUT",
+                        "wire": "RXPRBSSEL2"
+                    },
+                    "RXQPIEN": {
+                        "dir": "INPUT",
+                        "wire": "RXQPIEN"
+                    },
+                    "RXQPISENN": {
+                        "dir": "OUTPUT",
+                        "wire": "RXQPISENN"
+                    },
+                    "RXQPISENP": {
+                        "dir": "OUTPUT",
+                        "wire": "RXQPISENP"
+                    },
+                    "RXRATE0": {
+                        "dir": "INPUT",
+                        "wire": "RXRATE0"
+                    },
+                    "RXRATE1": {
+                        "dir": "INPUT",
+                        "wire": "RXRATE1"
+                    },
+                    "RXRATE2": {
+                        "dir": "INPUT",
+                        "wire": "RXRATE2"
+                    },
+                    "RXRATEDONE": {
+                        "dir": "OUTPUT",
+                        "wire": "RXRATEDONE"
+                    },
+                    "RXRESETDONE": {
+                        "dir": "OUTPUT",
+                        "wire": "RXRESETDONE"
+                    },
+                    "RXSLIDE": {
+                        "dir": "INPUT",
+                        "wire": "RXSLIDE"
+                    },
+                    "RXSTARTOFSEQ": {
+                        "dir": "OUTPUT",
+                        "wire": "RXSTARTOFSEQ"
+                    },
+                    "RXSTATUS0": {
+                        "dir": "OUTPUT",
+                        "wire": "RXSTATUS0"
+                    },
+                    "RXSTATUS1": {
+                        "dir": "OUTPUT",
+                        "wire": "RXSTATUS1"
+                    },
+                    "RXSTATUS2": {
+                        "dir": "OUTPUT",
+                        "wire": "RXSTATUS2"
+                    },
+                    "RXSYSCLKSEL0": {
+                        "dir": "INPUT",
+                        "wire": "RXSYSCLKSEL0"
+                    },
+                    "RXSYSCLKSEL1": {
+                        "dir": "INPUT",
+                        "wire": "RXSYSCLKSEL1"
+                    },
+                    "RXUSERRDY": {
+                        "dir": "INPUT",
+                        "wire": "RXUSERRDY"
+                    },
+                    "RXUSRCLK": {
+                        "dir": "INPUT",
+                        "wire": "RXUSRCLKINV_OUT"
+                    },
+                    "RXUSRCLK2": {
+                        "dir": "INPUT",
+                        "wire": "RXUSRCLK2INV_OUT"
+                    },
+                    "RXVALID": {
+                        "dir": "OUTPUT",
+                        "wire": "RXVALID"
+                    },
+                    "SCANCLK": {
+                        "dir": "INPUT",
+                        "wire": "SCANCLKINV_OUT"
+                    },
+                    "SCANENB": {
+                        "dir": "INPUT",
+                        "wire": "SCANENB"
+                    },
+                    "SCANIN0": {
+                        "dir": "INPUT",
+                        "wire": "SCANIN0"
+                    },
+                    "SCANIN1": {
+                        "dir": "INPUT",
+                        "wire": "SCANIN1"
+                    },
+                    "SCANIN2": {
+                        "dir": "INPUT",
+                        "wire": "SCANIN2"
+                    },
+                    "SCANIN3": {
+                        "dir": "INPUT",
+                        "wire": "SCANIN3"
+                    },
+                    "SCANIN4": {
+                        "dir": "INPUT",
+                        "wire": "SCANIN4"
+                    },
+                    "SCANMODEB": {
+                        "dir": "INPUT",
+                        "wire": "SCANMODEB"
+                    },
+                    "SCANOUT0": {
+                        "dir": "OUTPUT",
+                        "wire": "SCANOUT0"
+                    },
+                    "SCANOUT1": {
+                        "dir": "OUTPUT",
+                        "wire": "SCANOUT1"
+                    },
+                    "SCANOUT2": {
+                        "dir": "OUTPUT",
+                        "wire": "SCANOUT2"
+                    },
+                    "SCANOUT3": {
+                        "dir": "OUTPUT",
+                        "wire": "SCANOUT3"
+                    },
+                    "SCANOUT4": {
+                        "dir": "OUTPUT",
+                        "wire": "SCANOUT4"
+                    },
+                    "SETERRSTATUS": {
+                        "dir": "INPUT",
+                        "wire": "SETERRSTATUS"
+                    },
+                    "TSTCLK0": {
+                        "dir": "INPUT",
+                        "wire": "TSTCLK0INV_OUT"
+                    },
+                    "TSTCLK1": {
+                        "dir": "INPUT",
+                        "wire": "TSTCLK1INV_OUT"
+                    },
+                    "TSTIN0": {
+                        "dir": "INPUT",
+                        "wire": "TSTIN0"
+                    },
+                    "TSTIN1": {
+                        "dir": "INPUT",
+                        "wire": "TSTIN1"
+                    },
+                    "TSTIN2": {
+                        "dir": "INPUT",
+                        "wire": "TSTIN2"
+                    },
+                    "TSTIN3": {
+                        "dir": "INPUT",
+                        "wire": "TSTIN3"
+                    },
+                    "TSTIN4": {
+                        "dir": "INPUT",
+                        "wire": "TSTIN4"
+                    },
+                    "TSTIN5": {
+                        "dir": "INPUT",
+                        "wire": "TSTIN5"
+                    },
+                    "TSTIN6": {
+                        "dir": "INPUT",
+                        "wire": "TSTIN6"
+                    },
+                    "TSTIN7": {
+                        "dir": "INPUT",
+                        "wire": "TSTIN7"
+                    },
+                    "TSTIN8": {
+                        "dir": "INPUT",
+                        "wire": "TSTIN8"
+                    },
+                    "TSTIN9": {
+                        "dir": "INPUT",
+                        "wire": "TSTIN9"
+                    },
+                    "TSTIN10": {
+                        "dir": "INPUT",
+                        "wire": "TSTIN10"
+                    },
+                    "TSTIN11": {
+                        "dir": "INPUT",
+                        "wire": "TSTIN11"
+                    },
+                    "TSTIN12": {
+                        "dir": "INPUT",
+                        "wire": "TSTIN12"
+                    },
+                    "TSTIN13": {
+                        "dir": "INPUT",
+                        "wire": "TSTIN13"
+                    },
+                    "TSTIN14": {
+                        "dir": "INPUT",
+                        "wire": "TSTIN14"
+                    },
+                    "TSTIN15": {
+                        "dir": "INPUT",
+                        "wire": "TSTIN15"
+                    },
+                    "TSTIN16": {
+                        "dir": "INPUT",
+                        "wire": "TSTIN16"
+                    },
+                    "TSTIN17": {
+                        "dir": "INPUT",
+                        "wire": "TSTIN17"
+                    },
+                    "TSTIN18": {
+                        "dir": "INPUT",
+                        "wire": "TSTIN18"
+                    },
+                    "TSTIN19": {
+                        "dir": "INPUT",
+                        "wire": "TSTIN19"
+                    },
+                    "TSTOUT0": {
+                        "dir": "OUTPUT",
+                        "wire": "TSTOUT0"
+                    },
+                    "TSTOUT1": {
+                        "dir": "OUTPUT",
+                        "wire": "TSTOUT1"
+                    },
+                    "TSTOUT2": {
+                        "dir": "OUTPUT",
+                        "wire": "TSTOUT2"
+                    },
+                    "TSTOUT3": {
+                        "dir": "OUTPUT",
+                        "wire": "TSTOUT3"
+                    },
+                    "TSTOUT4": {
+                        "dir": "OUTPUT",
+                        "wire": "TSTOUT4"
+                    },
+                    "TSTOUT5": {
+                        "dir": "OUTPUT",
+                        "wire": "TSTOUT5"
+                    },
+                    "TSTOUT6": {
+                        "dir": "OUTPUT",
+                        "wire": "TSTOUT6"
+                    },
+                    "TSTOUT7": {
+                        "dir": "OUTPUT",
+                        "wire": "TSTOUT7"
+                    },
+                    "TSTOUT8": {
+                        "dir": "OUTPUT",
+                        "wire": "TSTOUT8"
+                    },
+                    "TSTOUT9": {
+                        "dir": "OUTPUT",
+                        "wire": "TSTOUT9"
+                    },
+                    "TSTPD0": {
+                        "dir": "INPUT",
+                        "wire": "TSTPD0"
+                    },
+                    "TSTPD1": {
+                        "dir": "INPUT",
+                        "wire": "TSTPD1"
+                    },
+                    "TSTPD2": {
+                        "dir": "INPUT",
+                        "wire": "TSTPD2"
+                    },
+                    "TSTPD3": {
+                        "dir": "INPUT",
+                        "wire": "TSTPD3"
+                    },
+                    "TSTPD4": {
+                        "dir": "INPUT",
+                        "wire": "TSTPD4"
+                    },
+                    "TSTPDOVRDB": {
+                        "dir": "INPUT",
+                        "wire": "TSTPDOVRDB"
+                    },
+                    "TX8B10BBYPASS0": {
+                        "dir": "INPUT",
+                        "wire": "TX8B10BBYPASS0"
+                    },
+                    "TX8B10BBYPASS1": {
+                        "dir": "INPUT",
+                        "wire": "TX8B10BBYPASS1"
+                    },
+                    "TX8B10BBYPASS2": {
+                        "dir": "INPUT",
+                        "wire": "TX8B10BBYPASS2"
+                    },
+                    "TX8B10BBYPASS3": {
+                        "dir": "INPUT",
+                        "wire": "TX8B10BBYPASS3"
+                    },
+                    "TX8B10BBYPASS4": {
+                        "dir": "INPUT",
+                        "wire": "TX8B10BBYPASS4"
+                    },
+                    "TX8B10BBYPASS5": {
+                        "dir": "INPUT",
+                        "wire": "TX8B10BBYPASS5"
+                    },
+                    "TX8B10BBYPASS6": {
+                        "dir": "INPUT",
+                        "wire": "TX8B10BBYPASS6"
+                    },
+                    "TX8B10BBYPASS7": {
+                        "dir": "INPUT",
+                        "wire": "TX8B10BBYPASS7"
+                    },
+                    "TX8B10BEN": {
+                        "dir": "INPUT",
+                        "wire": "TX8B10BEN"
+                    },
+                    "TXBUFDIFFCTRL0": {
+                        "dir": "INPUT",
+                        "wire": "TXBUFDIFFCTRL0"
+                    },
+                    "TXBUFDIFFCTRL1": {
+                        "dir": "INPUT",
+                        "wire": "TXBUFDIFFCTRL1"
+                    },
+                    "TXBUFDIFFCTRL2": {
+                        "dir": "INPUT",
+                        "wire": "TXBUFDIFFCTRL2"
+                    },
+                    "TXBUFSTATUS0": {
+                        "dir": "OUTPUT",
+                        "wire": "TXBUFSTATUS0"
+                    },
+                    "TXBUFSTATUS1": {
+                        "dir": "OUTPUT",
+                        "wire": "TXBUFSTATUS1"
+                    },
+                    "TXCHARDISPMODE0": {
+                        "dir": "INPUT",
+                        "wire": "TXCHARDISPMODE0"
+                    },
+                    "TXCHARDISPMODE1": {
+                        "dir": "INPUT",
+                        "wire": "TXCHARDISPMODE1"
+                    },
+                    "TXCHARDISPMODE2": {
+                        "dir": "INPUT",
+                        "wire": "TXCHARDISPMODE2"
+                    },
+                    "TXCHARDISPMODE3": {
+                        "dir": "INPUT",
+                        "wire": "TXCHARDISPMODE3"
+                    },
+                    "TXCHARDISPMODE4": {
+                        "dir": "INPUT",
+                        "wire": "TXCHARDISPMODE4"
+                    },
+                    "TXCHARDISPMODE5": {
+                        "dir": "INPUT",
+                        "wire": "TXCHARDISPMODE5"
+                    },
+                    "TXCHARDISPMODE6": {
+                        "dir": "INPUT",
+                        "wire": "TXCHARDISPMODE6"
+                    },
+                    "TXCHARDISPMODE7": {
+                        "dir": "INPUT",
+                        "wire": "TXCHARDISPMODE7"
+                    },
+                    "TXCHARDISPVAL0": {
+                        "dir": "INPUT",
+                        "wire": "TXCHARDISPVAL0"
+                    },
+                    "TXCHARDISPVAL1": {
+                        "dir": "INPUT",
+                        "wire": "TXCHARDISPVAL1"
+                    },
+                    "TXCHARDISPVAL2": {
+                        "dir": "INPUT",
+                        "wire": "TXCHARDISPVAL2"
+                    },
+                    "TXCHARDISPVAL3": {
+                        "dir": "INPUT",
+                        "wire": "TXCHARDISPVAL3"
+                    },
+                    "TXCHARDISPVAL4": {
+                        "dir": "INPUT",
+                        "wire": "TXCHARDISPVAL4"
+                    },
+                    "TXCHARDISPVAL5": {
+                        "dir": "INPUT",
+                        "wire": "TXCHARDISPVAL5"
+                    },
+                    "TXCHARDISPVAL6": {
+                        "dir": "INPUT",
+                        "wire": "TXCHARDISPVAL6"
+                    },
+                    "TXCHARDISPVAL7": {
+                        "dir": "INPUT",
+                        "wire": "TXCHARDISPVAL7"
+                    },
+                    "TXCHARISK0": {
+                        "dir": "INPUT",
+                        "wire": "TXCHARISK0"
+                    },
+                    "TXCHARISK1": {
+                        "dir": "INPUT",
+                        "wire": "TXCHARISK1"
+                    },
+                    "TXCHARISK2": {
+                        "dir": "INPUT",
+                        "wire": "TXCHARISK2"
+                    },
+                    "TXCHARISK3": {
+                        "dir": "INPUT",
+                        "wire": "TXCHARISK3"
+                    },
+                    "TXCHARISK4": {
+                        "dir": "INPUT",
+                        "wire": "TXCHARISK4"
+                    },
+                    "TXCHARISK5": {
+                        "dir": "INPUT",
+                        "wire": "TXCHARISK5"
+                    },
+                    "TXCHARISK6": {
+                        "dir": "INPUT",
+                        "wire": "TXCHARISK6"
+                    },
+                    "TXCHARISK7": {
+                        "dir": "INPUT",
+                        "wire": "TXCHARISK7"
+                    },
+                    "TXCOMFINISH": {
+                        "dir": "OUTPUT",
+                        "wire": "TXCOMFINISH"
+                    },
+                    "TXCOMINIT": {
+                        "dir": "INPUT",
+                        "wire": "TXCOMINIT"
+                    },
+                    "TXCOMSAS": {
+                        "dir": "INPUT",
+                        "wire": "TXCOMSAS"
+                    },
+                    "TXCOMWAKE": {
+                        "dir": "INPUT",
+                        "wire": "TXCOMWAKE"
+                    },
+                    "TXDATA0": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA0"
+                    },
+                    "TXDATA1": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA1"
+                    },
+                    "TXDATA2": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA2"
+                    },
+                    "TXDATA3": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA3"
+                    },
+                    "TXDATA4": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA4"
+                    },
+                    "TXDATA5": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA5"
+                    },
+                    "TXDATA6": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA6"
+                    },
+                    "TXDATA7": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA7"
+                    },
+                    "TXDATA8": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA8"
+                    },
+                    "TXDATA9": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA9"
+                    },
+                    "TXDATA10": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA10"
+                    },
+                    "TXDATA11": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA11"
+                    },
+                    "TXDATA12": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA12"
+                    },
+                    "TXDATA13": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA13"
+                    },
+                    "TXDATA14": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA14"
+                    },
+                    "TXDATA15": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA15"
+                    },
+                    "TXDATA16": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA16"
+                    },
+                    "TXDATA17": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA17"
+                    },
+                    "TXDATA18": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA18"
+                    },
+                    "TXDATA19": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA19"
+                    },
+                    "TXDATA20": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA20"
+                    },
+                    "TXDATA21": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA21"
+                    },
+                    "TXDATA22": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA22"
+                    },
+                    "TXDATA23": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA23"
+                    },
+                    "TXDATA24": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA24"
+                    },
+                    "TXDATA25": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA25"
+                    },
+                    "TXDATA26": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA26"
+                    },
+                    "TXDATA27": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA27"
+                    },
+                    "TXDATA28": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA28"
+                    },
+                    "TXDATA29": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA29"
+                    },
+                    "TXDATA30": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA30"
+                    },
+                    "TXDATA31": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA31"
+                    },
+                    "TXDATA32": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA32"
+                    },
+                    "TXDATA33": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA33"
+                    },
+                    "TXDATA34": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA34"
+                    },
+                    "TXDATA35": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA35"
+                    },
+                    "TXDATA36": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA36"
+                    },
+                    "TXDATA37": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA37"
+                    },
+                    "TXDATA38": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA38"
+                    },
+                    "TXDATA39": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA39"
+                    },
+                    "TXDATA40": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA40"
+                    },
+                    "TXDATA41": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA41"
+                    },
+                    "TXDATA42": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA42"
+                    },
+                    "TXDATA43": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA43"
+                    },
+                    "TXDATA44": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA44"
+                    },
+                    "TXDATA45": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA45"
+                    },
+                    "TXDATA46": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA46"
+                    },
+                    "TXDATA47": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA47"
+                    },
+                    "TXDATA48": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA48"
+                    },
+                    "TXDATA49": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA49"
+                    },
+                    "TXDATA50": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA50"
+                    },
+                    "TXDATA51": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA51"
+                    },
+                    "TXDATA52": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA52"
+                    },
+                    "TXDATA53": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA53"
+                    },
+                    "TXDATA54": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA54"
+                    },
+                    "TXDATA55": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA55"
+                    },
+                    "TXDATA56": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA56"
+                    },
+                    "TXDATA57": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA57"
+                    },
+                    "TXDATA58": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA58"
+                    },
+                    "TXDATA59": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA59"
+                    },
+                    "TXDATA60": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA60"
+                    },
+                    "TXDATA61": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA61"
+                    },
+                    "TXDATA62": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA62"
+                    },
+                    "TXDATA63": {
+                        "dir": "INPUT",
+                        "wire": "TXDATA63"
+                    },
+                    "TXDEEMPH": {
+                        "dir": "INPUT",
+                        "wire": "TXDEEMPH"
+                    },
+                    "TXDETECTRX": {
+                        "dir": "INPUT",
+                        "wire": "TXDETECTRX"
+                    },
+                    "TXDIFFCTRL0": {
+                        "dir": "INPUT",
+                        "wire": "TXDIFFCTRL0"
+                    },
+                    "TXDIFFCTRL1": {
+                        "dir": "INPUT",
+                        "wire": "TXDIFFCTRL1"
+                    },
+                    "TXDIFFCTRL2": {
+                        "dir": "INPUT",
+                        "wire": "TXDIFFCTRL2"
+                    },
+                    "TXDIFFCTRL3": {
+                        "dir": "INPUT",
+                        "wire": "TXDIFFCTRL3"
+                    },
+                    "TXDIFFPD": {
+                        "dir": "INPUT",
+                        "wire": "TXDIFFPD"
+                    },
+                    "TXDLYBYPASS": {
+                        "dir": "INPUT",
+                        "wire": "TXDLYBYPASS"
+                    },
+                    "TXDLYEN": {
+                        "dir": "INPUT",
+                        "wire": "TXDLYEN"
+                    },
+                    "TXDLYHOLD": {
+                        "dir": "INPUT",
+                        "wire": "TXDLYHOLD"
+                    },
+                    "TXDLYOVRDEN": {
+                        "dir": "INPUT",
+                        "wire": "TXDLYOVRDEN"
+                    },
+                    "TXDLYSRESET": {
+                        "dir": "INPUT",
+                        "wire": "TXDLYSRESET"
+                    },
+                    "TXDLYSRESETDONE": {
+                        "dir": "OUTPUT",
+                        "wire": "TXDLYSRESETDONE"
+                    },
+                    "TXDLYTESTENB": {
+                        "dir": "INPUT",
+                        "wire": "TXDLYTESTENB"
+                    },
+                    "TXDLYUPDOWN": {
+                        "dir": "INPUT",
+                        "wire": "TXDLYUPDOWN"
+                    },
+                    "TXELECIDLE": {
+                        "dir": "INPUT",
+                        "wire": "TXELECIDLE"
+                    },
+                    "TXGEARBOXREADY": {
+                        "dir": "OUTPUT",
+                        "wire": "TXGEARBOXREADY"
+                    },
+                    "TXHEADER0": {
+                        "dir": "INPUT",
+                        "wire": "TXHEADER0"
+                    },
+                    "TXHEADER1": {
+                        "dir": "INPUT",
+                        "wire": "TXHEADER1"
+                    },
+                    "TXHEADER2": {
+                        "dir": "INPUT",
+                        "wire": "TXHEADER2"
+                    },
+                    "TXINHIBIT": {
+                        "dir": "INPUT",
+                        "wire": "TXINHIBIT"
+                    },
+                    "TXMAINCURSOR0": {
+                        "dir": "INPUT",
+                        "wire": "TXMAINCURSOR0"
+                    },
+                    "TXMAINCURSOR1": {
+                        "dir": "INPUT",
+                        "wire": "TXMAINCURSOR1"
+                    },
+                    "TXMAINCURSOR2": {
+                        "dir": "INPUT",
+                        "wire": "TXMAINCURSOR2"
+                    },
+                    "TXMAINCURSOR3": {
+                        "dir": "INPUT",
+                        "wire": "TXMAINCURSOR3"
+                    },
+                    "TXMAINCURSOR4": {
+                        "dir": "INPUT",
+                        "wire": "TXMAINCURSOR4"
+                    },
+                    "TXMAINCURSOR5": {
+                        "dir": "INPUT",
+                        "wire": "TXMAINCURSOR5"
+                    },
+                    "TXMAINCURSOR6": {
+                        "dir": "INPUT",
+                        "wire": "TXMAINCURSOR6"
+                    },
+                    "TXMARGIN0": {
+                        "dir": "INPUT",
+                        "wire": "TXMARGIN0"
+                    },
+                    "TXMARGIN1": {
+                        "dir": "INPUT",
+                        "wire": "TXMARGIN1"
+                    },
+                    "TXMARGIN2": {
+                        "dir": "INPUT",
+                        "wire": "TXMARGIN2"
+                    },
+                    "TXOUTCLK": {
+                        "dir": "OUTPUT",
+                        "wire": "TXOUTCLK"
+                    },
+                    "TXOUTCLKFABRIC": {
+                        "dir": "OUTPUT",
+                        "wire": "TXOUTCLKFABRIC"
+                    },
+                    "TXOUTCLKPCS": {
+                        "dir": "OUTPUT",
+                        "wire": "TXOUTCLKPCS"
+                    },
+                    "TXOUTCLKSEL0": {
+                        "dir": "INPUT",
+                        "wire": "TXOUTCLKSEL0"
+                    },
+                    "TXOUTCLKSEL1": {
+                        "dir": "INPUT",
+                        "wire": "TXOUTCLKSEL1"
+                    },
+                    "TXOUTCLKSEL2": {
+                        "dir": "INPUT",
+                        "wire": "TXOUTCLKSEL2"
+                    },
+                    "TXPCSRESET": {
+                        "dir": "INPUT",
+                        "wire": "TXPCSRESET"
+                    },
+                    "TXPD0": {
+                        "dir": "INPUT",
+                        "wire": "TXPD0"
+                    },
+                    "TXPD1": {
+                        "dir": "INPUT",
+                        "wire": "TXPD1"
+                    },
+                    "TXPDELECIDLEMODE": {
+                        "dir": "INPUT",
+                        "wire": "TXPDELECIDLEMODE"
+                    },
+                    "TXPHALIGN": {
+                        "dir": "INPUT",
+                        "wire": "TXPHALIGN"
+                    },
+                    "TXPHALIGNDONE": {
+                        "dir": "OUTPUT",
+                        "wire": "TXPHALIGNDONE"
+                    },
+                    "TXPHALIGNEN": {
+                        "dir": "INPUT",
+                        "wire": "TXPHALIGNEN"
+                    },
+                    "TXPHDLYPD": {
+                        "dir": "INPUT",
+                        "wire": "TXPHDLYPD"
+                    },
+                    "TXPHDLYRESET": {
+                        "dir": "INPUT",
+                        "wire": "TXPHDLYRESET"
+                    },
+                    "TXPHDLYTSTCLK": {
+                        "dir": "INPUT",
+                        "wire": "TXPHDLYTSTCLKINV_OUT"
+                    },
+                    "TXPHINIT": {
+                        "dir": "INPUT",
+                        "wire": "TXPHINIT"
+                    },
+                    "TXPHINITDONE": {
+                        "dir": "OUTPUT",
+                        "wire": "TXPHINITDONE"
+                    },
+                    "TXPHOVRDEN": {
+                        "dir": "INPUT",
+                        "wire": "TXPHOVRDEN"
+                    },
+                    "TXPISOPD": {
+                        "dir": "INPUT",
+                        "wire": "TXPISOPD"
+                    },
+                    "TXPMARESET": {
+                        "dir": "INPUT",
+                        "wire": "TXPMARESET"
+                    },
+                    "TXPOLARITY": {
+                        "dir": "INPUT",
+                        "wire": "TXPOLARITY"
+                    },
+                    "TXPOSTCURSOR0": {
+                        "dir": "INPUT",
+                        "wire": "TXPOSTCURSOR0"
+                    },
+                    "TXPOSTCURSOR1": {
+                        "dir": "INPUT",
+                        "wire": "TXPOSTCURSOR1"
+                    },
+                    "TXPOSTCURSOR2": {
+                        "dir": "INPUT",
+                        "wire": "TXPOSTCURSOR2"
+                    },
+                    "TXPOSTCURSOR3": {
+                        "dir": "INPUT",
+                        "wire": "TXPOSTCURSOR3"
+                    },
+                    "TXPOSTCURSOR4": {
+                        "dir": "INPUT",
+                        "wire": "TXPOSTCURSOR4"
+                    },
+                    "TXPOSTCURSORINV": {
+                        "dir": "INPUT",
+                        "wire": "TXPOSTCURSORINV"
+                    },
+                    "TXPRBSFORCEERR": {
+                        "dir": "INPUT",
+                        "wire": "TXPRBSFORCEERR"
+                    },
+                    "TXPRBSSEL0": {
+                        "dir": "INPUT",
+                        "wire": "TXPRBSSEL0"
+                    },
+                    "TXPRBSSEL1": {
+                        "dir": "INPUT",
+                        "wire": "TXPRBSSEL1"
+                    },
+                    "TXPRBSSEL2": {
+                        "dir": "INPUT",
+                        "wire": "TXPRBSSEL2"
+                    },
+                    "TXPRECURSOR0": {
+                        "dir": "INPUT",
+                        "wire": "TXPRECURSOR0"
+                    },
+                    "TXPRECURSOR1": {
+                        "dir": "INPUT",
+                        "wire": "TXPRECURSOR1"
+                    },
+                    "TXPRECURSOR2": {
+                        "dir": "INPUT",
+                        "wire": "TXPRECURSOR2"
+                    },
+                    "TXPRECURSOR3": {
+                        "dir": "INPUT",
+                        "wire": "TXPRECURSOR3"
+                    },
+                    "TXPRECURSOR4": {
+                        "dir": "INPUT",
+                        "wire": "TXPRECURSOR4"
+                    },
+                    "TXPRECURSORINV": {
+                        "dir": "INPUT",
+                        "wire": "TXPRECURSORINV"
+                    },
+                    "TXQPIBIASEN": {
+                        "dir": "INPUT",
+                        "wire": "TXQPIBIASEN"
+                    },
+                    "TXQPISENN": {
+                        "dir": "OUTPUT",
+                        "wire": "TXQPISENN"
+                    },
+                    "TXQPISENP": {
+                        "dir": "OUTPUT",
+                        "wire": "TXQPISENP"
+                    },
+                    "TXQPISTRONGPDOWN": {
+                        "dir": "INPUT",
+                        "wire": "TXQPISTRONGPDOWN"
+                    },
+                    "TXQPIWEAKPUP": {
+                        "dir": "INPUT",
+                        "wire": "TXQPIWEAKPUP"
+                    },
+                    "TXRATE0": {
+                        "dir": "INPUT",
+                        "wire": "TXRATE0"
+                    },
+                    "TXRATE1": {
+                        "dir": "INPUT",
+                        "wire": "TXRATE1"
+                    },
+                    "TXRATE2": {
+                        "dir": "INPUT",
+                        "wire": "TXRATE2"
+                    },
+                    "TXRATEDONE": {
+                        "dir": "OUTPUT",
+                        "wire": "TXRATEDONE"
+                    },
+                    "TXRESETDONE": {
+                        "dir": "OUTPUT",
+                        "wire": "TXRESETDONE"
+                    },
+                    "TXRUNDISP0": {
+                        "dir": "OUTPUT",
+                        "wire": "TXRUNDISP0"
+                    },
+                    "TXRUNDISP1": {
+                        "dir": "OUTPUT",
+                        "wire": "TXRUNDISP1"
+                    },
+                    "TXRUNDISP2": {
+                        "dir": "OUTPUT",
+                        "wire": "TXRUNDISP2"
+                    },
+                    "TXRUNDISP3": {
+                        "dir": "OUTPUT",
+                        "wire": "TXRUNDISP3"
+                    },
+                    "TXRUNDISP4": {
+                        "dir": "OUTPUT",
+                        "wire": "TXRUNDISP4"
+                    },
+                    "TXRUNDISP5": {
+                        "dir": "OUTPUT",
+                        "wire": "TXRUNDISP5"
+                    },
+                    "TXRUNDISP6": {
+                        "dir": "OUTPUT",
+                        "wire": "TXRUNDISP6"
+                    },
+                    "TXRUNDISP7": {
+                        "dir": "OUTPUT",
+                        "wire": "TXRUNDISP7"
+                    },
+                    "TXSEQUENCE0": {
+                        "dir": "INPUT",
+                        "wire": "TXSEQUENCE0"
+                    },
+                    "TXSEQUENCE1": {
+                        "dir": "INPUT",
+                        "wire": "TXSEQUENCE1"
+                    },
+                    "TXSEQUENCE2": {
+                        "dir": "INPUT",
+                        "wire": "TXSEQUENCE2"
+                    },
+                    "TXSEQUENCE3": {
+                        "dir": "INPUT",
+                        "wire": "TXSEQUENCE3"
+                    },
+                    "TXSEQUENCE4": {
+                        "dir": "INPUT",
+                        "wire": "TXSEQUENCE4"
+                    },
+                    "TXSEQUENCE5": {
+                        "dir": "INPUT",
+                        "wire": "TXSEQUENCE5"
+                    },
+                    "TXSEQUENCE6": {
+                        "dir": "INPUT",
+                        "wire": "TXSEQUENCE6"
+                    },
+                    "TXSTARTSEQ": {
+                        "dir": "INPUT",
+                        "wire": "TXSTARTSEQ"
+                    },
+                    "TXSWING": {
+                        "dir": "INPUT",
+                        "wire": "TXSWING"
+                    },
+                    "TXSYSCLKSEL0": {
+                        "dir": "INPUT",
+                        "wire": "TXSYSCLKSEL0"
+                    },
+                    "TXSYSCLKSEL1": {
+                        "dir": "INPUT",
+                        "wire": "TXSYSCLKSEL1"
+                    },
+                    "TXUSERRDY": {
+                        "dir": "INPUT",
+                        "wire": "TXUSERRDY"
+                    },
+                    "TXUSRCLK": {
+                        "dir": "INPUT",
+                        "wire": "TXUSRCLKINV_OUT"
+                    },
+                    "TXUSRCLK2": {
+                        "dir": "INPUT",
+                        "wire": "TXUSRCLK2INV_OUT"
+                    }
+                },
+                "type": "GTXE2_CHANNEL_GTXE2_CHANNEL"
+            },
+            "CPLLLOCKDETCLKINV": {
+                "class": "RBEL",
+                "pins": {
+                    "CPLLLOCKDETCLK": {
+                        "dir": "INPUT",
+                        "wire": "CPLLLOCKDETCLK"
+                    },
+                    "CPLLLOCKDETCLK_B": {
+                        "dir": "INPUT",
+                        "wire": "CPLLLOCKDETCLK"
+                    },
+                    "OUT": {
+                        "dir": "OUTPUT",
+                        "wire": "CPLLLOCKDETCLKINV_OUT"
+                    }
+                },
+                "type": "GTXE2_CHANNEL_CPLLLOCKDETCLKINV"
+            },
+            "DRPCLKINV": {
+                "class": "RBEL",
+                "pins": {
+                    "DRPCLK": {
+                        "dir": "INPUT",
+                        "wire": "DRPCLK"
+                    },
+                    "DRPCLK_B": {
+                        "dir": "INPUT",
+                        "wire": "DRPCLK"
+                    },
+                    "OUT": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPCLKINV_OUT"
+                    }
+                },
+                "type": "GTXE2_CHANNEL_DRPCLKINV"
+            },
+            "EDTCLOCKINV": {
+                "class": "RBEL",
+                "pins": {
+                    "EDTCLOCK": {
+                        "dir": "INPUT",
+                        "wire": "EDTCLOCK"
+                    },
+                    "EDTCLOCK_B": {
+                        "dir": "INPUT",
+                        "wire": "EDTCLOCK"
+                    },
+                    "OUT": {
+                        "dir": "OUTPUT",
+                        "wire": "EDTCLOCKINV_OUT"
+                    }
+                },
+                "type": "GTXE2_CHANNEL_EDTCLOCKINV"
+            },
+            "GTGREFCLKINV": {
+                "class": "RBEL",
+                "pins": {
+                    "GTGREFCLK": {
+                        "dir": "INPUT",
+                        "wire": "GTGREFCLK"
+                    },
+                    "GTGREFCLK_B": {
+                        "dir": "INPUT",
+                        "wire": "GTGREFCLK"
+                    },
+                    "OUT": {
+                        "dir": "OUTPUT",
+                        "wire": "GTGREFCLKINV_OUT"
+                    }
+                },
+                "type": "GTXE2_CHANNEL_GTGREFCLKINV"
+            },
+            "PMASCANCLK0INV": {
+                "class": "RBEL",
+                "pins": {
+                    "OUT": {
+                        "dir": "OUTPUT",
+                        "wire": "PMASCANCLK0INV_OUT"
+                    },
+                    "PMASCANCLK0": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANCLK0"
+                    },
+                    "PMASCANCLK0_B": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANCLK0"
+                    }
+                },
+                "type": "GTXE2_CHANNEL_PMASCANCLK0INV"
+            },
+            "PMASCANCLK1INV": {
+                "class": "RBEL",
+                "pins": {
+                    "OUT": {
+                        "dir": "OUTPUT",
+                        "wire": "PMASCANCLK1INV_OUT"
+                    },
+                    "PMASCANCLK1": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANCLK1"
+                    },
+                    "PMASCANCLK1_B": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANCLK1"
+                    }
+                },
+                "type": "GTXE2_CHANNEL_PMASCANCLK1INV"
+            },
+            "PMASCANCLK2INV": {
+                "class": "RBEL",
+                "pins": {
+                    "OUT": {
+                        "dir": "OUTPUT",
+                        "wire": "PMASCANCLK2INV_OUT"
+                    },
+                    "PMASCANCLK2": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANCLK2"
+                    },
+                    "PMASCANCLK2_B": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANCLK2"
+                    }
+                },
+                "type": "GTXE2_CHANNEL_PMASCANCLK2INV"
+            },
+            "PMASCANCLK3INV": {
+                "class": "RBEL",
+                "pins": {
+                    "OUT": {
+                        "dir": "OUTPUT",
+                        "wire": "PMASCANCLK3INV_OUT"
+                    },
+                    "PMASCANCLK3": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANCLK3"
+                    },
+                    "PMASCANCLK3_B": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANCLK3"
+                    }
+                },
+                "type": "GTXE2_CHANNEL_PMASCANCLK3INV"
+            },
+            "PMASCANCLK4INV": {
+                "class": "RBEL",
+                "pins": {
+                    "OUT": {
+                        "dir": "OUTPUT",
+                        "wire": "PMASCANCLK4INV_OUT"
+                    },
+                    "PMASCANCLK4": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANCLK4"
+                    },
+                    "PMASCANCLK4_B": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANCLK4"
+                    }
+                },
+                "type": "GTXE2_CHANNEL_PMASCANCLK4INV"
+            },
+            "RXUSRCLKINV": {
+                "class": "RBEL",
+                "pins": {
+                    "OUT": {
+                        "dir": "OUTPUT",
+                        "wire": "RXUSRCLKINV_OUT"
+                    },
+                    "RXUSRCLK": {
+                        "dir": "INPUT",
+                        "wire": "RXUSRCLK"
+                    },
+                    "RXUSRCLK_B": {
+                        "dir": "INPUT",
+                        "wire": "RXUSRCLK"
+                    }
+                },
+                "type": "GTXE2_CHANNEL_RXUSRCLKINV"
+            },
+            "RXUSRCLK2INV": {
+                "class": "RBEL",
+                "pins": {
+                    "OUT": {
+                        "dir": "OUTPUT",
+                        "wire": "RXUSRCLK2INV_OUT"
+                    },
+                    "RXUSRCLK2": {
+                        "dir": "INPUT",
+                        "wire": "RXUSRCLK2"
+                    },
+                    "RXUSRCLK2_B": {
+                        "dir": "INPUT",
+                        "wire": "RXUSRCLK2"
+                    }
+                },
+                "type": "GTXE2_CHANNEL_RXUSRCLK2INV"
+            },
+            "SCANCLKINV": {
+                "class": "RBEL",
+                "pins": {
+                    "OUT": {
+                        "dir": "OUTPUT",
+                        "wire": "SCANCLKINV_OUT"
+                    },
+                    "SCANCLK": {
+                        "dir": "INPUT",
+                        "wire": "SCANCLK"
+                    },
+                    "SCANCLK_B": {
+                        "dir": "INPUT",
+                        "wire": "SCANCLK"
+                    }
+                },
+                "type": "GTXE2_CHANNEL_SCANCLKINV"
+            },
+            "TSTCLK0INV": {
+                "class": "RBEL",
+                "pins": {
+                    "OUT": {
+                        "dir": "OUTPUT",
+                        "wire": "TSTCLK0INV_OUT"
+                    },
+                    "TSTCLK0": {
+                        "dir": "INPUT",
+                        "wire": "TSTCLK0"
+                    },
+                    "TSTCLK0_B": {
+                        "dir": "INPUT",
+                        "wire": "TSTCLK0"
+                    }
+                },
+                "type": "GTXE2_CHANNEL_TSTCLK0INV"
+            },
+            "TSTCLK1INV": {
+                "class": "RBEL",
+                "pins": {
+                    "OUT": {
+                        "dir": "OUTPUT",
+                        "wire": "TSTCLK1INV_OUT"
+                    },
+                    "TSTCLK1": {
+                        "dir": "INPUT",
+                        "wire": "TSTCLK1"
+                    },
+                    "TSTCLK1_B": {
+                        "dir": "INPUT",
+                        "wire": "TSTCLK1"
+                    }
+                },
+                "type": "GTXE2_CHANNEL_TSTCLK1INV"
+            },
+            "TXPHDLYTSTCLKINV": {
+                "class": "RBEL",
+                "pins": {
+                    "OUT": {
+                        "dir": "OUTPUT",
+                        "wire": "TXPHDLYTSTCLKINV_OUT"
+                    },
+                    "TXPHDLYTSTCLK": {
+                        "dir": "INPUT",
+                        "wire": "TXPHDLYTSTCLK"
+                    },
+                    "TXPHDLYTSTCLK_B": {
+                        "dir": "INPUT",
+                        "wire": "TXPHDLYTSTCLK"
+                    }
+                },
+                "type": "GTXE2_CHANNEL_TXPHDLYTSTCLKINV"
+            },
+            "TXUSRCLKINV": {
+                "class": "RBEL",
+                "pins": {
+                    "OUT": {
+                        "dir": "OUTPUT",
+                        "wire": "TXUSRCLKINV_OUT"
+                    },
+                    "TXUSRCLK": {
+                        "dir": "INPUT",
+                        "wire": "TXUSRCLK"
+                    },
+                    "TXUSRCLK_B": {
+                        "dir": "INPUT",
+                        "wire": "TXUSRCLK"
+                    }
+                },
+                "type": "GTXE2_CHANNEL_TXUSRCLKINV"
+            },
+            "TXUSRCLK2INV": {
+                "class": "RBEL",
+                "pins": {
+                    "OUT": {
+                        "dir": "OUTPUT",
+                        "wire": "TXUSRCLK2INV_OUT"
+                    },
+                    "TXUSRCLK2": {
+                        "dir": "INPUT",
+                        "wire": "TXUSRCLK2"
+                    },
+                    "TXUSRCLK2_B": {
+                        "dir": "INPUT",
+                        "wire": "TXUSRCLK2"
+                    }
+                },
+                "type": "GTXE2_CHANNEL_TXUSRCLK2INV"
+            }
+        },
+        "pips": [
+            {
+                "bel": "CPLLLOCKDETCLKINV",
+                "from_pin": "CPLLLOCKDETCLK",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "CPLLLOCKDETCLKINV",
+                "from_pin": "CPLLLOCKDETCLK_B",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "DRPCLKINV",
+                "from_pin": "DRPCLK",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "DRPCLKINV",
+                "from_pin": "DRPCLK_B",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "EDTCLOCKINV",
+                "from_pin": "EDTCLOCK",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "EDTCLOCKINV",
+                "from_pin": "EDTCLOCK_B",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "GTGREFCLKINV",
+                "from_pin": "GTGREFCLK",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "GTGREFCLKINV",
+                "from_pin": "GTGREFCLK_B",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "PMASCANCLK0INV",
+                "from_pin": "PMASCANCLK0",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "PMASCANCLK0INV",
+                "from_pin": "PMASCANCLK0_B",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "PMASCANCLK1INV",
+                "from_pin": "PMASCANCLK1",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "PMASCANCLK1INV",
+                "from_pin": "PMASCANCLK1_B",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "PMASCANCLK2INV",
+                "from_pin": "PMASCANCLK2",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "PMASCANCLK2INV",
+                "from_pin": "PMASCANCLK2_B",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "PMASCANCLK3INV",
+                "from_pin": "PMASCANCLK3",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "PMASCANCLK3INV",
+                "from_pin": "PMASCANCLK3_B",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "PMASCANCLK4INV",
+                "from_pin": "PMASCANCLK4",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "PMASCANCLK4INV",
+                "from_pin": "PMASCANCLK4_B",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "RXUSRCLKINV",
+                "from_pin": "RXUSRCLK",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "RXUSRCLKINV",
+                "from_pin": "RXUSRCLK_B",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "RXUSRCLK2INV",
+                "from_pin": "RXUSRCLK2",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "RXUSRCLK2INV",
+                "from_pin": "RXUSRCLK2_B",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "SCANCLKINV",
+                "from_pin": "SCANCLK",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "SCANCLKINV",
+                "from_pin": "SCANCLK_B",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "TSTCLK0INV",
+                "from_pin": "TSTCLK0",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "TSTCLK0INV",
+                "from_pin": "TSTCLK0_B",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "TSTCLK1INV",
+                "from_pin": "TSTCLK1",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "TSTCLK1INV",
+                "from_pin": "TSTCLK1_B",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "TXPHDLYTSTCLKINV",
+                "from_pin": "TXPHDLYTSTCLK",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "TXPHDLYTSTCLKINV",
+                "from_pin": "TXPHDLYTSTCLK_B",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "TXUSRCLKINV",
+                "from_pin": "TXUSRCLK",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "TXUSRCLKINV",
+                "from_pin": "TXUSRCLK_B",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "TXUSRCLK2INV",
+                "from_pin": "TXUSRCLK2",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "TXUSRCLK2INV",
+                "from_pin": "TXUSRCLK2_B",
+                "to_pin": "OUT"
+            }
+        ],
+        "pins": {
+            "CFGRESET": {
+                "primary": "CFGRESET",
+                "dir": "INPUT",
+                "wire": "CFGRESET"
+            },
+            "CLKRSVD0": {
+                "primary": "CLKRSVD0",
+                "dir": "INPUT",
+                "wire": "CLKRSVD0"
+            },
+            "CLKRSVD1": {
+                "primary": "CLKRSVD1",
+                "dir": "INPUT",
+                "wire": "CLKRSVD1"
+            },
+            "CLKRSVD2": {
+                "primary": "CLKRSVD2",
+                "dir": "INPUT",
+                "wire": "CLKRSVD2"
+            },
+            "CLKRSVD3": {
+                "primary": "CLKRSVD3",
+                "dir": "INPUT",
+                "wire": "CLKRSVD3"
+            },
+            "CPLLFBCLKLOST": {
+                "primary": "CPLLFBCLKLOST",
+                "dir": "OUTPUT",
+                "wire": "CPLLFBCLKLOST"
+            },
+            "CPLLLOCK": {
+                "primary": "CPLLLOCK",
+                "dir": "OUTPUT",
+                "wire": "CPLLLOCK"
+            },
+            "CPLLLOCKDETCLK": {
+                "primary": "CPLLLOCKDETCLK",
+                "dir": "INPUT",
+                "wire": "CPLLLOCKDETCLK"
+            },
+            "CPLLLOCKEN": {
+                "primary": "CPLLLOCKEN",
+                "dir": "INPUT",
+                "wire": "CPLLLOCKEN"
+            },
+            "CPLLPD": {
+                "primary": "CPLLPD",
+                "dir": "INPUT",
+                "wire": "CPLLPD"
+            },
+            "CPLLREFCLKLOST": {
+                "primary": "CPLLREFCLKLOST",
+                "dir": "OUTPUT",
+                "wire": "CPLLREFCLKLOST"
+            },
+            "CPLLREFCLKSEL0": {
+                "primary": "CPLLREFCLKSEL0",
+                "dir": "INPUT",
+                "wire": "CPLLREFCLKSEL0"
+            },
+            "CPLLREFCLKSEL1": {
+                "primary": "CPLLREFCLKSEL1",
+                "dir": "INPUT",
+                "wire": "CPLLREFCLKSEL1"
+            },
+            "CPLLREFCLKSEL2": {
+                "primary": "CPLLREFCLKSEL2",
+                "dir": "INPUT",
+                "wire": "CPLLREFCLKSEL2"
+            },
+            "CPLLRESET": {
+                "primary": "CPLLRESET",
+                "dir": "INPUT",
+                "wire": "CPLLRESET"
+            },
+            "DMONITOROUT0": {
+                "primary": "DMONITOROUT0",
+                "dir": "OUTPUT",
+                "wire": "DMONITOROUT0"
+            },
+            "DMONITOROUT1": {
+                "primary": "DMONITOROUT1",
+                "dir": "OUTPUT",
+                "wire": "DMONITOROUT1"
+            },
+            "DMONITOROUT2": {
+                "primary": "DMONITOROUT2",
+                "dir": "OUTPUT",
+                "wire": "DMONITOROUT2"
+            },
+            "DMONITOROUT3": {
+                "primary": "DMONITOROUT3",
+                "dir": "OUTPUT",
+                "wire": "DMONITOROUT3"
+            },
+            "DMONITOROUT4": {
+                "primary": "DMONITOROUT4",
+                "dir": "OUTPUT",
+                "wire": "DMONITOROUT4"
+            },
+            "DMONITOROUT5": {
+                "primary": "DMONITOROUT5",
+                "dir": "OUTPUT",
+                "wire": "DMONITOROUT5"
+            },
+            "DMONITOROUT6": {
+                "primary": "DMONITOROUT6",
+                "dir": "OUTPUT",
+                "wire": "DMONITOROUT6"
+            },
+            "DMONITOROUT7": {
+                "primary": "DMONITOROUT7",
+                "dir": "OUTPUT",
+                "wire": "DMONITOROUT7"
+            },
+            "DRPADDR0": {
+                "primary": "DRPADDR0",
+                "dir": "INPUT",
+                "wire": "DRPADDR0"
+            },
+            "DRPADDR1": {
+                "primary": "DRPADDR1",
+                "dir": "INPUT",
+                "wire": "DRPADDR1"
+            },
+            "DRPADDR2": {
+                "primary": "DRPADDR2",
+                "dir": "INPUT",
+                "wire": "DRPADDR2"
+            },
+            "DRPADDR3": {
+                "primary": "DRPADDR3",
+                "dir": "INPUT",
+                "wire": "DRPADDR3"
+            },
+            "DRPADDR4": {
+                "primary": "DRPADDR4",
+                "dir": "INPUT",
+                "wire": "DRPADDR4"
+            },
+            "DRPADDR5": {
+                "primary": "DRPADDR5",
+                "dir": "INPUT",
+                "wire": "DRPADDR5"
+            },
+            "DRPADDR6": {
+                "primary": "DRPADDR6",
+                "dir": "INPUT",
+                "wire": "DRPADDR6"
+            },
+            "DRPADDR7": {
+                "primary": "DRPADDR7",
+                "dir": "INPUT",
+                "wire": "DRPADDR7"
+            },
+            "DRPADDR8": {
+                "primary": "DRPADDR8",
+                "dir": "INPUT",
+                "wire": "DRPADDR8"
+            },
+            "DRPCLK": {
+                "primary": "DRPCLK",
+                "dir": "INPUT",
+                "wire": "DRPCLK"
+            },
+            "DRPDI0": {
+                "primary": "DRPDI0",
+                "dir": "INPUT",
+                "wire": "DRPDI0"
+            },
+            "DRPDI1": {
+                "primary": "DRPDI1",
+                "dir": "INPUT",
+                "wire": "DRPDI1"
+            },
+            "DRPDI2": {
+                "primary": "DRPDI2",
+                "dir": "INPUT",
+                "wire": "DRPDI2"
+            },
+            "DRPDI3": {
+                "primary": "DRPDI3",
+                "dir": "INPUT",
+                "wire": "DRPDI3"
+            },
+            "DRPDI4": {
+                "primary": "DRPDI4",
+                "dir": "INPUT",
+                "wire": "DRPDI4"
+            },
+            "DRPDI5": {
+                "primary": "DRPDI5",
+                "dir": "INPUT",
+                "wire": "DRPDI5"
+            },
+            "DRPDI6": {
+                "primary": "DRPDI6",
+                "dir": "INPUT",
+                "wire": "DRPDI6"
+            },
+            "DRPDI7": {
+                "primary": "DRPDI7",
+                "dir": "INPUT",
+                "wire": "DRPDI7"
+            },
+            "DRPDI8": {
+                "primary": "DRPDI8",
+                "dir": "INPUT",
+                "wire": "DRPDI8"
+            },
+            "DRPDI9": {
+                "primary": "DRPDI9",
+                "dir": "INPUT",
+                "wire": "DRPDI9"
+            },
+            "DRPDI10": {
+                "primary": "DRPDI10",
+                "dir": "INPUT",
+                "wire": "DRPDI10"
+            },
+            "DRPDI11": {
+                "primary": "DRPDI11",
+                "dir": "INPUT",
+                "wire": "DRPDI11"
+            },
+            "DRPDI12": {
+                "primary": "DRPDI12",
+                "dir": "INPUT",
+                "wire": "DRPDI12"
+            },
+            "DRPDI13": {
+                "primary": "DRPDI13",
+                "dir": "INPUT",
+                "wire": "DRPDI13"
+            },
+            "DRPDI14": {
+                "primary": "DRPDI14",
+                "dir": "INPUT",
+                "wire": "DRPDI14"
+            },
+            "DRPDI15": {
+                "primary": "DRPDI15",
+                "dir": "INPUT",
+                "wire": "DRPDI15"
+            },
+            "DRPDO0": {
+                "primary": "DRPDO0",
+                "dir": "OUTPUT",
+                "wire": "DRPDO0"
+            },
+            "DRPDO1": {
+                "primary": "DRPDO1",
+                "dir": "OUTPUT",
+                "wire": "DRPDO1"
+            },
+            "DRPDO2": {
+                "primary": "DRPDO2",
+                "dir": "OUTPUT",
+                "wire": "DRPDO2"
+            },
+            "DRPDO3": {
+                "primary": "DRPDO3",
+                "dir": "OUTPUT",
+                "wire": "DRPDO3"
+            },
+            "DRPDO4": {
+                "primary": "DRPDO4",
+                "dir": "OUTPUT",
+                "wire": "DRPDO4"
+            },
+            "DRPDO5": {
+                "primary": "DRPDO5",
+                "dir": "OUTPUT",
+                "wire": "DRPDO5"
+            },
+            "DRPDO6": {
+                "primary": "DRPDO6",
+                "dir": "OUTPUT",
+                "wire": "DRPDO6"
+            },
+            "DRPDO7": {
+                "primary": "DRPDO7",
+                "dir": "OUTPUT",
+                "wire": "DRPDO7"
+            },
+            "DRPDO8": {
+                "primary": "DRPDO8",
+                "dir": "OUTPUT",
+                "wire": "DRPDO8"
+            },
+            "DRPDO9": {
+                "primary": "DRPDO9",
+                "dir": "OUTPUT",
+                "wire": "DRPDO9"
+            },
+            "DRPDO10": {
+                "primary": "DRPDO10",
+                "dir": "OUTPUT",
+                "wire": "DRPDO10"
+            },
+            "DRPDO11": {
+                "primary": "DRPDO11",
+                "dir": "OUTPUT",
+                "wire": "DRPDO11"
+            },
+            "DRPDO12": {
+                "primary": "DRPDO12",
+                "dir": "OUTPUT",
+                "wire": "DRPDO12"
+            },
+            "DRPDO13": {
+                "primary": "DRPDO13",
+                "dir": "OUTPUT",
+                "wire": "DRPDO13"
+            },
+            "DRPDO14": {
+                "primary": "DRPDO14",
+                "dir": "OUTPUT",
+                "wire": "DRPDO14"
+            },
+            "DRPDO15": {
+                "primary": "DRPDO15",
+                "dir": "OUTPUT",
+                "wire": "DRPDO15"
+            },
+            "DRPEN": {
+                "primary": "DRPEN",
+                "dir": "INPUT",
+                "wire": "DRPEN"
+            },
+            "DRPRDY": {
+                "primary": "DRPRDY",
+                "dir": "OUTPUT",
+                "wire": "DRPRDY"
+            },
+            "DRPWE": {
+                "primary": "DRPWE",
+                "dir": "INPUT",
+                "wire": "DRPWE"
+            },
+            "EDTBYPASS": {
+                "primary": "EDTBYPASS",
+                "dir": "INPUT",
+                "wire": "EDTBYPASS"
+            },
+            "EDTCLOCK": {
+                "primary": "EDTCLOCK",
+                "dir": "INPUT",
+                "wire": "EDTCLOCK"
+            },
+            "EDTCONFIGURATION": {
+                "primary": "EDTCONFIGURATION",
+                "dir": "INPUT",
+                "wire": "EDTCONFIGURATION"
+            },
+            "EDTSINGLEBYPASSCHAIN": {
+                "primary": "EDTSINGLEBYPASSCHAIN",
+                "dir": "INPUT",
+                "wire": "EDTSINGLEBYPASSCHAIN"
+            },
+            "EDTUPDATE": {
+                "primary": "EDTUPDATE",
+                "dir": "INPUT",
+                "wire": "EDTUPDATE"
+            },
+            "EYESCANDATAERROR": {
+                "primary": "EYESCANDATAERROR",
+                "dir": "OUTPUT",
+                "wire": "EYESCANDATAERROR"
+            },
+            "EYESCANMODE": {
+                "primary": "EYESCANMODE",
+                "dir": "INPUT",
+                "wire": "EYESCANMODE"
+            },
+            "EYESCANRESET": {
+                "primary": "EYESCANRESET",
+                "dir": "INPUT",
+                "wire": "EYESCANRESET"
+            },
+            "EYESCANTRIGGER": {
+                "primary": "EYESCANTRIGGER",
+                "dir": "INPUT",
+                "wire": "EYESCANTRIGGER"
+            },
+            "GTGREFCLK": {
+                "primary": "GTGREFCLK",
+                "dir": "INPUT",
+                "wire": "GTGREFCLK"
+            },
+            "GTNORTHREFCLK0": {
+                "primary": "GTNORTHREFCLK0",
+                "dir": "INPUT",
+                "wire": "GTNORTHREFCLK0"
+            },
+            "GTNORTHREFCLK1": {
+                "primary": "GTNORTHREFCLK1",
+                "dir": "INPUT",
+                "wire": "GTNORTHREFCLK1"
+            },
+            "GTREFCLK0": {
+                "primary": "GTREFCLK0",
+                "dir": "INPUT",
+                "wire": "GTREFCLK0"
+            },
+            "GTREFCLK1": {
+                "primary": "GTREFCLK1",
+                "dir": "INPUT",
+                "wire": "GTREFCLK1"
+            },
+            "GTREFCLKMONITOR": {
+                "primary": "GTREFCLKMONITOR",
+                "dir": "OUTPUT",
+                "wire": "GTREFCLKMONITOR"
+            },
+            "GTRESETSEL": {
+                "primary": "GTRESETSEL",
+                "dir": "INPUT",
+                "wire": "GTRESETSEL"
+            },
+            "GTRSVD0": {
+                "primary": "GTRSVD0",
+                "dir": "INPUT",
+                "wire": "GTRSVD0"
+            },
+            "GTRSVD1": {
+                "primary": "GTRSVD1",
+                "dir": "INPUT",
+                "wire": "GTRSVD1"
+            },
+            "GTRSVD2": {
+                "primary": "GTRSVD2",
+                "dir": "INPUT",
+                "wire": "GTRSVD2"
+            },
+            "GTRSVD3": {
+                "primary": "GTRSVD3",
+                "dir": "INPUT",
+                "wire": "GTRSVD3"
+            },
+            "GTRSVD4": {
+                "primary": "GTRSVD4",
+                "dir": "INPUT",
+                "wire": "GTRSVD4"
+            },
+            "GTRSVD5": {
+                "primary": "GTRSVD5",
+                "dir": "INPUT",
+                "wire": "GTRSVD5"
+            },
+            "GTRSVD6": {
+                "primary": "GTRSVD6",
+                "dir": "INPUT",
+                "wire": "GTRSVD6"
+            },
+            "GTRSVD7": {
+                "primary": "GTRSVD7",
+                "dir": "INPUT",
+                "wire": "GTRSVD7"
+            },
+            "GTRSVD8": {
+                "primary": "GTRSVD8",
+                "dir": "INPUT",
+                "wire": "GTRSVD8"
+            },
+            "GTRSVD9": {
+                "primary": "GTRSVD9",
+                "dir": "INPUT",
+                "wire": "GTRSVD9"
+            },
+            "GTRSVD10": {
+                "primary": "GTRSVD10",
+                "dir": "INPUT",
+                "wire": "GTRSVD10"
+            },
+            "GTRSVD11": {
+                "primary": "GTRSVD11",
+                "dir": "INPUT",
+                "wire": "GTRSVD11"
+            },
+            "GTRSVD12": {
+                "primary": "GTRSVD12",
+                "dir": "INPUT",
+                "wire": "GTRSVD12"
+            },
+            "GTRSVD13": {
+                "primary": "GTRSVD13",
+                "dir": "INPUT",
+                "wire": "GTRSVD13"
+            },
+            "GTRSVD14": {
+                "primary": "GTRSVD14",
+                "dir": "INPUT",
+                "wire": "GTRSVD14"
+            },
+            "GTRSVD15": {
+                "primary": "GTRSVD15",
+                "dir": "INPUT",
+                "wire": "GTRSVD15"
+            },
+            "GTRXRESET": {
+                "primary": "GTRXRESET",
+                "dir": "INPUT",
+                "wire": "GTRXRESET"
+            },
+            "GTSOUTHREFCLK0": {
+                "primary": "GTSOUTHREFCLK0",
+                "dir": "INPUT",
+                "wire": "GTSOUTHREFCLK0"
+            },
+            "GTSOUTHREFCLK1": {
+                "primary": "GTSOUTHREFCLK1",
+                "dir": "INPUT",
+                "wire": "GTSOUTHREFCLK1"
+            },
+            "GTTXRESET": {
+                "primary": "GTTXRESET",
+                "dir": "INPUT",
+                "wire": "GTTXRESET"
+            },
+            "GTXRXN": {
+                "primary": "GTXRXN",
+                "dir": "INPUT",
+                "wire": "GTXRXN"
+            },
+            "GTXRXP": {
+                "primary": "GTXRXP",
+                "dir": "INPUT",
+                "wire": "GTXRXP"
+            },
+            "GTXTXN": {
+                "primary": "GTXTXN",
+                "dir": "OUTPUT",
+                "wire": "GTXTXN"
+            },
+            "GTXTXP": {
+                "primary": "GTXTXP",
+                "dir": "OUTPUT",
+                "wire": "GTXTXP"
+            },
+            "LOOPBACK0": {
+                "primary": "LOOPBACK0",
+                "dir": "INPUT",
+                "wire": "LOOPBACK0"
+            },
+            "LOOPBACK1": {
+                "primary": "LOOPBACK1",
+                "dir": "INPUT",
+                "wire": "LOOPBACK1"
+            },
+            "LOOPBACK2": {
+                "primary": "LOOPBACK2",
+                "dir": "INPUT",
+                "wire": "LOOPBACK2"
+            },
+            "PCSRSVDIN0": {
+                "primary": "PCSRSVDIN0",
+                "dir": "INPUT",
+                "wire": "PCSRSVDIN0"
+            },
+            "PCSRSVDIN1": {
+                "primary": "PCSRSVDIN1",
+                "dir": "INPUT",
+                "wire": "PCSRSVDIN1"
+            },
+            "PCSRSVDIN2": {
+                "primary": "PCSRSVDIN2",
+                "dir": "INPUT",
+                "wire": "PCSRSVDIN2"
+            },
+            "PCSRSVDIN3": {
+                "primary": "PCSRSVDIN3",
+                "dir": "INPUT",
+                "wire": "PCSRSVDIN3"
+            },
+            "PCSRSVDIN4": {
+                "primary": "PCSRSVDIN4",
+                "dir": "INPUT",
+                "wire": "PCSRSVDIN4"
+            },
+            "PCSRSVDIN5": {
+                "primary": "PCSRSVDIN5",
+                "dir": "INPUT",
+                "wire": "PCSRSVDIN5"
+            },
+            "PCSRSVDIN6": {
+                "primary": "PCSRSVDIN6",
+                "dir": "INPUT",
+                "wire": "PCSRSVDIN6"
+            },
+            "PCSRSVDIN7": {
+                "primary": "PCSRSVDIN7",
+                "dir": "INPUT",
+                "wire": "PCSRSVDIN7"
+            },
+            "PCSRSVDIN8": {
+                "primary": "PCSRSVDIN8",
+                "dir": "INPUT",
+                "wire": "PCSRSVDIN8"
+            },
+            "PCSRSVDIN9": {
+                "primary": "PCSRSVDIN9",
+                "dir": "INPUT",
+                "wire": "PCSRSVDIN9"
+            },
+            "PCSRSVDIN10": {
+                "primary": "PCSRSVDIN10",
+                "dir": "INPUT",
+                "wire": "PCSRSVDIN10"
+            },
+            "PCSRSVDIN11": {
+                "primary": "PCSRSVDIN11",
+                "dir": "INPUT",
+                "wire": "PCSRSVDIN11"
+            },
+            "PCSRSVDIN12": {
+                "primary": "PCSRSVDIN12",
+                "dir": "INPUT",
+                "wire": "PCSRSVDIN12"
+            },
+            "PCSRSVDIN13": {
+                "primary": "PCSRSVDIN13",
+                "dir": "INPUT",
+                "wire": "PCSRSVDIN13"
+            },
+            "PCSRSVDIN14": {
+                "primary": "PCSRSVDIN14",
+                "dir": "INPUT",
+                "wire": "PCSRSVDIN14"
+            },
+            "PCSRSVDIN15": {
+                "primary": "PCSRSVDIN15",
+                "dir": "INPUT",
+                "wire": "PCSRSVDIN15"
+            },
+            "PCSRSVDIN20": {
+                "primary": "PCSRSVDIN20",
+                "dir": "INPUT",
+                "wire": "PCSRSVDIN20"
+            },
+            "PCSRSVDIN21": {
+                "primary": "PCSRSVDIN21",
+                "dir": "INPUT",
+                "wire": "PCSRSVDIN21"
+            },
+            "PCSRSVDIN22": {
+                "primary": "PCSRSVDIN22",
+                "dir": "INPUT",
+                "wire": "PCSRSVDIN22"
+            },
+            "PCSRSVDIN23": {
+                "primary": "PCSRSVDIN23",
+                "dir": "INPUT",
+                "wire": "PCSRSVDIN23"
+            },
+            "PCSRSVDIN24": {
+                "primary": "PCSRSVDIN24",
+                "dir": "INPUT",
+                "wire": "PCSRSVDIN24"
+            },
+            "PCSRSVDOUT0": {
+                "primary": "PCSRSVDOUT0",
+                "dir": "OUTPUT",
+                "wire": "PCSRSVDOUT0"
+            },
+            "PCSRSVDOUT1": {
+                "primary": "PCSRSVDOUT1",
+                "dir": "OUTPUT",
+                "wire": "PCSRSVDOUT1"
+            },
+            "PCSRSVDOUT2": {
+                "primary": "PCSRSVDOUT2",
+                "dir": "OUTPUT",
+                "wire": "PCSRSVDOUT2"
+            },
+            "PCSRSVDOUT3": {
+                "primary": "PCSRSVDOUT3",
+                "dir": "OUTPUT",
+                "wire": "PCSRSVDOUT3"
+            },
+            "PCSRSVDOUT4": {
+                "primary": "PCSRSVDOUT4",
+                "dir": "OUTPUT",
+                "wire": "PCSRSVDOUT4"
+            },
+            "PCSRSVDOUT5": {
+                "primary": "PCSRSVDOUT5",
+                "dir": "OUTPUT",
+                "wire": "PCSRSVDOUT5"
+            },
+            "PCSRSVDOUT6": {
+                "primary": "PCSRSVDOUT6",
+                "dir": "OUTPUT",
+                "wire": "PCSRSVDOUT6"
+            },
+            "PCSRSVDOUT7": {
+                "primary": "PCSRSVDOUT7",
+                "dir": "OUTPUT",
+                "wire": "PCSRSVDOUT7"
+            },
+            "PCSRSVDOUT8": {
+                "primary": "PCSRSVDOUT8",
+                "dir": "OUTPUT",
+                "wire": "PCSRSVDOUT8"
+            },
+            "PCSRSVDOUT9": {
+                "primary": "PCSRSVDOUT9",
+                "dir": "OUTPUT",
+                "wire": "PCSRSVDOUT9"
+            },
+            "PCSRSVDOUT10": {
+                "primary": "PCSRSVDOUT10",
+                "dir": "OUTPUT",
+                "wire": "PCSRSVDOUT10"
+            },
+            "PCSRSVDOUT11": {
+                "primary": "PCSRSVDOUT11",
+                "dir": "OUTPUT",
+                "wire": "PCSRSVDOUT11"
+            },
+            "PCSRSVDOUT12": {
+                "primary": "PCSRSVDOUT12",
+                "dir": "OUTPUT",
+                "wire": "PCSRSVDOUT12"
+            },
+            "PCSRSVDOUT13": {
+                "primary": "PCSRSVDOUT13",
+                "dir": "OUTPUT",
+                "wire": "PCSRSVDOUT13"
+            },
+            "PCSRSVDOUT14": {
+                "primary": "PCSRSVDOUT14",
+                "dir": "OUTPUT",
+                "wire": "PCSRSVDOUT14"
+            },
+            "PCSRSVDOUT15": {
+                "primary": "PCSRSVDOUT15",
+                "dir": "OUTPUT",
+                "wire": "PCSRSVDOUT15"
+            },
+            "PHYSTATUS": {
+                "primary": "PHYSTATUS",
+                "dir": "OUTPUT",
+                "wire": "PHYSTATUS"
+            },
+            "PMARSVDIN0": {
+                "primary": "PMARSVDIN0",
+                "dir": "INPUT",
+                "wire": "PMARSVDIN0"
+            },
+            "PMARSVDIN1": {
+                "primary": "PMARSVDIN1",
+                "dir": "INPUT",
+                "wire": "PMARSVDIN1"
+            },
+            "PMARSVDIN2": {
+                "primary": "PMARSVDIN2",
+                "dir": "INPUT",
+                "wire": "PMARSVDIN2"
+            },
+            "PMARSVDIN3": {
+                "primary": "PMARSVDIN3",
+                "dir": "INPUT",
+                "wire": "PMARSVDIN3"
+            },
+            "PMARSVDIN4": {
+                "primary": "PMARSVDIN4",
+                "dir": "INPUT",
+                "wire": "PMARSVDIN4"
+            },
+            "PMARSVDIN20": {
+                "primary": "PMARSVDIN20",
+                "dir": "INPUT",
+                "wire": "PMARSVDIN20"
+            },
+            "PMARSVDIN21": {
+                "primary": "PMARSVDIN21",
+                "dir": "INPUT",
+                "wire": "PMARSVDIN21"
+            },
+            "PMARSVDIN22": {
+                "primary": "PMARSVDIN22",
+                "dir": "INPUT",
+                "wire": "PMARSVDIN22"
+            },
+            "PMARSVDIN23": {
+                "primary": "PMARSVDIN23",
+                "dir": "INPUT",
+                "wire": "PMARSVDIN23"
+            },
+            "PMARSVDIN24": {
+                "primary": "PMARSVDIN24",
+                "dir": "INPUT",
+                "wire": "PMARSVDIN24"
+            },
+            "PMASCANCLK0": {
+                "primary": "PMASCANCLK0",
+                "dir": "INPUT",
+                "wire": "PMASCANCLK0"
+            },
+            "PMASCANCLK1": {
+                "primary": "PMASCANCLK1",
+                "dir": "INPUT",
+                "wire": "PMASCANCLK1"
+            },
+            "PMASCANCLK2": {
+                "primary": "PMASCANCLK2",
+                "dir": "INPUT",
+                "wire": "PMASCANCLK2"
+            },
+            "PMASCANCLK3": {
+                "primary": "PMASCANCLK3",
+                "dir": "INPUT",
+                "wire": "PMASCANCLK3"
+            },
+            "PMASCANCLK4": {
+                "primary": "PMASCANCLK4",
+                "dir": "INPUT",
+                "wire": "PMASCANCLK4"
+            },
+            "PMASCANENB": {
+                "primary": "PMASCANENB",
+                "dir": "INPUT",
+                "wire": "PMASCANENB"
+            },
+            "PMASCANIN0": {
+                "primary": "PMASCANIN0",
+                "dir": "INPUT",
+                "wire": "PMASCANIN0"
+            },
+            "PMASCANIN1": {
+                "primary": "PMASCANIN1",
+                "dir": "INPUT",
+                "wire": "PMASCANIN1"
+            },
+            "PMASCANIN2": {
+                "primary": "PMASCANIN2",
+                "dir": "INPUT",
+                "wire": "PMASCANIN2"
+            },
+            "PMASCANIN3": {
+                "primary": "PMASCANIN3",
+                "dir": "INPUT",
+                "wire": "PMASCANIN3"
+            },
+            "PMASCANIN4": {
+                "primary": "PMASCANIN4",
+                "dir": "INPUT",
+                "wire": "PMASCANIN4"
+            },
+            "PMASCANMODEB": {
+                "primary": "PMASCANMODEB",
+                "dir": "INPUT",
+                "wire": "PMASCANMODEB"
+            },
+            "PMASCANOUT0": {
+                "primary": "PMASCANOUT0",
+                "dir": "OUTPUT",
+                "wire": "PMASCANOUT0"
+            },
+            "PMASCANOUT1": {
+                "primary": "PMASCANOUT1",
+                "dir": "OUTPUT",
+                "wire": "PMASCANOUT1"
+            },
+            "PMASCANOUT2": {
+                "primary": "PMASCANOUT2",
+                "dir": "OUTPUT",
+                "wire": "PMASCANOUT2"
+            },
+            "PMASCANOUT3": {
+                "primary": "PMASCANOUT3",
+                "dir": "OUTPUT",
+                "wire": "PMASCANOUT3"
+            },
+            "PMASCANOUT4": {
+                "primary": "PMASCANOUT4",
+                "dir": "OUTPUT",
+                "wire": "PMASCANOUT4"
+            },
+            "PMASCANRSTEN": {
+                "primary": "PMASCANRSTEN",
+                "dir": "INPUT",
+                "wire": "PMASCANRSTEN"
+            },
+            "QPLLCLK": {
+                "primary": "QPLLCLK",
+                "dir": "INPUT",
+                "wire": "QPLLCLK"
+            },
+            "QPLLREFCLK": {
+                "primary": "QPLLREFCLK",
+                "dir": "INPUT",
+                "wire": "QPLLREFCLK"
+            },
+            "RESETOVRD": {
+                "primary": "RESETOVRD",
+                "dir": "INPUT",
+                "wire": "RESETOVRD"
+            },
+            "RX8B10BEN": {
+                "primary": "RX8B10BEN",
+                "dir": "INPUT",
+                "wire": "RX8B10BEN"
+            },
+            "RXBUFRESET": {
+                "primary": "RXBUFRESET",
+                "dir": "INPUT",
+                "wire": "RXBUFRESET"
+            },
+            "RXBUFSTATUS0": {
+                "primary": "RXBUFSTATUS0",
+                "dir": "OUTPUT",
+                "wire": "RXBUFSTATUS0"
+            },
+            "RXBUFSTATUS1": {
+                "primary": "RXBUFSTATUS1",
+                "dir": "OUTPUT",
+                "wire": "RXBUFSTATUS1"
+            },
+            "RXBUFSTATUS2": {
+                "primary": "RXBUFSTATUS2",
+                "dir": "OUTPUT",
+                "wire": "RXBUFSTATUS2"
+            },
+            "RXBYTEISALIGNED": {
+                "primary": "RXBYTEISALIGNED",
+                "dir": "OUTPUT",
+                "wire": "RXBYTEISALIGNED"
+            },
+            "RXBYTEREALIGN": {
+                "primary": "RXBYTEREALIGN",
+                "dir": "OUTPUT",
+                "wire": "RXBYTEREALIGN"
+            },
+            "RXCDRFREQRESET": {
+                "primary": "RXCDRFREQRESET",
+                "dir": "INPUT",
+                "wire": "RXCDRFREQRESET"
+            },
+            "RXCDRHOLD": {
+                "primary": "RXCDRHOLD",
+                "dir": "INPUT",
+                "wire": "RXCDRHOLD"
+            },
+            "RXCDRLOCK": {
+                "primary": "RXCDRLOCK",
+                "dir": "OUTPUT",
+                "wire": "RXCDRLOCK"
+            },
+            "RXCDROVRDEN": {
+                "primary": "RXCDROVRDEN",
+                "dir": "INPUT",
+                "wire": "RXCDROVRDEN"
+            },
+            "RXCDRRESET": {
+                "primary": "RXCDRRESET",
+                "dir": "INPUT",
+                "wire": "RXCDRRESET"
+            },
+            "RXCDRRESETRSV": {
+                "primary": "RXCDRRESETRSV",
+                "dir": "INPUT",
+                "wire": "RXCDRRESETRSV"
+            },
+            "RXCHANBONDSEQ": {
+                "primary": "RXCHANBONDSEQ",
+                "dir": "OUTPUT",
+                "wire": "RXCHANBONDSEQ"
+            },
+            "RXCHANISALIGNED": {
+                "primary": "RXCHANISALIGNED",
+                "dir": "OUTPUT",
+                "wire": "RXCHANISALIGNED"
+            },
+            "RXCHANREALIGN": {
+                "primary": "RXCHANREALIGN",
+                "dir": "OUTPUT",
+                "wire": "RXCHANREALIGN"
+            },
+            "RXCHARISCOMMA0": {
+                "primary": "RXCHARISCOMMA0",
+                "dir": "OUTPUT",
+                "wire": "RXCHARISCOMMA0"
+            },
+            "RXCHARISCOMMA1": {
+                "primary": "RXCHARISCOMMA1",
+                "dir": "OUTPUT",
+                "wire": "RXCHARISCOMMA1"
+            },
+            "RXCHARISCOMMA2": {
+                "primary": "RXCHARISCOMMA2",
+                "dir": "OUTPUT",
+                "wire": "RXCHARISCOMMA2"
+            },
+            "RXCHARISCOMMA3": {
+                "primary": "RXCHARISCOMMA3",
+                "dir": "OUTPUT",
+                "wire": "RXCHARISCOMMA3"
+            },
+            "RXCHARISCOMMA4": {
+                "primary": "RXCHARISCOMMA4",
+                "dir": "OUTPUT",
+                "wire": "RXCHARISCOMMA4"
+            },
+            "RXCHARISCOMMA5": {
+                "primary": "RXCHARISCOMMA5",
+                "dir": "OUTPUT",
+                "wire": "RXCHARISCOMMA5"
+            },
+            "RXCHARISCOMMA6": {
+                "primary": "RXCHARISCOMMA6",
+                "dir": "OUTPUT",
+                "wire": "RXCHARISCOMMA6"
+            },
+            "RXCHARISCOMMA7": {
+                "primary": "RXCHARISCOMMA7",
+                "dir": "OUTPUT",
+                "wire": "RXCHARISCOMMA7"
+            },
+            "RXCHARISK0": {
+                "primary": "RXCHARISK0",
+                "dir": "OUTPUT",
+                "wire": "RXCHARISK0"
+            },
+            "RXCHARISK1": {
+                "primary": "RXCHARISK1",
+                "dir": "OUTPUT",
+                "wire": "RXCHARISK1"
+            },
+            "RXCHARISK2": {
+                "primary": "RXCHARISK2",
+                "dir": "OUTPUT",
+                "wire": "RXCHARISK2"
+            },
+            "RXCHARISK3": {
+                "primary": "RXCHARISK3",
+                "dir": "OUTPUT",
+                "wire": "RXCHARISK3"
+            },
+            "RXCHARISK4": {
+                "primary": "RXCHARISK4",
+                "dir": "OUTPUT",
+                "wire": "RXCHARISK4"
+            },
+            "RXCHARISK5": {
+                "primary": "RXCHARISK5",
+                "dir": "OUTPUT",
+                "wire": "RXCHARISK5"
+            },
+            "RXCHARISK6": {
+                "primary": "RXCHARISK6",
+                "dir": "OUTPUT",
+                "wire": "RXCHARISK6"
+            },
+            "RXCHARISK7": {
+                "primary": "RXCHARISK7",
+                "dir": "OUTPUT",
+                "wire": "RXCHARISK7"
+            },
+            "RXCHBONDEN": {
+                "primary": "RXCHBONDEN",
+                "dir": "INPUT",
+                "wire": "RXCHBONDEN"
+            },
+            "RXCHBONDI0": {
+                "primary": "RXCHBONDI0",
+                "dir": "INPUT",
+                "wire": "RXCHBONDI0"
+            },
+            "RXCHBONDI1": {
+                "primary": "RXCHBONDI1",
+                "dir": "INPUT",
+                "wire": "RXCHBONDI1"
+            },
+            "RXCHBONDI2": {
+                "primary": "RXCHBONDI2",
+                "dir": "INPUT",
+                "wire": "RXCHBONDI2"
+            },
+            "RXCHBONDI3": {
+                "primary": "RXCHBONDI3",
+                "dir": "INPUT",
+                "wire": "RXCHBONDI3"
+            },
+            "RXCHBONDI4": {
+                "primary": "RXCHBONDI4",
+                "dir": "INPUT",
+                "wire": "RXCHBONDI4"
+            },
+            "RXCHBONDLEVEL0": {
+                "primary": "RXCHBONDLEVEL0",
+                "dir": "INPUT",
+                "wire": "RXCHBONDLEVEL0"
+            },
+            "RXCHBONDLEVEL1": {
+                "primary": "RXCHBONDLEVEL1",
+                "dir": "INPUT",
+                "wire": "RXCHBONDLEVEL1"
+            },
+            "RXCHBONDLEVEL2": {
+                "primary": "RXCHBONDLEVEL2",
+                "dir": "INPUT",
+                "wire": "RXCHBONDLEVEL2"
+            },
+            "RXCHBONDMASTER": {
+                "primary": "RXCHBONDMASTER",
+                "dir": "INPUT",
+                "wire": "RXCHBONDMASTER"
+            },
+            "RXCHBONDO0": {
+                "primary": "RXCHBONDO0",
+                "dir": "OUTPUT",
+                "wire": "RXCHBONDO0"
+            },
+            "RXCHBONDO1": {
+                "primary": "RXCHBONDO1",
+                "dir": "OUTPUT",
+                "wire": "RXCHBONDO1"
+            },
+            "RXCHBONDO2": {
+                "primary": "RXCHBONDO2",
+                "dir": "OUTPUT",
+                "wire": "RXCHBONDO2"
+            },
+            "RXCHBONDO3": {
+                "primary": "RXCHBONDO3",
+                "dir": "OUTPUT",
+                "wire": "RXCHBONDO3"
+            },
+            "RXCHBONDO4": {
+                "primary": "RXCHBONDO4",
+                "dir": "OUTPUT",
+                "wire": "RXCHBONDO4"
+            },
+            "RXCHBONDSLAVE": {
+                "primary": "RXCHBONDSLAVE",
+                "dir": "INPUT",
+                "wire": "RXCHBONDSLAVE"
+            },
+            "RXCLKCORCNT0": {
+                "primary": "RXCLKCORCNT0",
+                "dir": "OUTPUT",
+                "wire": "RXCLKCORCNT0"
+            },
+            "RXCLKCORCNT1": {
+                "primary": "RXCLKCORCNT1",
+                "dir": "OUTPUT",
+                "wire": "RXCLKCORCNT1"
+            },
+            "RXCOMINITDET": {
+                "primary": "RXCOMINITDET",
+                "dir": "OUTPUT",
+                "wire": "RXCOMINITDET"
+            },
+            "RXCOMMADET": {
+                "primary": "RXCOMMADET",
+                "dir": "OUTPUT",
+                "wire": "RXCOMMADET"
+            },
+            "RXCOMMADETEN": {
+                "primary": "RXCOMMADETEN",
+                "dir": "INPUT",
+                "wire": "RXCOMMADETEN"
+            },
+            "RXCOMSASDET": {
+                "primary": "RXCOMSASDET",
+                "dir": "OUTPUT",
+                "wire": "RXCOMSASDET"
+            },
+            "RXCOMWAKEDET": {
+                "primary": "RXCOMWAKEDET",
+                "dir": "OUTPUT",
+                "wire": "RXCOMWAKEDET"
+            },
+            "RXDATA0": {
+                "primary": "RXDATA0",
+                "dir": "OUTPUT",
+                "wire": "RXDATA0"
+            },
+            "RXDATA1": {
+                "primary": "RXDATA1",
+                "dir": "OUTPUT",
+                "wire": "RXDATA1"
+            },
+            "RXDATA2": {
+                "primary": "RXDATA2",
+                "dir": "OUTPUT",
+                "wire": "RXDATA2"
+            },
+            "RXDATA3": {
+                "primary": "RXDATA3",
+                "dir": "OUTPUT",
+                "wire": "RXDATA3"
+            },
+            "RXDATA4": {
+                "primary": "RXDATA4",
+                "dir": "OUTPUT",
+                "wire": "RXDATA4"
+            },
+            "RXDATA5": {
+                "primary": "RXDATA5",
+                "dir": "OUTPUT",
+                "wire": "RXDATA5"
+            },
+            "RXDATA6": {
+                "primary": "RXDATA6",
+                "dir": "OUTPUT",
+                "wire": "RXDATA6"
+            },
+            "RXDATA7": {
+                "primary": "RXDATA7",
+                "dir": "OUTPUT",
+                "wire": "RXDATA7"
+            },
+            "RXDATA8": {
+                "primary": "RXDATA8",
+                "dir": "OUTPUT",
+                "wire": "RXDATA8"
+            },
+            "RXDATA9": {
+                "primary": "RXDATA9",
+                "dir": "OUTPUT",
+                "wire": "RXDATA9"
+            },
+            "RXDATA10": {
+                "primary": "RXDATA10",
+                "dir": "OUTPUT",
+                "wire": "RXDATA10"
+            },
+            "RXDATA11": {
+                "primary": "RXDATA11",
+                "dir": "OUTPUT",
+                "wire": "RXDATA11"
+            },
+            "RXDATA12": {
+                "primary": "RXDATA12",
+                "dir": "OUTPUT",
+                "wire": "RXDATA12"
+            },
+            "RXDATA13": {
+                "primary": "RXDATA13",
+                "dir": "OUTPUT",
+                "wire": "RXDATA13"
+            },
+            "RXDATA14": {
+                "primary": "RXDATA14",
+                "dir": "OUTPUT",
+                "wire": "RXDATA14"
+            },
+            "RXDATA15": {
+                "primary": "RXDATA15",
+                "dir": "OUTPUT",
+                "wire": "RXDATA15"
+            },
+            "RXDATA16": {
+                "primary": "RXDATA16",
+                "dir": "OUTPUT",
+                "wire": "RXDATA16"
+            },
+            "RXDATA17": {
+                "primary": "RXDATA17",
+                "dir": "OUTPUT",
+                "wire": "RXDATA17"
+            },
+            "RXDATA18": {
+                "primary": "RXDATA18",
+                "dir": "OUTPUT",
+                "wire": "RXDATA18"
+            },
+            "RXDATA19": {
+                "primary": "RXDATA19",
+                "dir": "OUTPUT",
+                "wire": "RXDATA19"
+            },
+            "RXDATA20": {
+                "primary": "RXDATA20",
+                "dir": "OUTPUT",
+                "wire": "RXDATA20"
+            },
+            "RXDATA21": {
+                "primary": "RXDATA21",
+                "dir": "OUTPUT",
+                "wire": "RXDATA21"
+            },
+            "RXDATA22": {
+                "primary": "RXDATA22",
+                "dir": "OUTPUT",
+                "wire": "RXDATA22"
+            },
+            "RXDATA23": {
+                "primary": "RXDATA23",
+                "dir": "OUTPUT",
+                "wire": "RXDATA23"
+            },
+            "RXDATA24": {
+                "primary": "RXDATA24",
+                "dir": "OUTPUT",
+                "wire": "RXDATA24"
+            },
+            "RXDATA25": {
+                "primary": "RXDATA25",
+                "dir": "OUTPUT",
+                "wire": "RXDATA25"
+            },
+            "RXDATA26": {
+                "primary": "RXDATA26",
+                "dir": "OUTPUT",
+                "wire": "RXDATA26"
+            },
+            "RXDATA27": {
+                "primary": "RXDATA27",
+                "dir": "OUTPUT",
+                "wire": "RXDATA27"
+            },
+            "RXDATA28": {
+                "primary": "RXDATA28",
+                "dir": "OUTPUT",
+                "wire": "RXDATA28"
+            },
+            "RXDATA29": {
+                "primary": "RXDATA29",
+                "dir": "OUTPUT",
+                "wire": "RXDATA29"
+            },
+            "RXDATA30": {
+                "primary": "RXDATA30",
+                "dir": "OUTPUT",
+                "wire": "RXDATA30"
+            },
+            "RXDATA31": {
+                "primary": "RXDATA31",
+                "dir": "OUTPUT",
+                "wire": "RXDATA31"
+            },
+            "RXDATA32": {
+                "primary": "RXDATA32",
+                "dir": "OUTPUT",
+                "wire": "RXDATA32"
+            },
+            "RXDATA33": {
+                "primary": "RXDATA33",
+                "dir": "OUTPUT",
+                "wire": "RXDATA33"
+            },
+            "RXDATA34": {
+                "primary": "RXDATA34",
+                "dir": "OUTPUT",
+                "wire": "RXDATA34"
+            },
+            "RXDATA35": {
+                "primary": "RXDATA35",
+                "dir": "OUTPUT",
+                "wire": "RXDATA35"
+            },
+            "RXDATA36": {
+                "primary": "RXDATA36",
+                "dir": "OUTPUT",
+                "wire": "RXDATA36"
+            },
+            "RXDATA37": {
+                "primary": "RXDATA37",
+                "dir": "OUTPUT",
+                "wire": "RXDATA37"
+            },
+            "RXDATA38": {
+                "primary": "RXDATA38",
+                "dir": "OUTPUT",
+                "wire": "RXDATA38"
+            },
+            "RXDATA39": {
+                "primary": "RXDATA39",
+                "dir": "OUTPUT",
+                "wire": "RXDATA39"
+            },
+            "RXDATA40": {
+                "primary": "RXDATA40",
+                "dir": "OUTPUT",
+                "wire": "RXDATA40"
+            },
+            "RXDATA41": {
+                "primary": "RXDATA41",
+                "dir": "OUTPUT",
+                "wire": "RXDATA41"
+            },
+            "RXDATA42": {
+                "primary": "RXDATA42",
+                "dir": "OUTPUT",
+                "wire": "RXDATA42"
+            },
+            "RXDATA43": {
+                "primary": "RXDATA43",
+                "dir": "OUTPUT",
+                "wire": "RXDATA43"
+            },
+            "RXDATA44": {
+                "primary": "RXDATA44",
+                "dir": "OUTPUT",
+                "wire": "RXDATA44"
+            },
+            "RXDATA45": {
+                "primary": "RXDATA45",
+                "dir": "OUTPUT",
+                "wire": "RXDATA45"
+            },
+            "RXDATA46": {
+                "primary": "RXDATA46",
+                "dir": "OUTPUT",
+                "wire": "RXDATA46"
+            },
+            "RXDATA47": {
+                "primary": "RXDATA47",
+                "dir": "OUTPUT",
+                "wire": "RXDATA47"
+            },
+            "RXDATA48": {
+                "primary": "RXDATA48",
+                "dir": "OUTPUT",
+                "wire": "RXDATA48"
+            },
+            "RXDATA49": {
+                "primary": "RXDATA49",
+                "dir": "OUTPUT",
+                "wire": "RXDATA49"
+            },
+            "RXDATA50": {
+                "primary": "RXDATA50",
+                "dir": "OUTPUT",
+                "wire": "RXDATA50"
+            },
+            "RXDATA51": {
+                "primary": "RXDATA51",
+                "dir": "OUTPUT",
+                "wire": "RXDATA51"
+            },
+            "RXDATA52": {
+                "primary": "RXDATA52",
+                "dir": "OUTPUT",
+                "wire": "RXDATA52"
+            },
+            "RXDATA53": {
+                "primary": "RXDATA53",
+                "dir": "OUTPUT",
+                "wire": "RXDATA53"
+            },
+            "RXDATA54": {
+                "primary": "RXDATA54",
+                "dir": "OUTPUT",
+                "wire": "RXDATA54"
+            },
+            "RXDATA55": {
+                "primary": "RXDATA55",
+                "dir": "OUTPUT",
+                "wire": "RXDATA55"
+            },
+            "RXDATA56": {
+                "primary": "RXDATA56",
+                "dir": "OUTPUT",
+                "wire": "RXDATA56"
+            },
+            "RXDATA57": {
+                "primary": "RXDATA57",
+                "dir": "OUTPUT",
+                "wire": "RXDATA57"
+            },
+            "RXDATA58": {
+                "primary": "RXDATA58",
+                "dir": "OUTPUT",
+                "wire": "RXDATA58"
+            },
+            "RXDATA59": {
+                "primary": "RXDATA59",
+                "dir": "OUTPUT",
+                "wire": "RXDATA59"
+            },
+            "RXDATA60": {
+                "primary": "RXDATA60",
+                "dir": "OUTPUT",
+                "wire": "RXDATA60"
+            },
+            "RXDATA61": {
+                "primary": "RXDATA61",
+                "dir": "OUTPUT",
+                "wire": "RXDATA61"
+            },
+            "RXDATA62": {
+                "primary": "RXDATA62",
+                "dir": "OUTPUT",
+                "wire": "RXDATA62"
+            },
+            "RXDATA63": {
+                "primary": "RXDATA63",
+                "dir": "OUTPUT",
+                "wire": "RXDATA63"
+            },
+            "RXDATAVALID": {
+                "primary": "RXDATAVALID",
+                "dir": "OUTPUT",
+                "wire": "RXDATAVALID"
+            },
+            "RXDDIEN": {
+                "primary": "RXDDIEN",
+                "dir": "INPUT",
+                "wire": "RXDDIEN"
+            },
+            "RXDEBUGPULSE": {
+                "primary": "RXDEBUGPULSE",
+                "dir": "INPUT",
+                "wire": "RXDEBUGPULSE"
+            },
+            "RXDFEAGCHOLD": {
+                "primary": "RXDFEAGCHOLD",
+                "dir": "INPUT",
+                "wire": "RXDFEAGCHOLD"
+            },
+            "RXDFEAGCOVRDEN": {
+                "primary": "RXDFEAGCOVRDEN",
+                "dir": "INPUT",
+                "wire": "RXDFEAGCOVRDEN"
+            },
+            "RXDFECM1EN": {
+                "primary": "RXDFECM1EN",
+                "dir": "INPUT",
+                "wire": "RXDFECM1EN"
+            },
+            "RXDFELFHOLD": {
+                "primary": "RXDFELFHOLD",
+                "dir": "INPUT",
+                "wire": "RXDFELFHOLD"
+            },
+            "RXDFELFOVRDEN": {
+                "primary": "RXDFELFOVRDEN",
+                "dir": "INPUT",
+                "wire": "RXDFELFOVRDEN"
+            },
+            "RXDFELPMRESET": {
+                "primary": "RXDFELPMRESET",
+                "dir": "INPUT",
+                "wire": "RXDFELPMRESET"
+            },
+            "RXDFETAP2HOLD": {
+                "primary": "RXDFETAP2HOLD",
+                "dir": "INPUT",
+                "wire": "RXDFETAP2HOLD"
+            },
+            "RXDFETAP2OVRDEN": {
+                "primary": "RXDFETAP2OVRDEN",
+                "dir": "INPUT",
+                "wire": "RXDFETAP2OVRDEN"
+            },
+            "RXDFETAP3HOLD": {
+                "primary": "RXDFETAP3HOLD",
+                "dir": "INPUT",
+                "wire": "RXDFETAP3HOLD"
+            },
+            "RXDFETAP3OVRDEN": {
+                "primary": "RXDFETAP3OVRDEN",
+                "dir": "INPUT",
+                "wire": "RXDFETAP3OVRDEN"
+            },
+            "RXDFETAP4HOLD": {
+                "primary": "RXDFETAP4HOLD",
+                "dir": "INPUT",
+                "wire": "RXDFETAP4HOLD"
+            },
+            "RXDFETAP4OVRDEN": {
+                "primary": "RXDFETAP4OVRDEN",
+                "dir": "INPUT",
+                "wire": "RXDFETAP4OVRDEN"
+            },
+            "RXDFETAP5HOLD": {
+                "primary": "RXDFETAP5HOLD",
+                "dir": "INPUT",
+                "wire": "RXDFETAP5HOLD"
+            },
+            "RXDFETAP5OVRDEN": {
+                "primary": "RXDFETAP5OVRDEN",
+                "dir": "INPUT",
+                "wire": "RXDFETAP5OVRDEN"
+            },
+            "RXDFEUTHOLD": {
+                "primary": "RXDFEUTHOLD",
+                "dir": "INPUT",
+                "wire": "RXDFEUTHOLD"
+            },
+            "RXDFEUTOVRDEN": {
+                "primary": "RXDFEUTOVRDEN",
+                "dir": "INPUT",
+                "wire": "RXDFEUTOVRDEN"
+            },
+            "RXDFEVPHOLD": {
+                "primary": "RXDFEVPHOLD",
+                "dir": "INPUT",
+                "wire": "RXDFEVPHOLD"
+            },
+            "RXDFEVPOVRDEN": {
+                "primary": "RXDFEVPOVRDEN",
+                "dir": "INPUT",
+                "wire": "RXDFEVPOVRDEN"
+            },
+            "RXDFEVSEN": {
+                "primary": "RXDFEVSEN",
+                "dir": "INPUT",
+                "wire": "RXDFEVSEN"
+            },
+            "RXDFEXYDEN": {
+                "primary": "RXDFEXYDEN",
+                "dir": "INPUT",
+                "wire": "RXDFEXYDEN"
+            },
+            "RXDFEXYDHOLD": {
+                "primary": "RXDFEXYDHOLD",
+                "dir": "INPUT",
+                "wire": "RXDFEXYDHOLD"
+            },
+            "RXDFEXYDOVRDEN": {
+                "primary": "RXDFEXYDOVRDEN",
+                "dir": "INPUT",
+                "wire": "RXDFEXYDOVRDEN"
+            },
+            "RXDISPERR0": {
+                "primary": "RXDISPERR0",
+                "dir": "OUTPUT",
+                "wire": "RXDISPERR0"
+            },
+            "RXDISPERR1": {
+                "primary": "RXDISPERR1",
+                "dir": "OUTPUT",
+                "wire": "RXDISPERR1"
+            },
+            "RXDISPERR2": {
+                "primary": "RXDISPERR2",
+                "dir": "OUTPUT",
+                "wire": "RXDISPERR2"
+            },
+            "RXDISPERR3": {
+                "primary": "RXDISPERR3",
+                "dir": "OUTPUT",
+                "wire": "RXDISPERR3"
+            },
+            "RXDISPERR4": {
+                "primary": "RXDISPERR4",
+                "dir": "OUTPUT",
+                "wire": "RXDISPERR4"
+            },
+            "RXDISPERR5": {
+                "primary": "RXDISPERR5",
+                "dir": "OUTPUT",
+                "wire": "RXDISPERR5"
+            },
+            "RXDISPERR6": {
+                "primary": "RXDISPERR6",
+                "dir": "OUTPUT",
+                "wire": "RXDISPERR6"
+            },
+            "RXDISPERR7": {
+                "primary": "RXDISPERR7",
+                "dir": "OUTPUT",
+                "wire": "RXDISPERR7"
+            },
+            "RXDLYBYPASS": {
+                "primary": "RXDLYBYPASS",
+                "dir": "INPUT",
+                "wire": "RXDLYBYPASS"
+            },
+            "RXDLYEN": {
+                "primary": "RXDLYEN",
+                "dir": "INPUT",
+                "wire": "RXDLYEN"
+            },
+            "RXDLYOVRDEN": {
+                "primary": "RXDLYOVRDEN",
+                "dir": "INPUT",
+                "wire": "RXDLYOVRDEN"
+            },
+            "RXDLYSRESET": {
+                "primary": "RXDLYSRESET",
+                "dir": "INPUT",
+                "wire": "RXDLYSRESET"
+            },
+            "RXDLYSRESETDONE": {
+                "primary": "RXDLYSRESETDONE",
+                "dir": "OUTPUT",
+                "wire": "RXDLYSRESETDONE"
+            },
+            "RXDLYTESTENB": {
+                "primary": "RXDLYTESTENB",
+                "dir": "INPUT",
+                "wire": "RXDLYTESTENB"
+            },
+            "RXELECIDLE": {
+                "primary": "RXELECIDLE",
+                "dir": "OUTPUT",
+                "wire": "RXELECIDLE"
+            },
+            "RXELECIDLEMODE0": {
+                "primary": "RXELECIDLEMODE0",
+                "dir": "INPUT",
+                "wire": "RXELECIDLEMODE0"
+            },
+            "RXELECIDLEMODE1": {
+                "primary": "RXELECIDLEMODE1",
+                "dir": "INPUT",
+                "wire": "RXELECIDLEMODE1"
+            },
+            "RXGEARBOXSLIP": {
+                "primary": "RXGEARBOXSLIP",
+                "dir": "INPUT",
+                "wire": "RXGEARBOXSLIP"
+            },
+            "RXHEADER0": {
+                "primary": "RXHEADER0",
+                "dir": "OUTPUT",
+                "wire": "RXHEADER0"
+            },
+            "RXHEADER1": {
+                "primary": "RXHEADER1",
+                "dir": "OUTPUT",
+                "wire": "RXHEADER1"
+            },
+            "RXHEADER2": {
+                "primary": "RXHEADER2",
+                "dir": "OUTPUT",
+                "wire": "RXHEADER2"
+            },
+            "RXHEADERVALID": {
+                "primary": "RXHEADERVALID",
+                "dir": "OUTPUT",
+                "wire": "RXHEADERVALID"
+            },
+            "RXLPMEN": {
+                "primary": "RXLPMEN",
+                "dir": "INPUT",
+                "wire": "RXLPMEN"
+            },
+            "RXLPMHFHOLD": {
+                "primary": "RXLPMHFHOLD",
+                "dir": "INPUT",
+                "wire": "RXLPMHFHOLD"
+            },
+            "RXLPMHFOVRDEN": {
+                "primary": "RXLPMHFOVRDEN",
+                "dir": "INPUT",
+                "wire": "RXLPMHFOVRDEN"
+            },
+            "RXLPMLFHOLD": {
+                "primary": "RXLPMLFHOLD",
+                "dir": "INPUT",
+                "wire": "RXLPMLFHOLD"
+            },
+            "RXLPMLFKLOVRDEN": {
+                "primary": "RXLPMLFKLOVRDEN",
+                "dir": "INPUT",
+                "wire": "RXLPMLFKLOVRDEN"
+            },
+            "RXMCOMMAALIGNEN": {
+                "primary": "RXMCOMMAALIGNEN",
+                "dir": "INPUT",
+                "wire": "RXMCOMMAALIGNEN"
+            },
+            "RXMONITOROUT0": {
+                "primary": "RXMONITOROUT0",
+                "dir": "OUTPUT",
+                "wire": "RXMONITOROUT0"
+            },
+            "RXMONITOROUT1": {
+                "primary": "RXMONITOROUT1",
+                "dir": "OUTPUT",
+                "wire": "RXMONITOROUT1"
+            },
+            "RXMONITOROUT2": {
+                "primary": "RXMONITOROUT2",
+                "dir": "OUTPUT",
+                "wire": "RXMONITOROUT2"
+            },
+            "RXMONITOROUT3": {
+                "primary": "RXMONITOROUT3",
+                "dir": "OUTPUT",
+                "wire": "RXMONITOROUT3"
+            },
+            "RXMONITOROUT4": {
+                "primary": "RXMONITOROUT4",
+                "dir": "OUTPUT",
+                "wire": "RXMONITOROUT4"
+            },
+            "RXMONITOROUT5": {
+                "primary": "RXMONITOROUT5",
+                "dir": "OUTPUT",
+                "wire": "RXMONITOROUT5"
+            },
+            "RXMONITOROUT6": {
+                "primary": "RXMONITOROUT6",
+                "dir": "OUTPUT",
+                "wire": "RXMONITOROUT6"
+            },
+            "RXMONITORSEL0": {
+                "primary": "RXMONITORSEL0",
+                "dir": "INPUT",
+                "wire": "RXMONITORSEL0"
+            },
+            "RXMONITORSEL1": {
+                "primary": "RXMONITORSEL1",
+                "dir": "INPUT",
+                "wire": "RXMONITORSEL1"
+            },
+            "RXNOTINTABLE0": {
+                "primary": "RXNOTINTABLE0",
+                "dir": "OUTPUT",
+                "wire": "RXNOTINTABLE0"
+            },
+            "RXNOTINTABLE1": {
+                "primary": "RXNOTINTABLE1",
+                "dir": "OUTPUT",
+                "wire": "RXNOTINTABLE1"
+            },
+            "RXNOTINTABLE2": {
+                "primary": "RXNOTINTABLE2",
+                "dir": "OUTPUT",
+                "wire": "RXNOTINTABLE2"
+            },
+            "RXNOTINTABLE3": {
+                "primary": "RXNOTINTABLE3",
+                "dir": "OUTPUT",
+                "wire": "RXNOTINTABLE3"
+            },
+            "RXNOTINTABLE4": {
+                "primary": "RXNOTINTABLE4",
+                "dir": "OUTPUT",
+                "wire": "RXNOTINTABLE4"
+            },
+            "RXNOTINTABLE5": {
+                "primary": "RXNOTINTABLE5",
+                "dir": "OUTPUT",
+                "wire": "RXNOTINTABLE5"
+            },
+            "RXNOTINTABLE6": {
+                "primary": "RXNOTINTABLE6",
+                "dir": "OUTPUT",
+                "wire": "RXNOTINTABLE6"
+            },
+            "RXNOTINTABLE7": {
+                "primary": "RXNOTINTABLE7",
+                "dir": "OUTPUT",
+                "wire": "RXNOTINTABLE7"
+            },
+            "RXOOBRESET": {
+                "primary": "RXOOBRESET",
+                "dir": "INPUT",
+                "wire": "RXOOBRESET"
+            },
+            "RXOSHOLD": {
+                "primary": "RXOSHOLD",
+                "dir": "INPUT",
+                "wire": "RXOSHOLD"
+            },
+            "RXOSOVRDEN": {
+                "primary": "RXOSOVRDEN",
+                "dir": "INPUT",
+                "wire": "RXOSOVRDEN"
+            },
+            "RXOUTCLK": {
+                "primary": "RXOUTCLK",
+                "dir": "OUTPUT",
+                "wire": "RXOUTCLK"
+            },
+            "RXOUTCLKFABRIC": {
+                "primary": "RXOUTCLKFABRIC",
+                "dir": "OUTPUT",
+                "wire": "RXOUTCLKFABRIC"
+            },
+            "RXOUTCLKPCS": {
+                "primary": "RXOUTCLKPCS",
+                "dir": "OUTPUT",
+                "wire": "RXOUTCLKPCS"
+            },
+            "RXOUTCLKSEL0": {
+                "primary": "RXOUTCLKSEL0",
+                "dir": "INPUT",
+                "wire": "RXOUTCLKSEL0"
+            },
+            "RXOUTCLKSEL1": {
+                "primary": "RXOUTCLKSEL1",
+                "dir": "INPUT",
+                "wire": "RXOUTCLKSEL1"
+            },
+            "RXOUTCLKSEL2": {
+                "primary": "RXOUTCLKSEL2",
+                "dir": "INPUT",
+                "wire": "RXOUTCLKSEL2"
+            },
+            "RXPCD1DONE": {
+                "primary": "RXPCD1DONE",
+                "dir": "OUTPUT",
+                "wire": "RXPCD1DONE"
+            },
+            "RXPCOMMAALIGNEN": {
+                "primary": "RXPCOMMAALIGNEN",
+                "dir": "INPUT",
+                "wire": "RXPCOMMAALIGNEN"
+            },
+            "RXPCSRESET": {
+                "primary": "RXPCSRESET",
+                "dir": "INPUT",
+                "wire": "RXPCSRESET"
+            },
+            "RXPD0": {
+                "primary": "RXPD0",
+                "dir": "INPUT",
+                "wire": "RXPD0"
+            },
+            "RXPD1": {
+                "primary": "RXPD1",
+                "dir": "INPUT",
+                "wire": "RXPD1"
+            },
+            "RXPHALIGN": {
+                "primary": "RXPHALIGN",
+                "dir": "INPUT",
+                "wire": "RXPHALIGN"
+            },
+            "RXPHALIGNDONE": {
+                "primary": "RXPHALIGNDONE",
+                "dir": "OUTPUT",
+                "wire": "RXPHALIGNDONE"
+            },
+            "RXPHALIGNEN": {
+                "primary": "RXPHALIGNEN",
+                "dir": "INPUT",
+                "wire": "RXPHALIGNEN"
+            },
+            "RXPHDLYPD": {
+                "primary": "RXPHDLYPD",
+                "dir": "INPUT",
+                "wire": "RXPHDLYPD"
+            },
+            "RXPHDLYRESET": {
+                "primary": "RXPHDLYRESET",
+                "dir": "INPUT",
+                "wire": "RXPHDLYRESET"
+            },
+            "RXPHMONITOR0": {
+                "primary": "RXPHMONITOR0",
+                "dir": "OUTPUT",
+                "wire": "RXPHMONITOR0"
+            },
+            "RXPHMONITOR1": {
+                "primary": "RXPHMONITOR1",
+                "dir": "OUTPUT",
+                "wire": "RXPHMONITOR1"
+            },
+            "RXPHMONITOR2": {
+                "primary": "RXPHMONITOR2",
+                "dir": "OUTPUT",
+                "wire": "RXPHMONITOR2"
+            },
+            "RXPHMONITOR3": {
+                "primary": "RXPHMONITOR3",
+                "dir": "OUTPUT",
+                "wire": "RXPHMONITOR3"
+            },
+            "RXPHMONITOR4": {
+                "primary": "RXPHMONITOR4",
+                "dir": "OUTPUT",
+                "wire": "RXPHMONITOR4"
+            },
+            "RXPHOVRDEN": {
+                "primary": "RXPHOVRDEN",
+                "dir": "INPUT",
+                "wire": "RXPHOVRDEN"
+            },
+            "RXPHSLIPMONITOR0": {
+                "primary": "RXPHSLIPMONITOR0",
+                "dir": "OUTPUT",
+                "wire": "RXPHSLIPMONITOR0"
+            },
+            "RXPHSLIPMONITOR1": {
+                "primary": "RXPHSLIPMONITOR1",
+                "dir": "OUTPUT",
+                "wire": "RXPHSLIPMONITOR1"
+            },
+            "RXPHSLIPMONITOR2": {
+                "primary": "RXPHSLIPMONITOR2",
+                "dir": "OUTPUT",
+                "wire": "RXPHSLIPMONITOR2"
+            },
+            "RXPHSLIPMONITOR3": {
+                "primary": "RXPHSLIPMONITOR3",
+                "dir": "OUTPUT",
+                "wire": "RXPHSLIPMONITOR3"
+            },
+            "RXPHSLIPMONITOR4": {
+                "primary": "RXPHSLIPMONITOR4",
+                "dir": "OUTPUT",
+                "wire": "RXPHSLIPMONITOR4"
+            },
+            "RXPMARESET": {
+                "primary": "RXPMARESET",
+                "dir": "INPUT",
+                "wire": "RXPMARESET"
+            },
+            "RXPOLARITY": {
+                "primary": "RXPOLARITY",
+                "dir": "INPUT",
+                "wire": "RXPOLARITY"
+            },
+            "RXPRBSCNTRESET": {
+                "primary": "RXPRBSCNTRESET",
+                "dir": "INPUT",
+                "wire": "RXPRBSCNTRESET"
+            },
+            "RXPRBSERR": {
+                "primary": "RXPRBSERR",
+                "dir": "OUTPUT",
+                "wire": "RXPRBSERR"
+            },
+            "RXPRBSSEL0": {
+                "primary": "RXPRBSSEL0",
+                "dir": "INPUT",
+                "wire": "RXPRBSSEL0"
+            },
+            "RXPRBSSEL1": {
+                "primary": "RXPRBSSEL1",
+                "dir": "INPUT",
+                "wire": "RXPRBSSEL1"
+            },
+            "RXPRBSSEL2": {
+                "primary": "RXPRBSSEL2",
+                "dir": "INPUT",
+                "wire": "RXPRBSSEL2"
+            },
+            "RXQPIEN": {
+                "primary": "RXQPIEN",
+                "dir": "INPUT",
+                "wire": "RXQPIEN"
+            },
+            "RXQPISENN": {
+                "primary": "RXQPISENN",
+                "dir": "OUTPUT",
+                "wire": "RXQPISENN"
+            },
+            "RXQPISENP": {
+                "primary": "RXQPISENP",
+                "dir": "OUTPUT",
+                "wire": "RXQPISENP"
+            },
+            "RXRATE0": {
+                "primary": "RXRATE0",
+                "dir": "INPUT",
+                "wire": "RXRATE0"
+            },
+            "RXRATE1": {
+                "primary": "RXRATE1",
+                "dir": "INPUT",
+                "wire": "RXRATE1"
+            },
+            "RXRATE2": {
+                "primary": "RXRATE2",
+                "dir": "INPUT",
+                "wire": "RXRATE2"
+            },
+            "RXRATEDONE": {
+                "primary": "RXRATEDONE",
+                "dir": "OUTPUT",
+                "wire": "RXRATEDONE"
+            },
+            "RXRESETDONE": {
+                "primary": "RXRESETDONE",
+                "dir": "OUTPUT",
+                "wire": "RXRESETDONE"
+            },
+            "RXSLIDE": {
+                "primary": "RXSLIDE",
+                "dir": "INPUT",
+                "wire": "RXSLIDE"
+            },
+            "RXSTARTOFSEQ": {
+                "primary": "RXSTARTOFSEQ",
+                "dir": "OUTPUT",
+                "wire": "RXSTARTOFSEQ"
+            },
+            "RXSTATUS0": {
+                "primary": "RXSTATUS0",
+                "dir": "OUTPUT",
+                "wire": "RXSTATUS0"
+            },
+            "RXSTATUS1": {
+                "primary": "RXSTATUS1",
+                "dir": "OUTPUT",
+                "wire": "RXSTATUS1"
+            },
+            "RXSTATUS2": {
+                "primary": "RXSTATUS2",
+                "dir": "OUTPUT",
+                "wire": "RXSTATUS2"
+            },
+            "RXSYSCLKSEL0": {
+                "primary": "RXSYSCLKSEL0",
+                "dir": "INPUT",
+                "wire": "RXSYSCLKSEL0"
+            },
+            "RXSYSCLKSEL1": {
+                "primary": "RXSYSCLKSEL1",
+                "dir": "INPUT",
+                "wire": "RXSYSCLKSEL1"
+            },
+            "RXUSERRDY": {
+                "primary": "RXUSERRDY",
+                "dir": "INPUT",
+                "wire": "RXUSERRDY"
+            },
+            "RXUSRCLK": {
+                "primary": "RXUSRCLK",
+                "dir": "INPUT",
+                "wire": "RXUSRCLK"
+            },
+            "RXUSRCLK2": {
+                "primary": "RXUSRCLK2",
+                "dir": "INPUT",
+                "wire": "RXUSRCLK2"
+            },
+            "RXVALID": {
+                "primary": "RXVALID",
+                "dir": "OUTPUT",
+                "wire": "RXVALID"
+            },
+            "SCANCLK": {
+                "primary": "SCANCLK",
+                "dir": "INPUT",
+                "wire": "SCANCLK"
+            },
+            "SCANENB": {
+                "primary": "SCANENB",
+                "dir": "INPUT",
+                "wire": "SCANENB"
+            },
+            "SCANIN0": {
+                "primary": "SCANIN0",
+                "dir": "INPUT",
+                "wire": "SCANIN0"
+            },
+            "SCANIN1": {
+                "primary": "SCANIN1",
+                "dir": "INPUT",
+                "wire": "SCANIN1"
+            },
+            "SCANIN2": {
+                "primary": "SCANIN2",
+                "dir": "INPUT",
+                "wire": "SCANIN2"
+            },
+            "SCANIN3": {
+                "primary": "SCANIN3",
+                "dir": "INPUT",
+                "wire": "SCANIN3"
+            },
+            "SCANIN4": {
+                "primary": "SCANIN4",
+                "dir": "INPUT",
+                "wire": "SCANIN4"
+            },
+            "SCANMODEB": {
+                "primary": "SCANMODEB",
+                "dir": "INPUT",
+                "wire": "SCANMODEB"
+            },
+            "SCANOUT0": {
+                "primary": "SCANOUT0",
+                "dir": "OUTPUT",
+                "wire": "SCANOUT0"
+            },
+            "SCANOUT1": {
+                "primary": "SCANOUT1",
+                "dir": "OUTPUT",
+                "wire": "SCANOUT1"
+            },
+            "SCANOUT2": {
+                "primary": "SCANOUT2",
+                "dir": "OUTPUT",
+                "wire": "SCANOUT2"
+            },
+            "SCANOUT3": {
+                "primary": "SCANOUT3",
+                "dir": "OUTPUT",
+                "wire": "SCANOUT3"
+            },
+            "SCANOUT4": {
+                "primary": "SCANOUT4",
+                "dir": "OUTPUT",
+                "wire": "SCANOUT4"
+            },
+            "SETERRSTATUS": {
+                "primary": "SETERRSTATUS",
+                "dir": "INPUT",
+                "wire": "SETERRSTATUS"
+            },
+            "TSTCLK0": {
+                "primary": "TSTCLK0",
+                "dir": "INPUT",
+                "wire": "TSTCLK0"
+            },
+            "TSTCLK1": {
+                "primary": "TSTCLK1",
+                "dir": "INPUT",
+                "wire": "TSTCLK1"
+            },
+            "TSTIN0": {
+                "primary": "TSTIN0",
+                "dir": "INPUT",
+                "wire": "TSTIN0"
+            },
+            "TSTIN1": {
+                "primary": "TSTIN1",
+                "dir": "INPUT",
+                "wire": "TSTIN1"
+            },
+            "TSTIN2": {
+                "primary": "TSTIN2",
+                "dir": "INPUT",
+                "wire": "TSTIN2"
+            },
+            "TSTIN3": {
+                "primary": "TSTIN3",
+                "dir": "INPUT",
+                "wire": "TSTIN3"
+            },
+            "TSTIN4": {
+                "primary": "TSTIN4",
+                "dir": "INPUT",
+                "wire": "TSTIN4"
+            },
+            "TSTIN5": {
+                "primary": "TSTIN5",
+                "dir": "INPUT",
+                "wire": "TSTIN5"
+            },
+            "TSTIN6": {
+                "primary": "TSTIN6",
+                "dir": "INPUT",
+                "wire": "TSTIN6"
+            },
+            "TSTIN7": {
+                "primary": "TSTIN7",
+                "dir": "INPUT",
+                "wire": "TSTIN7"
+            },
+            "TSTIN8": {
+                "primary": "TSTIN8",
+                "dir": "INPUT",
+                "wire": "TSTIN8"
+            },
+            "TSTIN9": {
+                "primary": "TSTIN9",
+                "dir": "INPUT",
+                "wire": "TSTIN9"
+            },
+            "TSTIN10": {
+                "primary": "TSTIN10",
+                "dir": "INPUT",
+                "wire": "TSTIN10"
+            },
+            "TSTIN11": {
+                "primary": "TSTIN11",
+                "dir": "INPUT",
+                "wire": "TSTIN11"
+            },
+            "TSTIN12": {
+                "primary": "TSTIN12",
+                "dir": "INPUT",
+                "wire": "TSTIN12"
+            },
+            "TSTIN13": {
+                "primary": "TSTIN13",
+                "dir": "INPUT",
+                "wire": "TSTIN13"
+            },
+            "TSTIN14": {
+                "primary": "TSTIN14",
+                "dir": "INPUT",
+                "wire": "TSTIN14"
+            },
+            "TSTIN15": {
+                "primary": "TSTIN15",
+                "dir": "INPUT",
+                "wire": "TSTIN15"
+            },
+            "TSTIN16": {
+                "primary": "TSTIN16",
+                "dir": "INPUT",
+                "wire": "TSTIN16"
+            },
+            "TSTIN17": {
+                "primary": "TSTIN17",
+                "dir": "INPUT",
+                "wire": "TSTIN17"
+            },
+            "TSTIN18": {
+                "primary": "TSTIN18",
+                "dir": "INPUT",
+                "wire": "TSTIN18"
+            },
+            "TSTIN19": {
+                "primary": "TSTIN19",
+                "dir": "INPUT",
+                "wire": "TSTIN19"
+            },
+            "TSTOUT0": {
+                "primary": "TSTOUT0",
+                "dir": "OUTPUT",
+                "wire": "TSTOUT0"
+            },
+            "TSTOUT1": {
+                "primary": "TSTOUT1",
+                "dir": "OUTPUT",
+                "wire": "TSTOUT1"
+            },
+            "TSTOUT2": {
+                "primary": "TSTOUT2",
+                "dir": "OUTPUT",
+                "wire": "TSTOUT2"
+            },
+            "TSTOUT3": {
+                "primary": "TSTOUT3",
+                "dir": "OUTPUT",
+                "wire": "TSTOUT3"
+            },
+            "TSTOUT4": {
+                "primary": "TSTOUT4",
+                "dir": "OUTPUT",
+                "wire": "TSTOUT4"
+            },
+            "TSTOUT5": {
+                "primary": "TSTOUT5",
+                "dir": "OUTPUT",
+                "wire": "TSTOUT5"
+            },
+            "TSTOUT6": {
+                "primary": "TSTOUT6",
+                "dir": "OUTPUT",
+                "wire": "TSTOUT6"
+            },
+            "TSTOUT7": {
+                "primary": "TSTOUT7",
+                "dir": "OUTPUT",
+                "wire": "TSTOUT7"
+            },
+            "TSTOUT8": {
+                "primary": "TSTOUT8",
+                "dir": "OUTPUT",
+                "wire": "TSTOUT8"
+            },
+            "TSTOUT9": {
+                "primary": "TSTOUT9",
+                "dir": "OUTPUT",
+                "wire": "TSTOUT9"
+            },
+            "TSTPD0": {
+                "primary": "TSTPD0",
+                "dir": "INPUT",
+                "wire": "TSTPD0"
+            },
+            "TSTPD1": {
+                "primary": "TSTPD1",
+                "dir": "INPUT",
+                "wire": "TSTPD1"
+            },
+            "TSTPD2": {
+                "primary": "TSTPD2",
+                "dir": "INPUT",
+                "wire": "TSTPD2"
+            },
+            "TSTPD3": {
+                "primary": "TSTPD3",
+                "dir": "INPUT",
+                "wire": "TSTPD3"
+            },
+            "TSTPD4": {
+                "primary": "TSTPD4",
+                "dir": "INPUT",
+                "wire": "TSTPD4"
+            },
+            "TSTPDOVRDB": {
+                "primary": "TSTPDOVRDB",
+                "dir": "INPUT",
+                "wire": "TSTPDOVRDB"
+            },
+            "TX8B10BBYPASS0": {
+                "primary": "TX8B10BBYPASS0",
+                "dir": "INPUT",
+                "wire": "TX8B10BBYPASS0"
+            },
+            "TX8B10BBYPASS1": {
+                "primary": "TX8B10BBYPASS1",
+                "dir": "INPUT",
+                "wire": "TX8B10BBYPASS1"
+            },
+            "TX8B10BBYPASS2": {
+                "primary": "TX8B10BBYPASS2",
+                "dir": "INPUT",
+                "wire": "TX8B10BBYPASS2"
+            },
+            "TX8B10BBYPASS3": {
+                "primary": "TX8B10BBYPASS3",
+                "dir": "INPUT",
+                "wire": "TX8B10BBYPASS3"
+            },
+            "TX8B10BBYPASS4": {
+                "primary": "TX8B10BBYPASS4",
+                "dir": "INPUT",
+                "wire": "TX8B10BBYPASS4"
+            },
+            "TX8B10BBYPASS5": {
+                "primary": "TX8B10BBYPASS5",
+                "dir": "INPUT",
+                "wire": "TX8B10BBYPASS5"
+            },
+            "TX8B10BBYPASS6": {
+                "primary": "TX8B10BBYPASS6",
+                "dir": "INPUT",
+                "wire": "TX8B10BBYPASS6"
+            },
+            "TX8B10BBYPASS7": {
+                "primary": "TX8B10BBYPASS7",
+                "dir": "INPUT",
+                "wire": "TX8B10BBYPASS7"
+            },
+            "TX8B10BEN": {
+                "primary": "TX8B10BEN",
+                "dir": "INPUT",
+                "wire": "TX8B10BEN"
+            },
+            "TXBUFDIFFCTRL0": {
+                "primary": "TXBUFDIFFCTRL0",
+                "dir": "INPUT",
+                "wire": "TXBUFDIFFCTRL0"
+            },
+            "TXBUFDIFFCTRL1": {
+                "primary": "TXBUFDIFFCTRL1",
+                "dir": "INPUT",
+                "wire": "TXBUFDIFFCTRL1"
+            },
+            "TXBUFDIFFCTRL2": {
+                "primary": "TXBUFDIFFCTRL2",
+                "dir": "INPUT",
+                "wire": "TXBUFDIFFCTRL2"
+            },
+            "TXBUFSTATUS0": {
+                "primary": "TXBUFSTATUS0",
+                "dir": "OUTPUT",
+                "wire": "TXBUFSTATUS0"
+            },
+            "TXBUFSTATUS1": {
+                "primary": "TXBUFSTATUS1",
+                "dir": "OUTPUT",
+                "wire": "TXBUFSTATUS1"
+            },
+            "TXCHARDISPMODE0": {
+                "primary": "TXCHARDISPMODE0",
+                "dir": "INPUT",
+                "wire": "TXCHARDISPMODE0"
+            },
+            "TXCHARDISPMODE1": {
+                "primary": "TXCHARDISPMODE1",
+                "dir": "INPUT",
+                "wire": "TXCHARDISPMODE1"
+            },
+            "TXCHARDISPMODE2": {
+                "primary": "TXCHARDISPMODE2",
+                "dir": "INPUT",
+                "wire": "TXCHARDISPMODE2"
+            },
+            "TXCHARDISPMODE3": {
+                "primary": "TXCHARDISPMODE3",
+                "dir": "INPUT",
+                "wire": "TXCHARDISPMODE3"
+            },
+            "TXCHARDISPMODE4": {
+                "primary": "TXCHARDISPMODE4",
+                "dir": "INPUT",
+                "wire": "TXCHARDISPMODE4"
+            },
+            "TXCHARDISPMODE5": {
+                "primary": "TXCHARDISPMODE5",
+                "dir": "INPUT",
+                "wire": "TXCHARDISPMODE5"
+            },
+            "TXCHARDISPMODE6": {
+                "primary": "TXCHARDISPMODE6",
+                "dir": "INPUT",
+                "wire": "TXCHARDISPMODE6"
+            },
+            "TXCHARDISPMODE7": {
+                "primary": "TXCHARDISPMODE7",
+                "dir": "INPUT",
+                "wire": "TXCHARDISPMODE7"
+            },
+            "TXCHARDISPVAL0": {
+                "primary": "TXCHARDISPVAL0",
+                "dir": "INPUT",
+                "wire": "TXCHARDISPVAL0"
+            },
+            "TXCHARDISPVAL1": {
+                "primary": "TXCHARDISPVAL1",
+                "dir": "INPUT",
+                "wire": "TXCHARDISPVAL1"
+            },
+            "TXCHARDISPVAL2": {
+                "primary": "TXCHARDISPVAL2",
+                "dir": "INPUT",
+                "wire": "TXCHARDISPVAL2"
+            },
+            "TXCHARDISPVAL3": {
+                "primary": "TXCHARDISPVAL3",
+                "dir": "INPUT",
+                "wire": "TXCHARDISPVAL3"
+            },
+            "TXCHARDISPVAL4": {
+                "primary": "TXCHARDISPVAL4",
+                "dir": "INPUT",
+                "wire": "TXCHARDISPVAL4"
+            },
+            "TXCHARDISPVAL5": {
+                "primary": "TXCHARDISPVAL5",
+                "dir": "INPUT",
+                "wire": "TXCHARDISPVAL5"
+            },
+            "TXCHARDISPVAL6": {
+                "primary": "TXCHARDISPVAL6",
+                "dir": "INPUT",
+                "wire": "TXCHARDISPVAL6"
+            },
+            "TXCHARDISPVAL7": {
+                "primary": "TXCHARDISPVAL7",
+                "dir": "INPUT",
+                "wire": "TXCHARDISPVAL7"
+            },
+            "TXCHARISK0": {
+                "primary": "TXCHARISK0",
+                "dir": "INPUT",
+                "wire": "TXCHARISK0"
+            },
+            "TXCHARISK1": {
+                "primary": "TXCHARISK1",
+                "dir": "INPUT",
+                "wire": "TXCHARISK1"
+            },
+            "TXCHARISK2": {
+                "primary": "TXCHARISK2",
+                "dir": "INPUT",
+                "wire": "TXCHARISK2"
+            },
+            "TXCHARISK3": {
+                "primary": "TXCHARISK3",
+                "dir": "INPUT",
+                "wire": "TXCHARISK3"
+            },
+            "TXCHARISK4": {
+                "primary": "TXCHARISK4",
+                "dir": "INPUT",
+                "wire": "TXCHARISK4"
+            },
+            "TXCHARISK5": {
+                "primary": "TXCHARISK5",
+                "dir": "INPUT",
+                "wire": "TXCHARISK5"
+            },
+            "TXCHARISK6": {
+                "primary": "TXCHARISK6",
+                "dir": "INPUT",
+                "wire": "TXCHARISK6"
+            },
+            "TXCHARISK7": {
+                "primary": "TXCHARISK7",
+                "dir": "INPUT",
+                "wire": "TXCHARISK7"
+            },
+            "TXCOMFINISH": {
+                "primary": "TXCOMFINISH",
+                "dir": "OUTPUT",
+                "wire": "TXCOMFINISH"
+            },
+            "TXCOMINIT": {
+                "primary": "TXCOMINIT",
+                "dir": "INPUT",
+                "wire": "TXCOMINIT"
+            },
+            "TXCOMSAS": {
+                "primary": "TXCOMSAS",
+                "dir": "INPUT",
+                "wire": "TXCOMSAS"
+            },
+            "TXCOMWAKE": {
+                "primary": "TXCOMWAKE",
+                "dir": "INPUT",
+                "wire": "TXCOMWAKE"
+            },
+            "TXDATA0": {
+                "primary": "TXDATA0",
+                "dir": "INPUT",
+                "wire": "TXDATA0"
+            },
+            "TXDATA1": {
+                "primary": "TXDATA1",
+                "dir": "INPUT",
+                "wire": "TXDATA1"
+            },
+            "TXDATA2": {
+                "primary": "TXDATA2",
+                "dir": "INPUT",
+                "wire": "TXDATA2"
+            },
+            "TXDATA3": {
+                "primary": "TXDATA3",
+                "dir": "INPUT",
+                "wire": "TXDATA3"
+            },
+            "TXDATA4": {
+                "primary": "TXDATA4",
+                "dir": "INPUT",
+                "wire": "TXDATA4"
+            },
+            "TXDATA5": {
+                "primary": "TXDATA5",
+                "dir": "INPUT",
+                "wire": "TXDATA5"
+            },
+            "TXDATA6": {
+                "primary": "TXDATA6",
+                "dir": "INPUT",
+                "wire": "TXDATA6"
+            },
+            "TXDATA7": {
+                "primary": "TXDATA7",
+                "dir": "INPUT",
+                "wire": "TXDATA7"
+            },
+            "TXDATA8": {
+                "primary": "TXDATA8",
+                "dir": "INPUT",
+                "wire": "TXDATA8"
+            },
+            "TXDATA9": {
+                "primary": "TXDATA9",
+                "dir": "INPUT",
+                "wire": "TXDATA9"
+            },
+            "TXDATA10": {
+                "primary": "TXDATA10",
+                "dir": "INPUT",
+                "wire": "TXDATA10"
+            },
+            "TXDATA11": {
+                "primary": "TXDATA11",
+                "dir": "INPUT",
+                "wire": "TXDATA11"
+            },
+            "TXDATA12": {
+                "primary": "TXDATA12",
+                "dir": "INPUT",
+                "wire": "TXDATA12"
+            },
+            "TXDATA13": {
+                "primary": "TXDATA13",
+                "dir": "INPUT",
+                "wire": "TXDATA13"
+            },
+            "TXDATA14": {
+                "primary": "TXDATA14",
+                "dir": "INPUT",
+                "wire": "TXDATA14"
+            },
+            "TXDATA15": {
+                "primary": "TXDATA15",
+                "dir": "INPUT",
+                "wire": "TXDATA15"
+            },
+            "TXDATA16": {
+                "primary": "TXDATA16",
+                "dir": "INPUT",
+                "wire": "TXDATA16"
+            },
+            "TXDATA17": {
+                "primary": "TXDATA17",
+                "dir": "INPUT",
+                "wire": "TXDATA17"
+            },
+            "TXDATA18": {
+                "primary": "TXDATA18",
+                "dir": "INPUT",
+                "wire": "TXDATA18"
+            },
+            "TXDATA19": {
+                "primary": "TXDATA19",
+                "dir": "INPUT",
+                "wire": "TXDATA19"
+            },
+            "TXDATA20": {
+                "primary": "TXDATA20",
+                "dir": "INPUT",
+                "wire": "TXDATA20"
+            },
+            "TXDATA21": {
+                "primary": "TXDATA21",
+                "dir": "INPUT",
+                "wire": "TXDATA21"
+            },
+            "TXDATA22": {
+                "primary": "TXDATA22",
+                "dir": "INPUT",
+                "wire": "TXDATA22"
+            },
+            "TXDATA23": {
+                "primary": "TXDATA23",
+                "dir": "INPUT",
+                "wire": "TXDATA23"
+            },
+            "TXDATA24": {
+                "primary": "TXDATA24",
+                "dir": "INPUT",
+                "wire": "TXDATA24"
+            },
+            "TXDATA25": {
+                "primary": "TXDATA25",
+                "dir": "INPUT",
+                "wire": "TXDATA25"
+            },
+            "TXDATA26": {
+                "primary": "TXDATA26",
+                "dir": "INPUT",
+                "wire": "TXDATA26"
+            },
+            "TXDATA27": {
+                "primary": "TXDATA27",
+                "dir": "INPUT",
+                "wire": "TXDATA27"
+            },
+            "TXDATA28": {
+                "primary": "TXDATA28",
+                "dir": "INPUT",
+                "wire": "TXDATA28"
+            },
+            "TXDATA29": {
+                "primary": "TXDATA29",
+                "dir": "INPUT",
+                "wire": "TXDATA29"
+            },
+            "TXDATA30": {
+                "primary": "TXDATA30",
+                "dir": "INPUT",
+                "wire": "TXDATA30"
+            },
+            "TXDATA31": {
+                "primary": "TXDATA31",
+                "dir": "INPUT",
+                "wire": "TXDATA31"
+            },
+            "TXDATA32": {
+                "primary": "TXDATA32",
+                "dir": "INPUT",
+                "wire": "TXDATA32"
+            },
+            "TXDATA33": {
+                "primary": "TXDATA33",
+                "dir": "INPUT",
+                "wire": "TXDATA33"
+            },
+            "TXDATA34": {
+                "primary": "TXDATA34",
+                "dir": "INPUT",
+                "wire": "TXDATA34"
+            },
+            "TXDATA35": {
+                "primary": "TXDATA35",
+                "dir": "INPUT",
+                "wire": "TXDATA35"
+            },
+            "TXDATA36": {
+                "primary": "TXDATA36",
+                "dir": "INPUT",
+                "wire": "TXDATA36"
+            },
+            "TXDATA37": {
+                "primary": "TXDATA37",
+                "dir": "INPUT",
+                "wire": "TXDATA37"
+            },
+            "TXDATA38": {
+                "primary": "TXDATA38",
+                "dir": "INPUT",
+                "wire": "TXDATA38"
+            },
+            "TXDATA39": {
+                "primary": "TXDATA39",
+                "dir": "INPUT",
+                "wire": "TXDATA39"
+            },
+            "TXDATA40": {
+                "primary": "TXDATA40",
+                "dir": "INPUT",
+                "wire": "TXDATA40"
+            },
+            "TXDATA41": {
+                "primary": "TXDATA41",
+                "dir": "INPUT",
+                "wire": "TXDATA41"
+            },
+            "TXDATA42": {
+                "primary": "TXDATA42",
+                "dir": "INPUT",
+                "wire": "TXDATA42"
+            },
+            "TXDATA43": {
+                "primary": "TXDATA43",
+                "dir": "INPUT",
+                "wire": "TXDATA43"
+            },
+            "TXDATA44": {
+                "primary": "TXDATA44",
+                "dir": "INPUT",
+                "wire": "TXDATA44"
+            },
+            "TXDATA45": {
+                "primary": "TXDATA45",
+                "dir": "INPUT",
+                "wire": "TXDATA45"
+            },
+            "TXDATA46": {
+                "primary": "TXDATA46",
+                "dir": "INPUT",
+                "wire": "TXDATA46"
+            },
+            "TXDATA47": {
+                "primary": "TXDATA47",
+                "dir": "INPUT",
+                "wire": "TXDATA47"
+            },
+            "TXDATA48": {
+                "primary": "TXDATA48",
+                "dir": "INPUT",
+                "wire": "TXDATA48"
+            },
+            "TXDATA49": {
+                "primary": "TXDATA49",
+                "dir": "INPUT",
+                "wire": "TXDATA49"
+            },
+            "TXDATA50": {
+                "primary": "TXDATA50",
+                "dir": "INPUT",
+                "wire": "TXDATA50"
+            },
+            "TXDATA51": {
+                "primary": "TXDATA51",
+                "dir": "INPUT",
+                "wire": "TXDATA51"
+            },
+            "TXDATA52": {
+                "primary": "TXDATA52",
+                "dir": "INPUT",
+                "wire": "TXDATA52"
+            },
+            "TXDATA53": {
+                "primary": "TXDATA53",
+                "dir": "INPUT",
+                "wire": "TXDATA53"
+            },
+            "TXDATA54": {
+                "primary": "TXDATA54",
+                "dir": "INPUT",
+                "wire": "TXDATA54"
+            },
+            "TXDATA55": {
+                "primary": "TXDATA55",
+                "dir": "INPUT",
+                "wire": "TXDATA55"
+            },
+            "TXDATA56": {
+                "primary": "TXDATA56",
+                "dir": "INPUT",
+                "wire": "TXDATA56"
+            },
+            "TXDATA57": {
+                "primary": "TXDATA57",
+                "dir": "INPUT",
+                "wire": "TXDATA57"
+            },
+            "TXDATA58": {
+                "primary": "TXDATA58",
+                "dir": "INPUT",
+                "wire": "TXDATA58"
+            },
+            "TXDATA59": {
+                "primary": "TXDATA59",
+                "dir": "INPUT",
+                "wire": "TXDATA59"
+            },
+            "TXDATA60": {
+                "primary": "TXDATA60",
+                "dir": "INPUT",
+                "wire": "TXDATA60"
+            },
+            "TXDATA61": {
+                "primary": "TXDATA61",
+                "dir": "INPUT",
+                "wire": "TXDATA61"
+            },
+            "TXDATA62": {
+                "primary": "TXDATA62",
+                "dir": "INPUT",
+                "wire": "TXDATA62"
+            },
+            "TXDATA63": {
+                "primary": "TXDATA63",
+                "dir": "INPUT",
+                "wire": "TXDATA63"
+            },
+            "TXDEEMPH": {
+                "primary": "TXDEEMPH",
+                "dir": "INPUT",
+                "wire": "TXDEEMPH"
+            },
+            "TXDETECTRX": {
+                "primary": "TXDETECTRX",
+                "dir": "INPUT",
+                "wire": "TXDETECTRX"
+            },
+            "TXDIFFCTRL0": {
+                "primary": "TXDIFFCTRL0",
+                "dir": "INPUT",
+                "wire": "TXDIFFCTRL0"
+            },
+            "TXDIFFCTRL1": {
+                "primary": "TXDIFFCTRL1",
+                "dir": "INPUT",
+                "wire": "TXDIFFCTRL1"
+            },
+            "TXDIFFCTRL2": {
+                "primary": "TXDIFFCTRL2",
+                "dir": "INPUT",
+                "wire": "TXDIFFCTRL2"
+            },
+            "TXDIFFCTRL3": {
+                "primary": "TXDIFFCTRL3",
+                "dir": "INPUT",
+                "wire": "TXDIFFCTRL3"
+            },
+            "TXDIFFPD": {
+                "primary": "TXDIFFPD",
+                "dir": "INPUT",
+                "wire": "TXDIFFPD"
+            },
+            "TXDLYBYPASS": {
+                "primary": "TXDLYBYPASS",
+                "dir": "INPUT",
+                "wire": "TXDLYBYPASS"
+            },
+            "TXDLYEN": {
+                "primary": "TXDLYEN",
+                "dir": "INPUT",
+                "wire": "TXDLYEN"
+            },
+            "TXDLYHOLD": {
+                "primary": "TXDLYHOLD",
+                "dir": "INPUT",
+                "wire": "TXDLYHOLD"
+            },
+            "TXDLYOVRDEN": {
+                "primary": "TXDLYOVRDEN",
+                "dir": "INPUT",
+                "wire": "TXDLYOVRDEN"
+            },
+            "TXDLYSRESET": {
+                "primary": "TXDLYSRESET",
+                "dir": "INPUT",
+                "wire": "TXDLYSRESET"
+            },
+            "TXDLYSRESETDONE": {
+                "primary": "TXDLYSRESETDONE",
+                "dir": "OUTPUT",
+                "wire": "TXDLYSRESETDONE"
+            },
+            "TXDLYTESTENB": {
+                "primary": "TXDLYTESTENB",
+                "dir": "INPUT",
+                "wire": "TXDLYTESTENB"
+            },
+            "TXDLYUPDOWN": {
+                "primary": "TXDLYUPDOWN",
+                "dir": "INPUT",
+                "wire": "TXDLYUPDOWN"
+            },
+            "TXELECIDLE": {
+                "primary": "TXELECIDLE",
+                "dir": "INPUT",
+                "wire": "TXELECIDLE"
+            },
+            "TXGEARBOXREADY": {
+                "primary": "TXGEARBOXREADY",
+                "dir": "OUTPUT",
+                "wire": "TXGEARBOXREADY"
+            },
+            "TXHEADER0": {
+                "primary": "TXHEADER0",
+                "dir": "INPUT",
+                "wire": "TXHEADER0"
+            },
+            "TXHEADER1": {
+                "primary": "TXHEADER1",
+                "dir": "INPUT",
+                "wire": "TXHEADER1"
+            },
+            "TXHEADER2": {
+                "primary": "TXHEADER2",
+                "dir": "INPUT",
+                "wire": "TXHEADER2"
+            },
+            "TXINHIBIT": {
+                "primary": "TXINHIBIT",
+                "dir": "INPUT",
+                "wire": "TXINHIBIT"
+            },
+            "TXMAINCURSOR0": {
+                "primary": "TXMAINCURSOR0",
+                "dir": "INPUT",
+                "wire": "TXMAINCURSOR0"
+            },
+            "TXMAINCURSOR1": {
+                "primary": "TXMAINCURSOR1",
+                "dir": "INPUT",
+                "wire": "TXMAINCURSOR1"
+            },
+            "TXMAINCURSOR2": {
+                "primary": "TXMAINCURSOR2",
+                "dir": "INPUT",
+                "wire": "TXMAINCURSOR2"
+            },
+            "TXMAINCURSOR3": {
+                "primary": "TXMAINCURSOR3",
+                "dir": "INPUT",
+                "wire": "TXMAINCURSOR3"
+            },
+            "TXMAINCURSOR4": {
+                "primary": "TXMAINCURSOR4",
+                "dir": "INPUT",
+                "wire": "TXMAINCURSOR4"
+            },
+            "TXMAINCURSOR5": {
+                "primary": "TXMAINCURSOR5",
+                "dir": "INPUT",
+                "wire": "TXMAINCURSOR5"
+            },
+            "TXMAINCURSOR6": {
+                "primary": "TXMAINCURSOR6",
+                "dir": "INPUT",
+                "wire": "TXMAINCURSOR6"
+            },
+            "TXMARGIN0": {
+                "primary": "TXMARGIN0",
+                "dir": "INPUT",
+                "wire": "TXMARGIN0"
+            },
+            "TXMARGIN1": {
+                "primary": "TXMARGIN1",
+                "dir": "INPUT",
+                "wire": "TXMARGIN1"
+            },
+            "TXMARGIN2": {
+                "primary": "TXMARGIN2",
+                "dir": "INPUT",
+                "wire": "TXMARGIN2"
+            },
+            "TXOUTCLK": {
+                "primary": "TXOUTCLK",
+                "dir": "OUTPUT",
+                "wire": "TXOUTCLK"
+            },
+            "TXOUTCLKFABRIC": {
+                "primary": "TXOUTCLKFABRIC",
+                "dir": "OUTPUT",
+                "wire": "TXOUTCLKFABRIC"
+            },
+            "TXOUTCLKPCS": {
+                "primary": "TXOUTCLKPCS",
+                "dir": "OUTPUT",
+                "wire": "TXOUTCLKPCS"
+            },
+            "TXOUTCLKSEL0": {
+                "primary": "TXOUTCLKSEL0",
+                "dir": "INPUT",
+                "wire": "TXOUTCLKSEL0"
+            },
+            "TXOUTCLKSEL1": {
+                "primary": "TXOUTCLKSEL1",
+                "dir": "INPUT",
+                "wire": "TXOUTCLKSEL1"
+            },
+            "TXOUTCLKSEL2": {
+                "primary": "TXOUTCLKSEL2",
+                "dir": "INPUT",
+                "wire": "TXOUTCLKSEL2"
+            },
+            "TXPCSRESET": {
+                "primary": "TXPCSRESET",
+                "dir": "INPUT",
+                "wire": "TXPCSRESET"
+            },
+            "TXPD0": {
+                "primary": "TXPD0",
+                "dir": "INPUT",
+                "wire": "TXPD0"
+            },
+            "TXPD1": {
+                "primary": "TXPD1",
+                "dir": "INPUT",
+                "wire": "TXPD1"
+            },
+            "TXPDELECIDLEMODE": {
+                "primary": "TXPDELECIDLEMODE",
+                "dir": "INPUT",
+                "wire": "TXPDELECIDLEMODE"
+            },
+            "TXPHALIGN": {
+                "primary": "TXPHALIGN",
+                "dir": "INPUT",
+                "wire": "TXPHALIGN"
+            },
+            "TXPHALIGNDONE": {
+                "primary": "TXPHALIGNDONE",
+                "dir": "OUTPUT",
+                "wire": "TXPHALIGNDONE"
+            },
+            "TXPHALIGNEN": {
+                "primary": "TXPHALIGNEN",
+                "dir": "INPUT",
+                "wire": "TXPHALIGNEN"
+            },
+            "TXPHDLYPD": {
+                "primary": "TXPHDLYPD",
+                "dir": "INPUT",
+                "wire": "TXPHDLYPD"
+            },
+            "TXPHDLYRESET": {
+                "primary": "TXPHDLYRESET",
+                "dir": "INPUT",
+                "wire": "TXPHDLYRESET"
+            },
+            "TXPHDLYTSTCLK": {
+                "primary": "TXPHDLYTSTCLK",
+                "dir": "INPUT",
+                "wire": "TXPHDLYTSTCLK"
+            },
+            "TXPHINIT": {
+                "primary": "TXPHINIT",
+                "dir": "INPUT",
+                "wire": "TXPHINIT"
+            },
+            "TXPHINITDONE": {
+                "primary": "TXPHINITDONE",
+                "dir": "OUTPUT",
+                "wire": "TXPHINITDONE"
+            },
+            "TXPHOVRDEN": {
+                "primary": "TXPHOVRDEN",
+                "dir": "INPUT",
+                "wire": "TXPHOVRDEN"
+            },
+            "TXPISOPD": {
+                "primary": "TXPISOPD",
+                "dir": "INPUT",
+                "wire": "TXPISOPD"
+            },
+            "TXPMARESET": {
+                "primary": "TXPMARESET",
+                "dir": "INPUT",
+                "wire": "TXPMARESET"
+            },
+            "TXPOLARITY": {
+                "primary": "TXPOLARITY",
+                "dir": "INPUT",
+                "wire": "TXPOLARITY"
+            },
+            "TXPOSTCURSOR0": {
+                "primary": "TXPOSTCURSOR0",
+                "dir": "INPUT",
+                "wire": "TXPOSTCURSOR0"
+            },
+            "TXPOSTCURSOR1": {
+                "primary": "TXPOSTCURSOR1",
+                "dir": "INPUT",
+                "wire": "TXPOSTCURSOR1"
+            },
+            "TXPOSTCURSOR2": {
+                "primary": "TXPOSTCURSOR2",
+                "dir": "INPUT",
+                "wire": "TXPOSTCURSOR2"
+            },
+            "TXPOSTCURSOR3": {
+                "primary": "TXPOSTCURSOR3",
+                "dir": "INPUT",
+                "wire": "TXPOSTCURSOR3"
+            },
+            "TXPOSTCURSOR4": {
+                "primary": "TXPOSTCURSOR4",
+                "dir": "INPUT",
+                "wire": "TXPOSTCURSOR4"
+            },
+            "TXPOSTCURSORINV": {
+                "primary": "TXPOSTCURSORINV",
+                "dir": "INPUT",
+                "wire": "TXPOSTCURSORINV"
+            },
+            "TXPRBSFORCEERR": {
+                "primary": "TXPRBSFORCEERR",
+                "dir": "INPUT",
+                "wire": "TXPRBSFORCEERR"
+            },
+            "TXPRBSSEL0": {
+                "primary": "TXPRBSSEL0",
+                "dir": "INPUT",
+                "wire": "TXPRBSSEL0"
+            },
+            "TXPRBSSEL1": {
+                "primary": "TXPRBSSEL1",
+                "dir": "INPUT",
+                "wire": "TXPRBSSEL1"
+            },
+            "TXPRBSSEL2": {
+                "primary": "TXPRBSSEL2",
+                "dir": "INPUT",
+                "wire": "TXPRBSSEL2"
+            },
+            "TXPRECURSOR0": {
+                "primary": "TXPRECURSOR0",
+                "dir": "INPUT",
+                "wire": "TXPRECURSOR0"
+            },
+            "TXPRECURSOR1": {
+                "primary": "TXPRECURSOR1",
+                "dir": "INPUT",
+                "wire": "TXPRECURSOR1"
+            },
+            "TXPRECURSOR2": {
+                "primary": "TXPRECURSOR2",
+                "dir": "INPUT",
+                "wire": "TXPRECURSOR2"
+            },
+            "TXPRECURSOR3": {
+                "primary": "TXPRECURSOR3",
+                "dir": "INPUT",
+                "wire": "TXPRECURSOR3"
+            },
+            "TXPRECURSOR4": {
+                "primary": "TXPRECURSOR4",
+                "dir": "INPUT",
+                "wire": "TXPRECURSOR4"
+            },
+            "TXPRECURSORINV": {
+                "primary": "TXPRECURSORINV",
+                "dir": "INPUT",
+                "wire": "TXPRECURSORINV"
+            },
+            "TXQPIBIASEN": {
+                "primary": "TXQPIBIASEN",
+                "dir": "INPUT",
+                "wire": "TXQPIBIASEN"
+            },
+            "TXQPISENN": {
+                "primary": "TXQPISENN",
+                "dir": "OUTPUT",
+                "wire": "TXQPISENN"
+            },
+            "TXQPISENP": {
+                "primary": "TXQPISENP",
+                "dir": "OUTPUT",
+                "wire": "TXQPISENP"
+            },
+            "TXQPISTRONGPDOWN": {
+                "primary": "TXQPISTRONGPDOWN",
+                "dir": "INPUT",
+                "wire": "TXQPISTRONGPDOWN"
+            },
+            "TXQPIWEAKPUP": {
+                "primary": "TXQPIWEAKPUP",
+                "dir": "INPUT",
+                "wire": "TXQPIWEAKPUP"
+            },
+            "TXRATE0": {
+                "primary": "TXRATE0",
+                "dir": "INPUT",
+                "wire": "TXRATE0"
+            },
+            "TXRATE1": {
+                "primary": "TXRATE1",
+                "dir": "INPUT",
+                "wire": "TXRATE1"
+            },
+            "TXRATE2": {
+                "primary": "TXRATE2",
+                "dir": "INPUT",
+                "wire": "TXRATE2"
+            },
+            "TXRATEDONE": {
+                "primary": "TXRATEDONE",
+                "dir": "OUTPUT",
+                "wire": "TXRATEDONE"
+            },
+            "TXRESETDONE": {
+                "primary": "TXRESETDONE",
+                "dir": "OUTPUT",
+                "wire": "TXRESETDONE"
+            },
+            "TXRUNDISP0": {
+                "primary": "TXRUNDISP0",
+                "dir": "OUTPUT",
+                "wire": "TXRUNDISP0"
+            },
+            "TXRUNDISP1": {
+                "primary": "TXRUNDISP1",
+                "dir": "OUTPUT",
+                "wire": "TXRUNDISP1"
+            },
+            "TXRUNDISP2": {
+                "primary": "TXRUNDISP2",
+                "dir": "OUTPUT",
+                "wire": "TXRUNDISP2"
+            },
+            "TXRUNDISP3": {
+                "primary": "TXRUNDISP3",
+                "dir": "OUTPUT",
+                "wire": "TXRUNDISP3"
+            },
+            "TXRUNDISP4": {
+                "primary": "TXRUNDISP4",
+                "dir": "OUTPUT",
+                "wire": "TXRUNDISP4"
+            },
+            "TXRUNDISP5": {
+                "primary": "TXRUNDISP5",
+                "dir": "OUTPUT",
+                "wire": "TXRUNDISP5"
+            },
+            "TXRUNDISP6": {
+                "primary": "TXRUNDISP6",
+                "dir": "OUTPUT",
+                "wire": "TXRUNDISP6"
+            },
+            "TXRUNDISP7": {
+                "primary": "TXRUNDISP7",
+                "dir": "OUTPUT",
+                "wire": "TXRUNDISP7"
+            },
+            "TXSEQUENCE0": {
+                "primary": "TXSEQUENCE0",
+                "dir": "INPUT",
+                "wire": "TXSEQUENCE0"
+            },
+            "TXSEQUENCE1": {
+                "primary": "TXSEQUENCE1",
+                "dir": "INPUT",
+                "wire": "TXSEQUENCE1"
+            },
+            "TXSEQUENCE2": {
+                "primary": "TXSEQUENCE2",
+                "dir": "INPUT",
+                "wire": "TXSEQUENCE2"
+            },
+            "TXSEQUENCE3": {
+                "primary": "TXSEQUENCE3",
+                "dir": "INPUT",
+                "wire": "TXSEQUENCE3"
+            },
+            "TXSEQUENCE4": {
+                "primary": "TXSEQUENCE4",
+                "dir": "INPUT",
+                "wire": "TXSEQUENCE4"
+            },
+            "TXSEQUENCE5": {
+                "primary": "TXSEQUENCE5",
+                "dir": "INPUT",
+                "wire": "TXSEQUENCE5"
+            },
+            "TXSEQUENCE6": {
+                "primary": "TXSEQUENCE6",
+                "dir": "INPUT",
+                "wire": "TXSEQUENCE6"
+            },
+            "TXSTARTSEQ": {
+                "primary": "TXSTARTSEQ",
+                "dir": "INPUT",
+                "wire": "TXSTARTSEQ"
+            },
+            "TXSWING": {
+                "primary": "TXSWING",
+                "dir": "INPUT",
+                "wire": "TXSWING"
+            },
+            "TXSYSCLKSEL0": {
+                "primary": "TXSYSCLKSEL0",
+                "dir": "INPUT",
+                "wire": "TXSYSCLKSEL0"
+            },
+            "TXSYSCLKSEL1": {
+                "primary": "TXSYSCLKSEL1",
+                "dir": "INPUT",
+                "wire": "TXSYSCLKSEL1"
+            },
+            "TXUSERRDY": {
+                "primary": "TXUSERRDY",
+                "dir": "INPUT",
+                "wire": "TXUSERRDY"
+            },
+            "TXUSRCLK": {
+                "primary": "TXUSRCLK",
+                "dir": "INPUT",
+                "wire": "TXUSRCLK"
+            },
+            "TXUSRCLK2": {
+                "primary": "TXUSRCLK2",
+                "dir": "INPUT",
+                "wire": "TXUSRCLK2"
+            }
+        }
+    }
+}

--- a/kintex7/site_type_GTXE2_COMMON.json
+++ b/kintex7/site_type_GTXE2_COMMON.json
@@ -1,0 +1,1364 @@
+{
+    "GTXE2_COMMON": {
+        "bels": {
+            "GTXE2_COMMON": {
+                "class": "BEL",
+                "pins": {
+                    "BGBYPASSB": {
+                        "dir": "INPUT",
+                        "wire": "BGBYPASSB"
+                    },
+                    "BGMONITORENB": {
+                        "dir": "INPUT",
+                        "wire": "BGMONITORENB"
+                    },
+                    "BGPDB": {
+                        "dir": "INPUT",
+                        "wire": "BGPDB"
+                    },
+                    "BGRCALOVRD0": {
+                        "dir": "INPUT",
+                        "wire": "BGRCALOVRD0"
+                    },
+                    "BGRCALOVRD1": {
+                        "dir": "INPUT",
+                        "wire": "BGRCALOVRD1"
+                    },
+                    "BGRCALOVRD2": {
+                        "dir": "INPUT",
+                        "wire": "BGRCALOVRD2"
+                    },
+                    "BGRCALOVRD3": {
+                        "dir": "INPUT",
+                        "wire": "BGRCALOVRD3"
+                    },
+                    "BGRCALOVRD4": {
+                        "dir": "INPUT",
+                        "wire": "BGRCALOVRD4"
+                    },
+                    "DRPADDR0": {
+                        "dir": "INPUT",
+                        "wire": "DRPADDR0"
+                    },
+                    "DRPADDR1": {
+                        "dir": "INPUT",
+                        "wire": "DRPADDR1"
+                    },
+                    "DRPADDR2": {
+                        "dir": "INPUT",
+                        "wire": "DRPADDR2"
+                    },
+                    "DRPADDR3": {
+                        "dir": "INPUT",
+                        "wire": "DRPADDR3"
+                    },
+                    "DRPADDR4": {
+                        "dir": "INPUT",
+                        "wire": "DRPADDR4"
+                    },
+                    "DRPADDR5": {
+                        "dir": "INPUT",
+                        "wire": "DRPADDR5"
+                    },
+                    "DRPADDR6": {
+                        "dir": "INPUT",
+                        "wire": "DRPADDR6"
+                    },
+                    "DRPADDR7": {
+                        "dir": "INPUT",
+                        "wire": "DRPADDR7"
+                    },
+                    "DRPCLK": {
+                        "dir": "INPUT",
+                        "wire": "DRPCLKINV_OUT"
+                    },
+                    "DRPDI0": {
+                        "dir": "INPUT",
+                        "wire": "DRPDI0"
+                    },
+                    "DRPDI1": {
+                        "dir": "INPUT",
+                        "wire": "DRPDI1"
+                    },
+                    "DRPDI2": {
+                        "dir": "INPUT",
+                        "wire": "DRPDI2"
+                    },
+                    "DRPDI3": {
+                        "dir": "INPUT",
+                        "wire": "DRPDI3"
+                    },
+                    "DRPDI4": {
+                        "dir": "INPUT",
+                        "wire": "DRPDI4"
+                    },
+                    "DRPDI5": {
+                        "dir": "INPUT",
+                        "wire": "DRPDI5"
+                    },
+                    "DRPDI6": {
+                        "dir": "INPUT",
+                        "wire": "DRPDI6"
+                    },
+                    "DRPDI7": {
+                        "dir": "INPUT",
+                        "wire": "DRPDI7"
+                    },
+                    "DRPDI8": {
+                        "dir": "INPUT",
+                        "wire": "DRPDI8"
+                    },
+                    "DRPDI9": {
+                        "dir": "INPUT",
+                        "wire": "DRPDI9"
+                    },
+                    "DRPDI10": {
+                        "dir": "INPUT",
+                        "wire": "DRPDI10"
+                    },
+                    "DRPDI11": {
+                        "dir": "INPUT",
+                        "wire": "DRPDI11"
+                    },
+                    "DRPDI12": {
+                        "dir": "INPUT",
+                        "wire": "DRPDI12"
+                    },
+                    "DRPDI13": {
+                        "dir": "INPUT",
+                        "wire": "DRPDI13"
+                    },
+                    "DRPDI14": {
+                        "dir": "INPUT",
+                        "wire": "DRPDI14"
+                    },
+                    "DRPDI15": {
+                        "dir": "INPUT",
+                        "wire": "DRPDI15"
+                    },
+                    "DRPDO0": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPDO0"
+                    },
+                    "DRPDO1": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPDO1"
+                    },
+                    "DRPDO2": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPDO2"
+                    },
+                    "DRPDO3": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPDO3"
+                    },
+                    "DRPDO4": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPDO4"
+                    },
+                    "DRPDO5": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPDO5"
+                    },
+                    "DRPDO6": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPDO6"
+                    },
+                    "DRPDO7": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPDO7"
+                    },
+                    "DRPDO8": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPDO8"
+                    },
+                    "DRPDO9": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPDO9"
+                    },
+                    "DRPDO10": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPDO10"
+                    },
+                    "DRPDO11": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPDO11"
+                    },
+                    "DRPDO12": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPDO12"
+                    },
+                    "DRPDO13": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPDO13"
+                    },
+                    "DRPDO14": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPDO14"
+                    },
+                    "DRPDO15": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPDO15"
+                    },
+                    "DRPEN": {
+                        "dir": "INPUT",
+                        "wire": "DRPEN"
+                    },
+                    "DRPRDY": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPRDY"
+                    },
+                    "DRPWE": {
+                        "dir": "INPUT",
+                        "wire": "DRPWE"
+                    },
+                    "GTGREFCLK": {
+                        "dir": "INPUT",
+                        "wire": "GTGREFCLKINV_OUT"
+                    },
+                    "GTNORTHREFCLK0": {
+                        "dir": "INPUT",
+                        "wire": "GTNORTHREFCLK0"
+                    },
+                    "GTNORTHREFCLK1": {
+                        "dir": "INPUT",
+                        "wire": "GTNORTHREFCLK1"
+                    },
+                    "GTREFCLK0": {
+                        "dir": "INPUT",
+                        "wire": "GTREFCLK0"
+                    },
+                    "GTREFCLK1": {
+                        "dir": "INPUT",
+                        "wire": "GTREFCLK1"
+                    },
+                    "GTSOUTHREFCLK0": {
+                        "dir": "INPUT",
+                        "wire": "GTSOUTHREFCLK0"
+                    },
+                    "GTSOUTHREFCLK1": {
+                        "dir": "INPUT",
+                        "wire": "GTSOUTHREFCLK1"
+                    },
+                    "PMARSVD0": {
+                        "dir": "INPUT",
+                        "wire": "PMARSVD0"
+                    },
+                    "PMARSVD1": {
+                        "dir": "INPUT",
+                        "wire": "PMARSVD1"
+                    },
+                    "PMARSVD2": {
+                        "dir": "INPUT",
+                        "wire": "PMARSVD2"
+                    },
+                    "PMARSVD3": {
+                        "dir": "INPUT",
+                        "wire": "PMARSVD3"
+                    },
+                    "PMARSVD4": {
+                        "dir": "INPUT",
+                        "wire": "PMARSVD4"
+                    },
+                    "PMARSVD5": {
+                        "dir": "INPUT",
+                        "wire": "PMARSVD5"
+                    },
+                    "PMARSVD6": {
+                        "dir": "INPUT",
+                        "wire": "PMARSVD6"
+                    },
+                    "PMARSVD7": {
+                        "dir": "INPUT",
+                        "wire": "PMARSVD7"
+                    },
+                    "PMASCANCLK0": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANCLK0INV_OUT"
+                    },
+                    "PMASCANCLK1": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANCLK1INV_OUT"
+                    },
+                    "PMASCANENB": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANENB"
+                    },
+                    "PMASCANIN0": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANIN0"
+                    },
+                    "PMASCANIN1": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANIN1"
+                    },
+                    "PMASCANIN2": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANIN2"
+                    },
+                    "PMASCANIN3": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANIN3"
+                    },
+                    "PMASCANIN4": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANIN4"
+                    },
+                    "PMASCANOUT0": {
+                        "dir": "OUTPUT",
+                        "wire": "PMASCANOUT0"
+                    },
+                    "PMASCANOUT1": {
+                        "dir": "OUTPUT",
+                        "wire": "PMASCANOUT1"
+                    },
+                    "PMASCANOUT2": {
+                        "dir": "OUTPUT",
+                        "wire": "PMASCANOUT2"
+                    },
+                    "PMASCANOUT3": {
+                        "dir": "OUTPUT",
+                        "wire": "PMASCANOUT3"
+                    },
+                    "PMASCANOUT4": {
+                        "dir": "OUTPUT",
+                        "wire": "PMASCANOUT4"
+                    },
+                    "QDPMASCANMODEB": {
+                        "dir": "INPUT",
+                        "wire": "QDPMASCANMODEB"
+                    },
+                    "QDPMASCANRSTEN": {
+                        "dir": "INPUT",
+                        "wire": "QDPMASCANRSTEN"
+                    },
+                    "QPLLCLKSPARE0": {
+                        "dir": "INPUT",
+                        "wire": "QPLLCLKSPARE0INV_OUT"
+                    },
+                    "QPLLCLKSPARE1": {
+                        "dir": "INPUT",
+                        "wire": "QPLLCLKSPARE1INV_OUT"
+                    },
+                    "QPLLDMONITOR0": {
+                        "dir": "OUTPUT",
+                        "wire": "QPLLDMONITOR0"
+                    },
+                    "QPLLDMONITOR1": {
+                        "dir": "OUTPUT",
+                        "wire": "QPLLDMONITOR1"
+                    },
+                    "QPLLDMONITOR2": {
+                        "dir": "OUTPUT",
+                        "wire": "QPLLDMONITOR2"
+                    },
+                    "QPLLDMONITOR3": {
+                        "dir": "OUTPUT",
+                        "wire": "QPLLDMONITOR3"
+                    },
+                    "QPLLDMONITOR4": {
+                        "dir": "OUTPUT",
+                        "wire": "QPLLDMONITOR4"
+                    },
+                    "QPLLDMONITOR5": {
+                        "dir": "OUTPUT",
+                        "wire": "QPLLDMONITOR5"
+                    },
+                    "QPLLDMONITOR6": {
+                        "dir": "OUTPUT",
+                        "wire": "QPLLDMONITOR6"
+                    },
+                    "QPLLDMONITOR7": {
+                        "dir": "OUTPUT",
+                        "wire": "QPLLDMONITOR7"
+                    },
+                    "QPLLFBCLKLOST": {
+                        "dir": "OUTPUT",
+                        "wire": "QPLLFBCLKLOST"
+                    },
+                    "QPLLLOCK": {
+                        "dir": "OUTPUT",
+                        "wire": "QPLLLOCK"
+                    },
+                    "QPLLLOCKDETCLK": {
+                        "dir": "INPUT",
+                        "wire": "QPLLLOCKDETCLKINV_OUT"
+                    },
+                    "QPLLLOCKEN": {
+                        "dir": "INPUT",
+                        "wire": "QPLLLOCKEN"
+                    },
+                    "QPLLOUTCLK": {
+                        "dir": "OUTPUT",
+                        "wire": "QPLLOUTCLK"
+                    },
+                    "QPLLOUTREFCLK": {
+                        "dir": "OUTPUT",
+                        "wire": "QPLLOUTREFCLK"
+                    },
+                    "QPLLOUTRESET": {
+                        "dir": "INPUT",
+                        "wire": "QPLLOUTRESET"
+                    },
+                    "QPLLPD": {
+                        "dir": "INPUT",
+                        "wire": "QPLLPD"
+                    },
+                    "QPLLREFCLKLOST": {
+                        "dir": "OUTPUT",
+                        "wire": "QPLLREFCLKLOST"
+                    },
+                    "QPLLREFCLKSEL0": {
+                        "dir": "INPUT",
+                        "wire": "QPLLREFCLKSEL0"
+                    },
+                    "QPLLREFCLKSEL1": {
+                        "dir": "INPUT",
+                        "wire": "QPLLREFCLKSEL1"
+                    },
+                    "QPLLREFCLKSEL2": {
+                        "dir": "INPUT",
+                        "wire": "QPLLREFCLKSEL2"
+                    },
+                    "QPLLRESET": {
+                        "dir": "INPUT",
+                        "wire": "QPLLRESET"
+                    },
+                    "QPLLRSVD10": {
+                        "dir": "INPUT",
+                        "wire": "QPLLRSVD10"
+                    },
+                    "QPLLRSVD11": {
+                        "dir": "INPUT",
+                        "wire": "QPLLRSVD11"
+                    },
+                    "QPLLRSVD12": {
+                        "dir": "INPUT",
+                        "wire": "QPLLRSVD12"
+                    },
+                    "QPLLRSVD13": {
+                        "dir": "INPUT",
+                        "wire": "QPLLRSVD13"
+                    },
+                    "QPLLRSVD14": {
+                        "dir": "INPUT",
+                        "wire": "QPLLRSVD14"
+                    },
+                    "QPLLRSVD15": {
+                        "dir": "INPUT",
+                        "wire": "QPLLRSVD15"
+                    },
+                    "QPLLRSVD16": {
+                        "dir": "INPUT",
+                        "wire": "QPLLRSVD16"
+                    },
+                    "QPLLRSVD17": {
+                        "dir": "INPUT",
+                        "wire": "QPLLRSVD17"
+                    },
+                    "QPLLRSVD18": {
+                        "dir": "INPUT",
+                        "wire": "QPLLRSVD18"
+                    },
+                    "QPLLRSVD19": {
+                        "dir": "INPUT",
+                        "wire": "QPLLRSVD19"
+                    },
+                    "QPLLRSVD20": {
+                        "dir": "INPUT",
+                        "wire": "QPLLRSVD20"
+                    },
+                    "QPLLRSVD21": {
+                        "dir": "INPUT",
+                        "wire": "QPLLRSVD21"
+                    },
+                    "QPLLRSVD22": {
+                        "dir": "INPUT",
+                        "wire": "QPLLRSVD22"
+                    },
+                    "QPLLRSVD23": {
+                        "dir": "INPUT",
+                        "wire": "QPLLRSVD23"
+                    },
+                    "QPLLRSVD24": {
+                        "dir": "INPUT",
+                        "wire": "QPLLRSVD24"
+                    },
+                    "QPLLRSVD110": {
+                        "dir": "INPUT",
+                        "wire": "QPLLRSVD110"
+                    },
+                    "QPLLRSVD111": {
+                        "dir": "INPUT",
+                        "wire": "QPLLRSVD111"
+                    },
+                    "QPLLRSVD112": {
+                        "dir": "INPUT",
+                        "wire": "QPLLRSVD112"
+                    },
+                    "QPLLRSVD113": {
+                        "dir": "INPUT",
+                        "wire": "QPLLRSVD113"
+                    },
+                    "QPLLRSVD114": {
+                        "dir": "INPUT",
+                        "wire": "QPLLRSVD114"
+                    },
+                    "QPLLRSVD115": {
+                        "dir": "INPUT",
+                        "wire": "QPLLRSVD115"
+                    },
+                    "RCALENB": {
+                        "dir": "INPUT",
+                        "wire": "RCALENB"
+                    },
+                    "REFCLKOUTMONITOR": {
+                        "dir": "OUTPUT",
+                        "wire": "REFCLKOUTMONITOR"
+                    }
+                },
+                "type": "GTXE2_COMMON_GTXE2_COMMON"
+            },
+            "DRPCLKINV": {
+                "class": "RBEL",
+                "pins": {
+                    "DRPCLK": {
+                        "dir": "INPUT",
+                        "wire": "DRPCLK"
+                    },
+                    "DRPCLK_B": {
+                        "dir": "INPUT",
+                        "wire": "DRPCLK"
+                    },
+                    "OUT": {
+                        "dir": "OUTPUT",
+                        "wire": "DRPCLKINV_OUT"
+                    }
+                },
+                "type": "GTXE2_COMMON_DRPCLKINV"
+            },
+            "GTGREFCLKINV": {
+                "class": "RBEL",
+                "pins": {
+                    "GTGREFCLK": {
+                        "dir": "INPUT",
+                        "wire": "GTGREFCLK"
+                    },
+                    "GTGREFCLK_B": {
+                        "dir": "INPUT",
+                        "wire": "GTGREFCLK"
+                    },
+                    "OUT": {
+                        "dir": "OUTPUT",
+                        "wire": "GTGREFCLKINV_OUT"
+                    }
+                },
+                "type": "GTXE2_COMMON_GTGREFCLKINV"
+            },
+            "PMASCANCLK0INV": {
+                "class": "RBEL",
+                "pins": {
+                    "OUT": {
+                        "dir": "OUTPUT",
+                        "wire": "PMASCANCLK0INV_OUT"
+                    },
+                    "PMASCANCLK0": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANCLK0"
+                    },
+                    "PMASCANCLK0_B": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANCLK0"
+                    }
+                },
+                "type": "GTXE2_COMMON_PMASCANCLK0INV"
+            },
+            "PMASCANCLK1INV": {
+                "class": "RBEL",
+                "pins": {
+                    "OUT": {
+                        "dir": "OUTPUT",
+                        "wire": "PMASCANCLK1INV_OUT"
+                    },
+                    "PMASCANCLK1": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANCLK1"
+                    },
+                    "PMASCANCLK1_B": {
+                        "dir": "INPUT",
+                        "wire": "PMASCANCLK1"
+                    }
+                },
+                "type": "GTXE2_COMMON_PMASCANCLK1INV"
+            },
+            "QPLLCLKSPARE0INV": {
+                "class": "RBEL",
+                "pins": {
+                    "OUT": {
+                        "dir": "OUTPUT",
+                        "wire": "QPLLCLKSPARE0INV_OUT"
+                    },
+                    "QPLLCLKSPARE0": {
+                        "dir": "INPUT",
+                        "wire": "QPLLCLKSPARE0"
+                    },
+                    "QPLLCLKSPARE0_B": {
+                        "dir": "INPUT",
+                        "wire": "QPLLCLKSPARE0"
+                    }
+                },
+                "type": "GTXE2_COMMON_QPLLCLKSPARE0INV"
+            },
+            "QPLLCLKSPARE1INV": {
+                "class": "RBEL",
+                "pins": {
+                    "OUT": {
+                        "dir": "OUTPUT",
+                        "wire": "QPLLCLKSPARE1INV_OUT"
+                    },
+                    "QPLLCLKSPARE1": {
+                        "dir": "INPUT",
+                        "wire": "QPLLCLKSPARE1"
+                    },
+                    "QPLLCLKSPARE1_B": {
+                        "dir": "INPUT",
+                        "wire": "QPLLCLKSPARE1"
+                    }
+                },
+                "type": "GTXE2_COMMON_QPLLCLKSPARE1INV"
+            },
+            "QPLLLOCKDETCLKINV": {
+                "class": "RBEL",
+                "pins": {
+                    "OUT": {
+                        "dir": "OUTPUT",
+                        "wire": "QPLLLOCKDETCLKINV_OUT"
+                    },
+                    "QPLLLOCKDETCLK": {
+                        "dir": "INPUT",
+                        "wire": "QPLLLOCKDETCLK"
+                    },
+                    "QPLLLOCKDETCLK_B": {
+                        "dir": "INPUT",
+                        "wire": "QPLLLOCKDETCLK"
+                    }
+                },
+                "type": "GTXE2_COMMON_QPLLLOCKDETCLKINV"
+            }
+        },
+        "pips": [
+            {
+                "bel": "DRPCLKINV",
+                "from_pin": "DRPCLK",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "DRPCLKINV",
+                "from_pin": "DRPCLK_B",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "GTGREFCLKINV",
+                "from_pin": "GTGREFCLK",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "GTGREFCLKINV",
+                "from_pin": "GTGREFCLK_B",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "PMASCANCLK0INV",
+                "from_pin": "PMASCANCLK0",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "PMASCANCLK0INV",
+                "from_pin": "PMASCANCLK0_B",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "PMASCANCLK1INV",
+                "from_pin": "PMASCANCLK1",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "PMASCANCLK1INV",
+                "from_pin": "PMASCANCLK1_B",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "QPLLCLKSPARE0INV",
+                "from_pin": "QPLLCLKSPARE0",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "QPLLCLKSPARE0INV",
+                "from_pin": "QPLLCLKSPARE0_B",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "QPLLCLKSPARE1INV",
+                "from_pin": "QPLLCLKSPARE1",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "QPLLCLKSPARE1INV",
+                "from_pin": "QPLLCLKSPARE1_B",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "QPLLLOCKDETCLKINV",
+                "from_pin": "QPLLLOCKDETCLK",
+                "to_pin": "OUT"
+            },
+            {
+                "bel": "QPLLLOCKDETCLKINV",
+                "from_pin": "QPLLLOCKDETCLK_B",
+                "to_pin": "OUT"
+            }
+        ],
+        "pins": {
+            "BGBYPASSB": {
+                "primary": "BGBYPASSB",
+                "dir": "INPUT",
+                "wire": "BGBYPASSB"
+            },
+            "BGMONITORENB": {
+                "primary": "BGMONITORENB",
+                "dir": "INPUT",
+                "wire": "BGMONITORENB"
+            },
+            "BGPDB": {
+                "primary": "BGPDB",
+                "dir": "INPUT",
+                "wire": "BGPDB"
+            },
+            "BGRCALOVRD0": {
+                "primary": "BGRCALOVRD0",
+                "dir": "INPUT",
+                "wire": "BGRCALOVRD0"
+            },
+            "BGRCALOVRD1": {
+                "primary": "BGRCALOVRD1",
+                "dir": "INPUT",
+                "wire": "BGRCALOVRD1"
+            },
+            "BGRCALOVRD2": {
+                "primary": "BGRCALOVRD2",
+                "dir": "INPUT",
+                "wire": "BGRCALOVRD2"
+            },
+            "BGRCALOVRD3": {
+                "primary": "BGRCALOVRD3",
+                "dir": "INPUT",
+                "wire": "BGRCALOVRD3"
+            },
+            "BGRCALOVRD4": {
+                "primary": "BGRCALOVRD4",
+                "dir": "INPUT",
+                "wire": "BGRCALOVRD4"
+            },
+            "DRPADDR0": {
+                "primary": "DRPADDR0",
+                "dir": "INPUT",
+                "wire": "DRPADDR0"
+            },
+            "DRPADDR1": {
+                "primary": "DRPADDR1",
+                "dir": "INPUT",
+                "wire": "DRPADDR1"
+            },
+            "DRPADDR2": {
+                "primary": "DRPADDR2",
+                "dir": "INPUT",
+                "wire": "DRPADDR2"
+            },
+            "DRPADDR3": {
+                "primary": "DRPADDR3",
+                "dir": "INPUT",
+                "wire": "DRPADDR3"
+            },
+            "DRPADDR4": {
+                "primary": "DRPADDR4",
+                "dir": "INPUT",
+                "wire": "DRPADDR4"
+            },
+            "DRPADDR5": {
+                "primary": "DRPADDR5",
+                "dir": "INPUT",
+                "wire": "DRPADDR5"
+            },
+            "DRPADDR6": {
+                "primary": "DRPADDR6",
+                "dir": "INPUT",
+                "wire": "DRPADDR6"
+            },
+            "DRPADDR7": {
+                "primary": "DRPADDR7",
+                "dir": "INPUT",
+                "wire": "DRPADDR7"
+            },
+            "DRPCLK": {
+                "primary": "DRPCLK",
+                "dir": "INPUT",
+                "wire": "DRPCLK"
+            },
+            "DRPDI0": {
+                "primary": "DRPDI0",
+                "dir": "INPUT",
+                "wire": "DRPDI0"
+            },
+            "DRPDI1": {
+                "primary": "DRPDI1",
+                "dir": "INPUT",
+                "wire": "DRPDI1"
+            },
+            "DRPDI2": {
+                "primary": "DRPDI2",
+                "dir": "INPUT",
+                "wire": "DRPDI2"
+            },
+            "DRPDI3": {
+                "primary": "DRPDI3",
+                "dir": "INPUT",
+                "wire": "DRPDI3"
+            },
+            "DRPDI4": {
+                "primary": "DRPDI4",
+                "dir": "INPUT",
+                "wire": "DRPDI4"
+            },
+            "DRPDI5": {
+                "primary": "DRPDI5",
+                "dir": "INPUT",
+                "wire": "DRPDI5"
+            },
+            "DRPDI6": {
+                "primary": "DRPDI6",
+                "dir": "INPUT",
+                "wire": "DRPDI6"
+            },
+            "DRPDI7": {
+                "primary": "DRPDI7",
+                "dir": "INPUT",
+                "wire": "DRPDI7"
+            },
+            "DRPDI8": {
+                "primary": "DRPDI8",
+                "dir": "INPUT",
+                "wire": "DRPDI8"
+            },
+            "DRPDI9": {
+                "primary": "DRPDI9",
+                "dir": "INPUT",
+                "wire": "DRPDI9"
+            },
+            "DRPDI10": {
+                "primary": "DRPDI10",
+                "dir": "INPUT",
+                "wire": "DRPDI10"
+            },
+            "DRPDI11": {
+                "primary": "DRPDI11",
+                "dir": "INPUT",
+                "wire": "DRPDI11"
+            },
+            "DRPDI12": {
+                "primary": "DRPDI12",
+                "dir": "INPUT",
+                "wire": "DRPDI12"
+            },
+            "DRPDI13": {
+                "primary": "DRPDI13",
+                "dir": "INPUT",
+                "wire": "DRPDI13"
+            },
+            "DRPDI14": {
+                "primary": "DRPDI14",
+                "dir": "INPUT",
+                "wire": "DRPDI14"
+            },
+            "DRPDI15": {
+                "primary": "DRPDI15",
+                "dir": "INPUT",
+                "wire": "DRPDI15"
+            },
+            "DRPDO0": {
+                "primary": "DRPDO0",
+                "dir": "OUTPUT",
+                "wire": "DRPDO0"
+            },
+            "DRPDO1": {
+                "primary": "DRPDO1",
+                "dir": "OUTPUT",
+                "wire": "DRPDO1"
+            },
+            "DRPDO2": {
+                "primary": "DRPDO2",
+                "dir": "OUTPUT",
+                "wire": "DRPDO2"
+            },
+            "DRPDO3": {
+                "primary": "DRPDO3",
+                "dir": "OUTPUT",
+                "wire": "DRPDO3"
+            },
+            "DRPDO4": {
+                "primary": "DRPDO4",
+                "dir": "OUTPUT",
+                "wire": "DRPDO4"
+            },
+            "DRPDO5": {
+                "primary": "DRPDO5",
+                "dir": "OUTPUT",
+                "wire": "DRPDO5"
+            },
+            "DRPDO6": {
+                "primary": "DRPDO6",
+                "dir": "OUTPUT",
+                "wire": "DRPDO6"
+            },
+            "DRPDO7": {
+                "primary": "DRPDO7",
+                "dir": "OUTPUT",
+                "wire": "DRPDO7"
+            },
+            "DRPDO8": {
+                "primary": "DRPDO8",
+                "dir": "OUTPUT",
+                "wire": "DRPDO8"
+            },
+            "DRPDO9": {
+                "primary": "DRPDO9",
+                "dir": "OUTPUT",
+                "wire": "DRPDO9"
+            },
+            "DRPDO10": {
+                "primary": "DRPDO10",
+                "dir": "OUTPUT",
+                "wire": "DRPDO10"
+            },
+            "DRPDO11": {
+                "primary": "DRPDO11",
+                "dir": "OUTPUT",
+                "wire": "DRPDO11"
+            },
+            "DRPDO12": {
+                "primary": "DRPDO12",
+                "dir": "OUTPUT",
+                "wire": "DRPDO12"
+            },
+            "DRPDO13": {
+                "primary": "DRPDO13",
+                "dir": "OUTPUT",
+                "wire": "DRPDO13"
+            },
+            "DRPDO14": {
+                "primary": "DRPDO14",
+                "dir": "OUTPUT",
+                "wire": "DRPDO14"
+            },
+            "DRPDO15": {
+                "primary": "DRPDO15",
+                "dir": "OUTPUT",
+                "wire": "DRPDO15"
+            },
+            "DRPEN": {
+                "primary": "DRPEN",
+                "dir": "INPUT",
+                "wire": "DRPEN"
+            },
+            "DRPRDY": {
+                "primary": "DRPRDY",
+                "dir": "OUTPUT",
+                "wire": "DRPRDY"
+            },
+            "DRPWE": {
+                "primary": "DRPWE",
+                "dir": "INPUT",
+                "wire": "DRPWE"
+            },
+            "GTGREFCLK": {
+                "primary": "GTGREFCLK",
+                "dir": "INPUT",
+                "wire": "GTGREFCLK"
+            },
+            "GTNORTHREFCLK0": {
+                "primary": "GTNORTHREFCLK0",
+                "dir": "INPUT",
+                "wire": "GTNORTHREFCLK0"
+            },
+            "GTNORTHREFCLK1": {
+                "primary": "GTNORTHREFCLK1",
+                "dir": "INPUT",
+                "wire": "GTNORTHREFCLK1"
+            },
+            "GTREFCLK0": {
+                "primary": "GTREFCLK0",
+                "dir": "INPUT",
+                "wire": "GTREFCLK0"
+            },
+            "GTREFCLK1": {
+                "primary": "GTREFCLK1",
+                "dir": "INPUT",
+                "wire": "GTREFCLK1"
+            },
+            "GTSOUTHREFCLK0": {
+                "primary": "GTSOUTHREFCLK0",
+                "dir": "INPUT",
+                "wire": "GTSOUTHREFCLK0"
+            },
+            "GTSOUTHREFCLK1": {
+                "primary": "GTSOUTHREFCLK1",
+                "dir": "INPUT",
+                "wire": "GTSOUTHREFCLK1"
+            },
+            "PMARSVD0": {
+                "primary": "PMARSVD0",
+                "dir": "INPUT",
+                "wire": "PMARSVD0"
+            },
+            "PMARSVD1": {
+                "primary": "PMARSVD1",
+                "dir": "INPUT",
+                "wire": "PMARSVD1"
+            },
+            "PMARSVD2": {
+                "primary": "PMARSVD2",
+                "dir": "INPUT",
+                "wire": "PMARSVD2"
+            },
+            "PMARSVD3": {
+                "primary": "PMARSVD3",
+                "dir": "INPUT",
+                "wire": "PMARSVD3"
+            },
+            "PMARSVD4": {
+                "primary": "PMARSVD4",
+                "dir": "INPUT",
+                "wire": "PMARSVD4"
+            },
+            "PMARSVD5": {
+                "primary": "PMARSVD5",
+                "dir": "INPUT",
+                "wire": "PMARSVD5"
+            },
+            "PMARSVD6": {
+                "primary": "PMARSVD6",
+                "dir": "INPUT",
+                "wire": "PMARSVD6"
+            },
+            "PMARSVD7": {
+                "primary": "PMARSVD7",
+                "dir": "INPUT",
+                "wire": "PMARSVD7"
+            },
+            "PMASCANCLK0": {
+                "primary": "PMASCANCLK0",
+                "dir": "INPUT",
+                "wire": "PMASCANCLK0"
+            },
+            "PMASCANCLK1": {
+                "primary": "PMASCANCLK1",
+                "dir": "INPUT",
+                "wire": "PMASCANCLK1"
+            },
+            "PMASCANENB": {
+                "primary": "PMASCANENB",
+                "dir": "INPUT",
+                "wire": "PMASCANENB"
+            },
+            "PMASCANIN0": {
+                "primary": "PMASCANIN0",
+                "dir": "INPUT",
+                "wire": "PMASCANIN0"
+            },
+            "PMASCANIN1": {
+                "primary": "PMASCANIN1",
+                "dir": "INPUT",
+                "wire": "PMASCANIN1"
+            },
+            "PMASCANIN2": {
+                "primary": "PMASCANIN2",
+                "dir": "INPUT",
+                "wire": "PMASCANIN2"
+            },
+            "PMASCANIN3": {
+                "primary": "PMASCANIN3",
+                "dir": "INPUT",
+                "wire": "PMASCANIN3"
+            },
+            "PMASCANIN4": {
+                "primary": "PMASCANIN4",
+                "dir": "INPUT",
+                "wire": "PMASCANIN4"
+            },
+            "PMASCANOUT0": {
+                "primary": "PMASCANOUT0",
+                "dir": "OUTPUT",
+                "wire": "PMASCANOUT0"
+            },
+            "PMASCANOUT1": {
+                "primary": "PMASCANOUT1",
+                "dir": "OUTPUT",
+                "wire": "PMASCANOUT1"
+            },
+            "PMASCANOUT2": {
+                "primary": "PMASCANOUT2",
+                "dir": "OUTPUT",
+                "wire": "PMASCANOUT2"
+            },
+            "PMASCANOUT3": {
+                "primary": "PMASCANOUT3",
+                "dir": "OUTPUT",
+                "wire": "PMASCANOUT3"
+            },
+            "PMASCANOUT4": {
+                "primary": "PMASCANOUT4",
+                "dir": "OUTPUT",
+                "wire": "PMASCANOUT4"
+            },
+            "QDPMASCANMODEB": {
+                "primary": "QDPMASCANMODEB",
+                "dir": "INPUT",
+                "wire": "QDPMASCANMODEB"
+            },
+            "QDPMASCANRSTEN": {
+                "primary": "QDPMASCANRSTEN",
+                "dir": "INPUT",
+                "wire": "QDPMASCANRSTEN"
+            },
+            "QPLLCLKSPARE0": {
+                "primary": "QPLLCLKSPARE0",
+                "dir": "INPUT",
+                "wire": "QPLLCLKSPARE0"
+            },
+            "QPLLCLKSPARE1": {
+                "primary": "QPLLCLKSPARE1",
+                "dir": "INPUT",
+                "wire": "QPLLCLKSPARE1"
+            },
+            "QPLLDMONITOR0": {
+                "primary": "QPLLDMONITOR0",
+                "dir": "OUTPUT",
+                "wire": "QPLLDMONITOR0"
+            },
+            "QPLLDMONITOR1": {
+                "primary": "QPLLDMONITOR1",
+                "dir": "OUTPUT",
+                "wire": "QPLLDMONITOR1"
+            },
+            "QPLLDMONITOR2": {
+                "primary": "QPLLDMONITOR2",
+                "dir": "OUTPUT",
+                "wire": "QPLLDMONITOR2"
+            },
+            "QPLLDMONITOR3": {
+                "primary": "QPLLDMONITOR3",
+                "dir": "OUTPUT",
+                "wire": "QPLLDMONITOR3"
+            },
+            "QPLLDMONITOR4": {
+                "primary": "QPLLDMONITOR4",
+                "dir": "OUTPUT",
+                "wire": "QPLLDMONITOR4"
+            },
+            "QPLLDMONITOR5": {
+                "primary": "QPLLDMONITOR5",
+                "dir": "OUTPUT",
+                "wire": "QPLLDMONITOR5"
+            },
+            "QPLLDMONITOR6": {
+                "primary": "QPLLDMONITOR6",
+                "dir": "OUTPUT",
+                "wire": "QPLLDMONITOR6"
+            },
+            "QPLLDMONITOR7": {
+                "primary": "QPLLDMONITOR7",
+                "dir": "OUTPUT",
+                "wire": "QPLLDMONITOR7"
+            },
+            "QPLLFBCLKLOST": {
+                "primary": "QPLLFBCLKLOST",
+                "dir": "OUTPUT",
+                "wire": "QPLLFBCLKLOST"
+            },
+            "QPLLLOCK": {
+                "primary": "QPLLLOCK",
+                "dir": "OUTPUT",
+                "wire": "QPLLLOCK"
+            },
+            "QPLLLOCKDETCLK": {
+                "primary": "QPLLLOCKDETCLK",
+                "dir": "INPUT",
+                "wire": "QPLLLOCKDETCLK"
+            },
+            "QPLLLOCKEN": {
+                "primary": "QPLLLOCKEN",
+                "dir": "INPUT",
+                "wire": "QPLLLOCKEN"
+            },
+            "QPLLOUTCLK": {
+                "primary": "QPLLOUTCLK",
+                "dir": "OUTPUT",
+                "wire": "QPLLOUTCLK"
+            },
+            "QPLLOUTREFCLK": {
+                "primary": "QPLLOUTREFCLK",
+                "dir": "OUTPUT",
+                "wire": "QPLLOUTREFCLK"
+            },
+            "QPLLOUTRESET": {
+                "primary": "QPLLOUTRESET",
+                "dir": "INPUT",
+                "wire": "QPLLOUTRESET"
+            },
+            "QPLLPD": {
+                "primary": "QPLLPD",
+                "dir": "INPUT",
+                "wire": "QPLLPD"
+            },
+            "QPLLREFCLKLOST": {
+                "primary": "QPLLREFCLKLOST",
+                "dir": "OUTPUT",
+                "wire": "QPLLREFCLKLOST"
+            },
+            "QPLLREFCLKSEL0": {
+                "primary": "QPLLREFCLKSEL0",
+                "dir": "INPUT",
+                "wire": "QPLLREFCLKSEL0"
+            },
+            "QPLLREFCLKSEL1": {
+                "primary": "QPLLREFCLKSEL1",
+                "dir": "INPUT",
+                "wire": "QPLLREFCLKSEL1"
+            },
+            "QPLLREFCLKSEL2": {
+                "primary": "QPLLREFCLKSEL2",
+                "dir": "INPUT",
+                "wire": "QPLLREFCLKSEL2"
+            },
+            "QPLLRESET": {
+                "primary": "QPLLRESET",
+                "dir": "INPUT",
+                "wire": "QPLLRESET"
+            },
+            "QPLLRSVD10": {
+                "primary": "QPLLRSVD10",
+                "dir": "INPUT",
+                "wire": "QPLLRSVD10"
+            },
+            "QPLLRSVD11": {
+                "primary": "QPLLRSVD11",
+                "dir": "INPUT",
+                "wire": "QPLLRSVD11"
+            },
+            "QPLLRSVD12": {
+                "primary": "QPLLRSVD12",
+                "dir": "INPUT",
+                "wire": "QPLLRSVD12"
+            },
+            "QPLLRSVD13": {
+                "primary": "QPLLRSVD13",
+                "dir": "INPUT",
+                "wire": "QPLLRSVD13"
+            },
+            "QPLLRSVD14": {
+                "primary": "QPLLRSVD14",
+                "dir": "INPUT",
+                "wire": "QPLLRSVD14"
+            },
+            "QPLLRSVD15": {
+                "primary": "QPLLRSVD15",
+                "dir": "INPUT",
+                "wire": "QPLLRSVD15"
+            },
+            "QPLLRSVD16": {
+                "primary": "QPLLRSVD16",
+                "dir": "INPUT",
+                "wire": "QPLLRSVD16"
+            },
+            "QPLLRSVD17": {
+                "primary": "QPLLRSVD17",
+                "dir": "INPUT",
+                "wire": "QPLLRSVD17"
+            },
+            "QPLLRSVD18": {
+                "primary": "QPLLRSVD18",
+                "dir": "INPUT",
+                "wire": "QPLLRSVD18"
+            },
+            "QPLLRSVD19": {
+                "primary": "QPLLRSVD19",
+                "dir": "INPUT",
+                "wire": "QPLLRSVD19"
+            },
+            "QPLLRSVD20": {
+                "primary": "QPLLRSVD20",
+                "dir": "INPUT",
+                "wire": "QPLLRSVD20"
+            },
+            "QPLLRSVD21": {
+                "primary": "QPLLRSVD21",
+                "dir": "INPUT",
+                "wire": "QPLLRSVD21"
+            },
+            "QPLLRSVD22": {
+                "primary": "QPLLRSVD22",
+                "dir": "INPUT",
+                "wire": "QPLLRSVD22"
+            },
+            "QPLLRSVD23": {
+                "primary": "QPLLRSVD23",
+                "dir": "INPUT",
+                "wire": "QPLLRSVD23"
+            },
+            "QPLLRSVD24": {
+                "primary": "QPLLRSVD24",
+                "dir": "INPUT",
+                "wire": "QPLLRSVD24"
+            },
+            "QPLLRSVD110": {
+                "primary": "QPLLRSVD110",
+                "dir": "INPUT",
+                "wire": "QPLLRSVD110"
+            },
+            "QPLLRSVD111": {
+                "primary": "QPLLRSVD111",
+                "dir": "INPUT",
+                "wire": "QPLLRSVD111"
+            },
+            "QPLLRSVD112": {
+                "primary": "QPLLRSVD112",
+                "dir": "INPUT",
+                "wire": "QPLLRSVD112"
+            },
+            "QPLLRSVD113": {
+                "primary": "QPLLRSVD113",
+                "dir": "INPUT",
+                "wire": "QPLLRSVD113"
+            },
+            "QPLLRSVD114": {
+                "primary": "QPLLRSVD114",
+                "dir": "INPUT",
+                "wire": "QPLLRSVD114"
+            },
+            "QPLLRSVD115": {
+                "primary": "QPLLRSVD115",
+                "dir": "INPUT",
+                "wire": "QPLLRSVD115"
+            },
+            "RCALENB": {
+                "primary": "RCALENB",
+                "dir": "INPUT",
+                "wire": "RCALENB"
+            },
+            "REFCLKOUTMONITOR": {
+                "primary": "REFCLKOUTMONITOR",
+                "dir": "OUTPUT",
+                "wire": "REFCLKOUTMONITOR"
+            }
+        }
+    }
+}

--- a/kintex7/site_type_IBUFDS_GTE2.json
+++ b/kintex7/site_type_IBUFDS_GTE2.json
@@ -1,0 +1,87 @@
+{
+    "IBUFDS_GTE2": {
+      "bels": {
+        "CLKTESTSIGINV": {
+          "class": "RBEL",
+          "pins": {
+              "CLKTESTSIG": {
+                  "dir": "INPUT",
+                  "wire": "CLKTESTSIG"
+              },
+              "CLKTESTSIG_B": {
+                  "dir": "INPUT",
+                  "wire": "CLKTESTSIG"
+              },
+              "OUT": {
+                  "dir": "OUTPUT",
+                  "wire": "CLKTESTSIGINV_OUT"
+              }
+          },
+          "type": "IBUFDS_GTE2_CLKTESTSIGINV"
+        },
+        "IBUFDS_GTE2": {
+          "type": "IBUFDS_GTE2",
+          "class": "BEL",
+          "pins": {
+            "I": {
+              "dir": "INPUT",
+              "wire": "I"
+            },
+            "IB": {
+              "dir": "INPUT",
+              "wire": "IB"
+            },
+            "CEB": {
+              "dir": "INPUT",
+              "wire": "CEB"
+            },
+            "CLKTESTSIG": {
+              "dir": "INPUT",
+              "wire": "CLKTESTSIGINV_OUT"
+            },
+            "O": {
+              "dir": "OUTPUT",
+              "wire": "O"
+            },
+            "ODIV2": {
+              "dir": "OUTPUT",
+              "wire": "ODIV2"
+            }
+          }
+        }
+      },
+      "pips": [],
+      "pins": {
+        "I": {
+          "primary": "I",
+          "wire": "I",
+          "dir": "INPUT"
+        },
+        "IB": {
+          "primary": "IB",
+          "wire": "IB",
+          "dir": "INPUT"
+        },
+        "CLKTESTSIG": {
+          "primary": "CLKTESTSIG",
+          "wire": "CLKTESTSIGINV_OUT",
+          "dir": "INPUT"
+        },
+        "CEB": {
+          "primary": "CEB",
+          "wire": "CEB",
+          "dir": "INPUT"
+        },
+        "O": {
+          "primary": "O",
+          "wire": "O",
+          "dir": "OUTPUT"
+        },
+        "ODIV2": {
+          "primary": "ODIV2",
+          "wire": "ODIV2",
+          "dir": "OUTPUT"
+        }
+      }
+    }
+  }


### PR DESCRIPTION
I refer to vivado Device to export the GTX part of the xlsx file and convert it to site_type.json through the py script to complete the lack of GTX in the kintex7 series.
![image](https://github.com/user-attachments/assets/d358e31f-7437-4690-81eb-0cde6a27277e)

In addition, I also found a problem. The wire_intents.json in the kintex7 and artix7 folders seems to be the same. However, i think kintex7's wire_intents.json should be incorrect, at least there is no description of RIOI, RIOB18, etc.
